### PR TITLE
Implement Milestone 3 gate and behavior proof

### DIFF
--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -1,0 +1,40 @@
+schema_version = "1.0"
+
+[behavior]
+intended_behavior = "Existing complexity and gate-policy decisions remain unchanged; complete review evidence passes, while missing, malformed, or insufficient evidence blocks."
+proof = "tests/test_evaluate_complexity.py::test_valid_milestone_three_evidence_passes_and_reports_judgment"
+
+[characterization]
+captured_behavior = "All 26 Milestone 1 and Milestone 2 regression tests remain green with the Milestone 3 evidence requirement active."
+proof = "tests/test_evaluate_complexity.py"
+
+[separation_of_concerns]
+before = "The evaluator had no owner for structured review-evidence parsing or validation."
+after = "review_evidence owns the fixed schema; cli owns immutable Git reads and orchestration; reporting owns deterministic JSON and derived Markdown."
+
+[architecture]
+dependency_direction = "cli and reporting depend on the bottom-layer review_evidence module; review_evidence uses only Python standard-library parsing."
+reviewed_paths = [
+    "src/supportability_gate/cli.py",
+    "src/supportability_gate/reporting.py",
+    "src/supportability_gate/review_evidence.py",
+]
+
+[responsibility_boundary]
+path = "src/supportability_gate/review_evidence.py"
+owns = "Fixed structured review-evidence schema validation and deterministic defect classification."
+does_not_own = "Git access, target-code execution, gate-policy waivers, semantic scoring, or report rendering."
+
+[incremental_refactor]
+target = "Add only the Milestone 3 evidence boundary to the proven evaluator."
+completed_step = "One parser module, one orchestration read, and one reporting field were added without replacing Milestone 1 or Milestone 2 interfaces."
+
+[review_handoff]
+summary = "Review the fixed schema, fail-closed classifications, unchanged deterministic policy blocks, and JSON-to-Markdown reporting."
+remaining_risks = ["Evidence sufficiency is structural; approved executable gates and human review remain independently required and cannot be waived by this metadata."]
+
+[human_review]
+naming = "Names state evidence categories and parser responsibility directly."
+cohesion = "Schema validation is cohesive in one module; Git reads and rendering remain separate."
+intended_behavior = "The change preserves existing gate decisions and adds the authorized Milestone 3 requirement."
+reviewability = "The focused implementation and parameterized direct evaluations are reviewable as one milestone slice."

--- a/docs/enforcement_matrix.md
+++ b/docs/enforcement_matrix.md
@@ -16,13 +16,13 @@ Every required `NOT_IMPLEMENTED` row keeps full product incomplete.
 | Highest-risk-file gate coverage proof | DETERMINISTIC | 2 | IMPLEMENTED |
 | Threshold anti-weakening | DETERMINISTIC | 2 | IMPLEMENTED |
 | Gate-scope anti-narrowing | DETERMINISTIC | 2 | IMPLEMENTED |
-| Behavior and characterization proof | STRUCTURED_REVIEW_EVIDENCE | 3 | NOT_IMPLEMENTED |
-| Separation-of-concerns evidence | STRUCTURED_REVIEW_EVIDENCE | 3 | NOT_IMPLEMENTED |
-| Architecture and dependency-direction review evidence | STRUCTURED_REVIEW_EVIDENCE | 3 | NOT_IMPLEMENTED |
-| Responsibility-boundary reporting | STRUCTURED_REVIEW_EVIDENCE | 3 | NOT_IMPLEMENTED |
-| Incremental refactor evidence | STRUCTURED_REVIEW_EVIDENCE | 3 | NOT_IMPLEMENTED |
-| Review handoff and remaining-risk evidence | STRUCTURED_REVIEW_EVIDENCE | 3 | NOT_IMPLEMENTED |
-| Naming, cohesion, intended behavior, and reviewability judgment | HUMAN_REVIEW | 3 | NOT_IMPLEMENTED |
+| Behavior and characterization proof | STRUCTURED_REVIEW_EVIDENCE | 3 | IMPLEMENTED |
+| Separation-of-concerns evidence | STRUCTURED_REVIEW_EVIDENCE | 3 | IMPLEMENTED |
+| Architecture and dependency-direction review evidence | STRUCTURED_REVIEW_EVIDENCE | 3 | IMPLEMENTED |
+| Responsibility-boundary reporting | STRUCTURED_REVIEW_EVIDENCE | 3 | IMPLEMENTED |
+| Incremental refactor evidence | STRUCTURED_REVIEW_EVIDENCE | 3 | IMPLEMENTED |
+| Review handoff and remaining-risk evidence | STRUCTURED_REVIEW_EVIDENCE | 3 | IMPLEMENTED |
+| Naming, cohesion, intended behavior, and reviewability judgment | HUMAN_REVIEW | 3 | IMPLEMENTED |
 | Organization required-workflow enforcement proof | DETERMINISTIC | 4 | NOT_IMPLEMENTED |
 | Temporary target-repository protected merge proof | DETERMINISTIC | 4 | NOT_IMPLEMENTED |
 | TWMN clean and defect canaries | DETERMINISTIC | 5 | NOT_IMPLEMENTED |

--- a/docs/product_completion_contract.md
+++ b/docs/product_completion_contract.md
@@ -96,9 +96,30 @@ workflow, check-run, ruleset, or GitHub state supports them.
   responsibility-boundary evidence.
 - Required runtime proof: Direct evaluations proving required evidence is accepted when valid and
   blocked when missing, malformed, or insufficient.
-- Current status: `NOT_STARTED`
-- Verified evidence: None recorded.
-- Remaining work: Entire milestone; no owner-authorized execution directive.
+- Current status: `COMPLETE`
+- Verified evidence:
+  - Implementation commit: `d45e3335effc65a79087145aebfe167291dd8347`.
+  - Python `3.12.13` exact-lock proof passed on 2026-07-28: Ruff lint and format; C901 at
+    maximum 10; strict mypy; Import Linter; 52 pytest tests; compileall; wheel build; fresh
+    environment wheel install; installed `supportability-gate --help`; immutable-standard tamper
+    test; and exact-range whitespace validation excluding only the immutable standard.
+  - Twenty-six direct Milestone 3 evaluations passed: complete valid evidence passes and reports
+    the required judgment; behavior, characterization, separation-of-concerns, architecture and
+    dependency direction, responsibility boundary, incremental refactor, review handoff and
+    remaining risk, and human-review evidence each block when missing, malformed, or insufficient;
+    repeated identical inputs emit byte-identical JSON.
+  - Exact implementation-head self-evaluation passed twice with byte-identical JSON, all three
+    changed production files covered by all five approved adapters, and no policy block.
+  - Pull request #12 workflow run `30376335471` succeeded through workflow ID `320787297`,
+    job/check-run ID `90332853177`, required context `Source Validation`, and GitHub Actions App ID
+    `15368`.
+  - Active repository ruleset `19767613` targets `refs/heads/main`, requires strict
+    `Source Validation` from App ID `15368`, requires pull requests, and blocks deletion and
+    non-fast-forward updates.
+  - Approved gate scopes, maximum complexity 10, and the four recorded highest-risk trust-boundary
+    files remain unchanged. All changed production files remain inside every approved `src` gate
+    scope; no production file is excluded.
+- Remaining work: None for Milestone 3. Stop; Milestone 4 is not authorized.
 
 ### 4. Organization required workflow proof in one temporary target repository.
 
@@ -123,7 +144,7 @@ workflow, check-run, ruleset, or GitHub state supports them.
 ```text
 Deployable to target repositories: NO
 Full Supportability Standard runtime: NO
-Current authorized work: None — Milestone 2 complete; stop
+Current authorized work: None — Milestone 3 complete; stop
 Next milestone authorized: NO
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,5 +64,5 @@ layers = [
     "supportability_gate.gate_policy | supportability_gate.complexity_policy",
     "supportability_gate.complexity_metrics",
     "supportability_gate.function_changes",
-    "supportability_gate.contract | supportability_gate.git_changes",
+    "supportability_gate.contract | supportability_gate.git_changes | supportability_gate.review_evidence",
 ]

--- a/src/supportability_gate/cli.py
+++ b/src/supportability_gate/cli.py
@@ -15,6 +15,7 @@ from supportability_gate import (
     gate_policy,
     git_changes,
     reporting,
+    review_evidence,
 )
 
 
@@ -159,6 +160,8 @@ def _result(
     analyzed: _AnalyzedChanges,
     records: list[git_changes.CommandRecord],
     ruff_records: list[complexity_metrics.RuffCommandRecord],
+    structured_review: review_evidence.ReviewEvidence | None,
+    review_blocks: tuple[str, ...],
 ) -> reporting.EvaluationResult:
     if any(
         contract_path in {item.change.old_path, item.change.new_path}
@@ -184,8 +187,9 @@ def _result(
             _versions(identity),
             tuple(records),
             (),
+            structured_review,
         )
-    policy_blocks = gate_policy.evaluate_contract(policy, analyzed.assessments)
+    policy_blocks = (*gate_policy.evaluate_contract(policy, analyzed.assessments), *review_blocks)
     if policy_blocks:
         return reporting.EvaluationResult(
             identity,
@@ -204,6 +208,7 @@ def _result(
             _versions(identity),
             tuple(records),
             (),
+            structured_review,
         )
     base_definitions = _all_definitions(analyzed.analyses, "base")
     head_definitions = _all_definitions(analyzed.analyses, "head")
@@ -237,7 +242,29 @@ def _result(
         _versions(identity),
         tuple(records),
         tuple(ruff_records),
+        structured_review,
     )
+
+
+def _read_review_evidence(
+    repository: Path,
+    head_sha: str,
+    records: list[git_changes.CommandRecord],
+) -> tuple[review_evidence.ReviewEvidence | None, tuple[str, ...]]:
+    try:
+        blob = git_changes.read_regular_blob(
+            repository,
+            head_sha,
+            review_evidence.REVIEW_EVIDENCE_PATH,
+            records,
+        )
+    except git_changes.GitError as error:
+        if error.code == "MISSING_BLOB":
+            return review_evidence.evaluate_review_evidence(None)
+        if error.code == "SYMLINK_OR_NONFILE":
+            return None, ("MALFORMED_REVIEW_EVIDENCE:document",)
+        raise
+    return review_evidence.evaluate_review_evidence(blob.content)
 
 
 def _technical_result(
@@ -280,6 +307,8 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
     policy: contract.Contract | None = None
     assessments: tuple[function_changes.ChangedFileAssessment, ...] = ()
     candidate_policy: contract.Contract | None = None
+    structured_review: review_evidence.ReviewEvidence | None = None
+    review_blocks: tuple[str, ...] = ()
     contract_path = str(arguments.contract_path)
     try:
         contract_path = contract.validate_contract_path(contract_path)
@@ -304,6 +333,11 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
             records,
         )
         assessments = _classify_changes(repository, identity, policy, changes, records)
+        structured_review, review_blocks = _read_review_evidence(
+            repository,
+            identity.head_sha,
+            records,
+        )
         contract_changed = any(
             contract_path in {item.change.old_path, item.change.new_path} for item in assessments
         )
@@ -332,6 +366,8 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
             analyzed,
             records,
             ruff_records,
+            structured_review,
+            review_blocks,
         )
     except Exception as error:  # fail closed at the CLI trust boundary
         return _technical_result(

--- a/src/supportability_gate/reporting.py
+++ b/src/supportability_gate/reporting.py
@@ -11,6 +11,7 @@ from supportability_gate.complexity_metrics import RuffCommandRecord, RuffDiagno
 from supportability_gate.complexity_policy import FunctionDecision
 from supportability_gate.function_changes import ChangedFileAssessment
 from supportability_gate.git_changes import CommandRecord, RepositoryIdentity
+from supportability_gate.review_evidence import ReviewEvidence
 
 STANDARD_SHA256 = "81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2"
 
@@ -43,6 +44,7 @@ class EvaluationResult:
     tool_versions: dict[str, str]
     git_commands: tuple[CommandRecord, ...]
     ruff_commands: tuple[RuffCommandRecord, ...]
+    review_evidence: ReviewEvidence | None = None
 
 
 def _span_metric(metric: object | None) -> dict[str, Any] | None:
@@ -123,6 +125,8 @@ def result_payload(result: EvaluationResult) -> dict[str, Any]:
         "production_paths": list(result.production_paths),
         "rename_bindings": renames,
         "repository_remote": identity["remote"],
+        "review_evidence": result.review_evidence,
+        "review_evidence_path": ".supportability-review.toml",
         "ruff_diagnostics": [asdict(item) for item in result.ruff_diagnostics],
         "schema_version": "1.0",
         "standard_sha256": STANDARD_SHA256,
@@ -167,6 +171,19 @@ def markdown_from_json(payload: dict[str, Any]) -> str:
     if payload["policy_blocks"]:
         lines.extend(["", "## Policy blocks", ""])
         lines.extend(f"- `{item}`" for item in payload["policy_blocks"])
+    if payload["review_evidence"]:
+        lines.extend(
+            [
+                "",
+                "## Structured review evidence",
+                "",
+                "```json",
+                json.dumps(
+                    payload["review_evidence"], ensure_ascii=False, indent=2, sort_keys=True
+                ),
+                "```",
+            ]
+        )
     lines.extend(["", "Derived from `complexity-result.json`.", ""])
     return "\n".join(lines)
 

--- a/src/supportability_gate/review_evidence.py
+++ b/src/supportability_gate/review_evidence.py
@@ -1,0 +1,97 @@
+"""Validate fixed structured review evidence without executing target code."""
+
+from __future__ import annotations
+
+import tomllib
+from typing import Any
+
+REVIEW_EVIDENCE_PATH = ".supportability-review.toml"
+_TEXT_FIELDS = {
+    "behavior": ("intended_behavior", "proof"),
+    "characterization": ("captured_behavior", "proof"),
+    "separation_of_concerns": ("before", "after"),
+    "architecture": ("dependency_direction",),
+    "responsibility_boundary": ("path", "owns", "does_not_own"),
+    "incremental_refactor": ("target", "completed_step"),
+    "review_handoff": ("summary",),
+    "human_review": ("naming", "cohesion", "intended_behavior", "reviewability"),
+}
+_LIST_FIELDS = {
+    "architecture": ("reviewed_paths",),
+    "review_handoff": ("remaining_risks",),
+}
+
+ReviewEvidence = dict[str, object]
+
+
+class ReviewEvidenceError(ValueError):
+    """One deterministic structured-review evidence defect."""
+
+    def __init__(self, kind: str, location: str) -> None:
+        super().__init__(location)
+        self.kind = kind
+        self.location = location
+
+
+def _require_keys(data: dict[str, Any], expected: set[str], location: str) -> None:
+    missing = sorted(expected - set(data))
+    if missing:
+        raise ReviewEvidenceError("MISSING", f"{location}.{missing[0]}")
+    unknown = sorted(set(data) - expected)
+    if unknown:
+        raise ReviewEvidenceError("MALFORMED", f"{location}.{unknown[0]}")
+
+
+def _section(data: dict[str, Any], name: str) -> dict[str, Any]:
+    value = data[name]
+    if not isinstance(value, dict):
+        raise ReviewEvidenceError("MALFORMED", name)
+    return value
+
+
+def _validate_text(value: object, location: str) -> None:
+    if not isinstance(value, str):
+        raise ReviewEvidenceError("MALFORMED", location)
+    if not value.strip():
+        raise ReviewEvidenceError("INSUFFICIENT", location)
+
+
+def _validate_text_list(value: object, location: str) -> None:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise ReviewEvidenceError("MALFORMED", location)
+    if not value or any(not item.strip() for item in value):
+        raise ReviewEvidenceError("INSUFFICIENT", location)
+
+
+def parse_review_evidence(content: bytes) -> ReviewEvidence:
+    """Parse the only supported structured-review evidence schema."""
+    try:
+        data = tomllib.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise ReviewEvidenceError("MALFORMED", "document") from error
+    expected_sections = set(_TEXT_FIELDS) | set(_LIST_FIELDS)
+    _require_keys(data, {"schema_version", *expected_sections}, "review_evidence")
+    if data["schema_version"] != "1.0":
+        raise ReviewEvidenceError("MALFORMED", "schema_version")
+    for name in sorted(expected_sections):
+        section = _section(data, name)
+        text_fields = _TEXT_FIELDS.get(name, ())
+        list_fields = _LIST_FIELDS.get(name, ())
+        _require_keys(section, {*text_fields, *list_fields}, name)
+        for field in text_fields:
+            _validate_text(section[field], f"{name}.{field}")
+        for field in list_fields:
+            _validate_text_list(section[field], f"{name}.{field}")
+    return data
+
+
+def evaluate_review_evidence(
+    content: bytes | None,
+) -> tuple[ReviewEvidence | None, tuple[str, ...]]:
+    """Return normalized evidence or one deterministic blocking reason."""
+    if content is None:
+        return None, ("MISSING_REVIEW_EVIDENCE:document",)
+    try:
+        return parse_review_evidence(content), ()
+    except ReviewEvidenceError as error:
+        return None, (f"{error.kind}_REVIEW_EVIDENCE:{error.location}",)

--- a/tests/test_evaluate_complexity.py
+++ b/tests/test_evaluate_complexity.py
@@ -40,6 +40,45 @@ adapter = "python.c901-touched.v1"
 maximum = 10
 """
 
+REVIEW_EVIDENCE = """\
+schema_version = "1.0"
+
+[behavior]
+intended_behavior = "Changed behavior remains covered by focused tests."
+proof = "tests/test_behavior.py::test_changed_behavior"
+
+[characterization]
+captured_behavior = "Pre-change behavior is captured before refactoring."
+proof = "tests/test_behavior.py::test_characterized_behavior"
+
+[separation_of_concerns]
+before = "The changed boundary previously mixed responsibilities."
+after = "The changed boundary now has one named responsibility."
+
+[architecture]
+dependency_direction = "Dependencies continue to point toward domain policy."
+reviewed_paths = ["src/sample.py"]
+
+[responsibility_boundary]
+path = "src/sample.py"
+owns = "Sample behavior."
+does_not_own = "CLI presentation."
+
+[incremental_refactor]
+target = "One focused sample boundary."
+completed_step = "Characterized and changed only that boundary."
+
+[review_handoff]
+summary = "Focused behavior-preserving change ready for review."
+remaining_risks = ["No known remaining risk in the focused boundary."]
+
+[human_review]
+naming = "Names express owned responsibilities."
+cohesion = "Changed code remains cohesive."
+intended_behavior = "Reported behavior remains intended."
+reviewability = "Change is small enough for direct review."
+"""
+
 
 def _run_git(repository: Path, *arguments: str) -> str:
     completed = subprocess.run(
@@ -83,6 +122,7 @@ def _initialize_repository(tmp_path: Path, contract_text: str = CONTRACT) -> Pat
     _run_git(repository, "config", "core.autocrlf", "false")
     _run_git(repository, "remote", "add", "origin", "https://github.com/example/fixture.git")
     _write(repository / ".supportability.toml", contract_text)
+    _write(repository / ".supportability-review.toml", REVIEW_EVIDENCE)
     return repository
 
 
@@ -427,6 +467,150 @@ def test_milestone_two_block_evidence_is_byte_identical(tmp_path: Path) -> None:
     second_exit, _ = _evaluate(repository, base_sha, head_sha, second)
 
     assert first_exit == second_exit == 1
+    assert (first / "complexity-result.json").read_bytes() == (
+        second / "complexity-result.json"
+    ).read_bytes()
+
+
+def _section_span(content: str, section: str) -> tuple[int, int, list[str]]:
+    lines = content.splitlines()
+    start = lines.index(f"[{section}]")
+    end = next(
+        (index for index in range(start + 1, len(lines)) if lines[index].startswith("[")),
+        len(lines),
+    )
+    return start, end, lines
+
+
+def _defective_review_evidence(section: str, defect: str) -> str:
+    start, end, lines = _section_span(REVIEW_EVIDENCE, section)
+    if defect == "missing":
+        del lines[start:end]
+    else:
+        field_index = next(index for index in range(start + 1, end) if "=" in lines[index])
+        field = lines[field_index].split("=", 1)[0]
+        lines[field_index] = f"{field}= {1 if defect == 'malformed' else '""'}"
+    return "\n".join(lines) + "\n"
+
+
+@pytest.mark.parametrize(
+    "section",
+    [
+        "behavior",
+        "characterization",
+        "separation_of_concerns",
+        "architecture",
+        "responsibility_boundary",
+        "incremental_refactor",
+        "review_handoff",
+        "human_review",
+    ],
+)
+def test_missing_milestone_three_evidence_blocks(tmp_path: Path, section: str) -> None:
+    repository = _initialize_repository(tmp_path)
+    base_sha = _commit(repository, "base")
+    _write(
+        repository / ".supportability-review.toml", _defective_review_evidence(section, "missing")
+    )
+    head_sha = _commit(repository, "head")
+
+    exit_code, result = _evaluate(repository, base_sha, head_sha, tmp_path / "result")
+
+    assert exit_code == 1
+    assert result["policy_blocks"][0].startswith("MISSING_REVIEW_EVIDENCE:")
+
+
+@pytest.mark.parametrize(
+    "section",
+    [
+        "behavior",
+        "characterization",
+        "separation_of_concerns",
+        "architecture",
+        "responsibility_boundary",
+        "incremental_refactor",
+        "review_handoff",
+        "human_review",
+    ],
+)
+def test_malformed_milestone_three_evidence_blocks(tmp_path: Path, section: str) -> None:
+    repository = _initialize_repository(tmp_path)
+    base_sha = _commit(repository, "base")
+    _write(
+        repository / ".supportability-review.toml",
+        _defective_review_evidence(section, "malformed"),
+    )
+    head_sha = _commit(repository, "head")
+
+    exit_code, result = _evaluate(repository, base_sha, head_sha, tmp_path / "result")
+
+    assert exit_code == 1
+    assert result["policy_blocks"][0].startswith("MALFORMED_REVIEW_EVIDENCE:")
+
+
+@pytest.mark.parametrize(
+    "section",
+    [
+        "behavior",
+        "characterization",
+        "separation_of_concerns",
+        "architecture",
+        "responsibility_boundary",
+        "incremental_refactor",
+        "review_handoff",
+        "human_review",
+    ],
+)
+def test_insufficient_milestone_three_evidence_blocks(tmp_path: Path, section: str) -> None:
+    repository = _initialize_repository(tmp_path)
+    base_sha = _commit(repository, "base")
+    _write(
+        repository / ".supportability-review.toml",
+        _defective_review_evidence(section, "insufficient"),
+    )
+    head_sha = _commit(repository, "head")
+
+    exit_code, result = _evaluate(repository, base_sha, head_sha, tmp_path / "result")
+
+    assert exit_code == 1
+    assert result["policy_blocks"][0].startswith("INSUFFICIENT_REVIEW_EVIDENCE:")
+
+
+def test_valid_milestone_three_evidence_passes_and_reports_judgment(tmp_path: Path) -> None:
+    repository, base_sha, head_sha = _repository(
+        tmp_path,
+        _function_source("existing", 1),
+        _function_source("existing", 1, 1),
+    )
+
+    exit_code, result = _evaluate(repository, base_sha, head_sha, tmp_path / "result")
+
+    assert exit_code == 0
+    assert result["review_evidence"]["behavior"]["proof"].endswith("::test_changed_behavior")
+    assert result["review_evidence"]["human_review"] == {
+        "cohesion": "Changed code remains cohesive.",
+        "intended_behavior": "Reported behavior remains intended.",
+        "naming": "Names express owned responsibilities.",
+        "reviewability": "Change is small enough for direct review.",
+    }
+    markdown = (tmp_path / "result" / "complexity-result.md").read_text(encoding="utf-8")
+    assert "## Structured review evidence" in markdown
+    assert '"reviewability": "Change is small enough for direct review."' in markdown
+
+
+def test_milestone_three_evidence_is_byte_identical(tmp_path: Path) -> None:
+    repository, base_sha, head_sha = _repository(
+        tmp_path,
+        _function_source("existing", 1),
+        _function_source("existing", 1, 1),
+    )
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+
+    first_exit, _ = _evaluate(repository, base_sha, head_sha, first)
+    second_exit, _ = _evaluate(repository, base_sha, head_sha, second)
+
+    assert first_exit == second_exit == 0
     assert (first / "complexity-result.json").read_bytes() == (
         second / "complexity-result.json"
     ).read_bytes()


### PR DESCRIPTION
## Scope
- require fixed `.supportability-review.toml` structured evidence for all Milestone 3 categories
- block missing, malformed, or insufficient evidence deterministically
- report valid evidence in authoritative JSON and derived Markdown
- preserve Milestone 1 and Milestone 2 decisions, adapters, thresholds, and scopes

## Direct proof
- Python 3.12.13 exact hashed lock
- 52 tests passed; 26 direct Milestone 3 cases
- valid evidence passes and reports human-review judgment
- 8 evidence categories each block when missing, malformed, or insufficient
- repeated actual and fixture evaluations emit byte-identical JSON
- Ruff lint/format/C901, strict mypy, Import Linter, compileall passed
- wheel build, fresh-environment install, installed CLI smoke passed
- exact-head self-evaluation PASS at `d45e3335effc65a79087145aebfe167291dd8347`
- all 3 changed production files and all 4 recorded highest-risk files remain inside all 5 approved `src` gate scopes
- complexity maximum remains 10; no gate scope narrowed; no production file excluded

Milestones 4 and 5 excluded.