### PR TITLE
Enforce domain modularization and coupling

### DIFF
--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -44,3 +44,9 @@ naming = "Architecture names describe import edges, fixed layers, coverage, dire
 cohesion = "One architecture_policy module owns static graph enforcement; existing CLI, reporting, GitHub, and semantic modules only integrate its evidence."
 intended_behavior = "Existing complexity and responsibility checks remain; architecture checks now execute for Python and TypeScript."
 reviewability = "Focused fixtures cover valid graphs, cycles, inversions, forbidden dependencies, execution, complete coverage, determinism, and semantic citation binding."
+
+[[module_boundaries]]
+path = "src/supportability_gate/modularity_policy.py"
+owner_path = "src/supportability_gate/modularity_policy.py"
+basis = "responsibility"
+justification = "Owns deterministic new-location justification, vague-location, coupling-edge, and complete-coverage evidence required by Enforcement Milestone 6."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 ## Product boundary
 
-- Execute Enforcement Milestone 5 only under `docs/enforcement_milestone_5.md`.
+- Execute Enforcement Milestone 6 only under `docs/enforcement_milestone_6.md`.
 - Never import or execute target repository code.
 - Git and Ruff use fixed argument vectors, finite timeouts, captured output, and no shell.
 - Do not add commands, executable paths, environment controls, exclusions, waivers, or threshold
@@ -26,7 +26,7 @@ Before planning or editing, read:
 2. `docs/supportability_standard.md`
 3. `docs/fixed_roadmap.md`
 4. `docs/product_completion_contract.md`
-5. `docs/enforcement_milestone_5.md` while Enforcement Milestone 5 is active
+5. `docs/enforcement_milestone_6.md` while Enforcement Milestone 6 is active
 
 Before editing, report:
 

--- a/docs/enforcement_milestone_6.md
+++ b/docs/enforcement_milestone_6.md
@@ -1,0 +1,57 @@
+# Enforcement Milestone 6 Execution Directive
+
+## Authority
+
+- Owner authorization: 2026-07-28 owner execution prompt.
+- Repository: `mbh-solutions/supportability-gate`.
+- Successor project: https://github.com/orgs/mbh-solutions/projects/3.
+- Active issue: https://github.com/mbh-solutions/supportability-gate/issues/21.
+- Historical Project #2 must remain unchanged.
+- Required immutable-standard SHA-256:
+  `81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2`.
+
+## Terminal capability
+
+Block vague or parallel production locations, unjustified package or module boundaries, weak
+cohesion, unjustified or excessive coupling, and new production locations without complete quality
+and architecture coverage.
+
+## Approved scope
+
+- Package and module ownership and exact-path new-location justification.
+- Cohesion and coupling judgment, vague-location prohibition, and parallel-package detection.
+- Complete quality and architecture coverage for every new production location.
+- Source-backed evidence cross-checking and minimum integration with existing evaluator, reporting,
+  semantic-review, workflow, and GitHub enforcement paths.
+
+## Excluded scope
+
+- General refactor-size policy or Milestone 7 characterization and golden-master sequencing.
+- Enforcement Milestones 7–11.
+- Changes to `docs/supportability_standard.md` or `docs/fixed_roadmap.md`.
+- Target-code import or execution, arbitrary repository commands, waivers, exclusions, threshold
+  overrides, cleanup, redesign, generalized frameworks, speculative infrastructure, or new
+  dependencies.
+
+## Required direct proof
+
+- Cohesive responsibility-based and domain-based fixtures pass.
+- New `utils`, `helpers`, `common`, `misc`, and `stuff` locations block.
+- Unjustified parallel packages, uncovered new production locations, weak cohesion, and
+  unjustified or excessive coupling block.
+- Every new-location justification resolves to an exact immutable path; ownership and
+  domain/responsibility claims resolve to source-backed evidence.
+- Every required gate claim resolves to an executed result; every applicable changed and high-risk
+  production path remains covered.
+- Identical immutable inputs produce deterministic, independently verifiable evidence.
+- Passing Python and TypeScript cases merge normally through protection; required failing cases
+  cannot merge normally.
+- Every source-proof command in `AGENTS.md` passes with Python 3.12 and the exact lock.
+
+## Closure
+
+Record exact commits, pull requests, runs, checks, Apps, rulesets, canaries, rejected and successful
+normal merges, ownership, cohesion, coupling, path justification, coverage, validation, and gaps in
+issue #21. Then update only Milestone 6 ledger fields; set Status `Complete`, Evidence `Complete`,
+Scope `On scope`, Stop confirmed `Yes`; close issue #21; prove Project #2 and Milestones 7–11
+unchanged; stop.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ layers = [
     "supportability_gate.__main__",
     "supportability_gate.cli",
     "supportability_gate.reporting",
+    "supportability_gate.modularity_policy",
     "supportability_gate.architecture_policy | supportability_gate.gate_policy | supportability_gate.complexity_policy",
     "supportability_gate.complexity_metrics",
     "supportability_gate.function_changes",

--- a/src/supportability_gate/cli.py
+++ b/src/supportability_gate/cli.py
@@ -15,6 +15,7 @@ from supportability_gate import (
     function_changes,
     gate_policy,
     git_changes,
+    modularity_policy,
     reporting,
     review_evidence,
 )
@@ -197,6 +198,7 @@ def _result(
     structured_review: review_evidence.ReviewEvidence | None,
     review_blocks: tuple[str, ...],
     architecture: architecture_policy.ArchitectureResult,
+    modularity: modularity_policy.ModularityResult,
 ) -> reporting.EvaluationResult:
     if any(
         contract_path in {item.change.old_path, item.change.new_path}
@@ -229,6 +231,7 @@ def _result(
     policy_blocks = (
         *gate_policy.evaluate_contract(policy, analyzed.assessments),
         *architecture.blocks,
+        *modularity.blocks,
         *review_blocks,
     )
     if policy_blocks:
@@ -252,6 +255,7 @@ def _result(
             structured_review,
             policy.language,
             architecture,
+            modularity,
         )
     base_definitions = _all_definitions(analyzed.analyses, "base")
     head_definitions = _all_definitions(analyzed.analyses, "head")
@@ -294,6 +298,7 @@ def _result(
         structured_review,
         policy.language,
         architecture,
+        modularity,
     )
 
 
@@ -424,6 +429,12 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
             _architecture_sources(repository, identity.head_sha, policy, records),
             architecture_gate,
         )
+        modularity = modularity_policy.evaluate_modularity(
+            policy,
+            assessments,
+            structured_review,
+            architecture,
+        )
         return _result(
             identity,
             contract_path,
@@ -436,6 +447,7 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
             structured_review,
             review_blocks,
             architecture,
+            modularity,
         )
     except Exception as error:  # fail closed at the CLI trust boundary
         return _technical_result(

--- a/src/supportability_gate/modularity_policy.py
+++ b/src/supportability_gate/modularity_policy.py
@@ -1,0 +1,168 @@
+"""Prove new production locations are owned, justified, and fully governed."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+from supportability_gate.architecture_policy import ArchitectureResult, ImportEdge
+from supportability_gate.contract import Contract, ContractError, normalize_repository_path
+from supportability_gate.function_changes import ChangedFileAssessment
+from supportability_gate.review_evidence import ReviewEvidence
+
+VAGUE_LOCATION_NAMES = frozenset({"common", "helpers", "misc", "stuff", "utils"})
+
+
+@dataclass(frozen=True)
+class LocationJustification:
+    """One exact-path ownership claim for a new production source location."""
+
+    path: str
+    owner_path: str
+    basis: str
+    justification: str
+
+
+@dataclass(frozen=True)
+class LocationCoverage:
+    """Executed gate coverage for one new production source location."""
+
+    path: str
+    adapters: tuple[str, ...]
+    architecture: bool
+
+
+@dataclass(frozen=True)
+class ModularityResult:
+    """Deterministic module ownership, coupling, and coverage evidence."""
+
+    changed_paths: tuple[str, ...]
+    new_paths: tuple[str, ...]
+    justifications: tuple[LocationJustification, ...]
+    coupling_edges: tuple[ImportEdge, ...]
+    coverage: tuple[LocationCoverage, ...]
+    blocks: tuple[str, ...]
+
+
+def _changed_paths(assessments: tuple[ChangedFileAssessment, ...]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                item.change.new_path
+                for item in assessments
+                if item.head_production and item.change.new_path and item.complexity_assessed
+            }
+        )
+    )
+
+
+def _new_paths(assessments: tuple[ChangedFileAssessment, ...]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                item.change.new_path
+                for item in assessments
+                if item.head_production
+                and item.change.new_path
+                and item.complexity_assessed
+                and (not item.base_production or item.change.old_path != item.change.new_path)
+            }
+        )
+    )
+
+
+def _justifications(review: ReviewEvidence | None) -> tuple[LocationJustification, ...]:
+    raw = review.get("module_boundaries", []) if review else []
+    if not isinstance(raw, list):
+        return ()
+    return tuple(
+        LocationJustification(
+            str(item["path"]),
+            str(item["owner_path"]),
+            str(item["basis"]),
+            str(item["justification"]),
+        )
+        for item in raw
+        if isinstance(item, dict)
+    )
+
+
+def _package(path: str, policy: Contract) -> str:
+    root = max(
+        (root for root in policy.production_paths if path == root or path.startswith(f"{root}/")),
+        key=len,
+    )
+    relative = PurePosixPath(path).relative_to(root)
+    return relative.parts[0] if len(relative.parts) > 1 else relative.stem
+
+
+def _path_blocks(path: str) -> tuple[str, ...]:
+    names = {part.lower() for part in PurePosixPath(path).parts[:-1]}
+    names.add(PurePosixPath(path).stem.lower())
+    return tuple(
+        f"VAGUE_PRODUCTION_LOCATION:{path}:{name}" for name in sorted(names & VAGUE_LOCATION_NAMES)
+    )
+
+
+def _claim_blocks(
+    policy: Contract,
+    new_paths: tuple[str, ...],
+    justifications: tuple[LocationJustification, ...],
+    nodes: tuple[str, ...],
+) -> tuple[str, ...]:
+    blocks: list[str] = []
+    claims = {item.path: item for item in justifications}
+    for path in new_paths:
+        claim = claims.get(path)
+        if claim is None:
+            blocks.append(f"MISSING_NEW_LOCATION_JUSTIFICATION:{path}")
+            continue
+        try:
+            normalize_repository_path(claim.path, "module_boundaries.path")
+            normalize_repository_path(claim.owner_path, "module_boundaries.owner_path")
+        except ContractError:
+            blocks.append(f"INVALID_NEW_LOCATION_JUSTIFICATION:{path}")
+            continue
+        if claim.owner_path not in nodes:
+            blocks.append(f"UNRESOLVED_MODULE_OWNER:{path}:{claim.owner_path}")
+        elif claim.owner_path != path and _package(claim.owner_path, policy) != _package(
+            path, policy
+        ):
+            blocks.append(f"PARALLEL_PACKAGE:{path}:{claim.owner_path}")
+    return tuple(blocks)
+
+
+def evaluate_modularity(
+    policy: Contract,
+    assessments: tuple[ChangedFileAssessment, ...],
+    review: ReviewEvidence | None,
+    architecture: ArchitectureResult,
+) -> ModularityResult:
+    """Return deterministic exact-path modularity evidence without executing target code."""
+    changed_paths = _changed_paths(assessments)
+    new_paths = _new_paths(assessments)
+    justifications = _justifications(review)
+    coverage = tuple(
+        LocationCoverage(
+            path,
+            tuple(sorted(gate.adapter for gate in policy.gates if gate.covers(path))),
+            path in architecture.covered_paths,
+        )
+        for path in new_paths
+    )
+    blocks = [block for path in new_paths for block in _path_blocks(path)]
+    blocks.extend(_claim_blocks(policy, new_paths, justifications, architecture.nodes))
+    blocks.extend(
+        f"NEW_LOCATION_GATE_COVERAGE:{item.path}"
+        for item in coverage
+        if len(item.adapters) != len(policy.gates) or not item.architecture
+    )
+    coupling = tuple(edge for edge in architecture.edges if edge.source in changed_paths)
+    return ModularityResult(
+        changed_paths,
+        new_paths,
+        justifications,
+        coupling,
+        coverage,
+        tuple(sorted(blocks)),
+    )

--- a/src/supportability_gate/reporting.py
+++ b/src/supportability_gate/reporting.py
@@ -12,6 +12,7 @@ from supportability_gate.complexity_metrics import RuffCommandRecord, RuffDiagno
 from supportability_gate.complexity_policy import FunctionDecision
 from supportability_gate.function_changes import ChangedFileAssessment
 from supportability_gate.git_changes import CommandRecord, RepositoryIdentity
+from supportability_gate.modularity_policy import ModularityResult
 from supportability_gate.review_evidence import ReviewEvidence
 
 STANDARD_SHA256 = "81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2"
@@ -48,6 +49,7 @@ class EvaluationResult:
     review_evidence: ReviewEvidence | None = None
     language: str | None = None
     architecture: ArchitectureResult | None = None
+    modularity: ModularityResult | None = None
 
 
 def _span_metric(metric: object | None) -> dict[str, Any] | None:
@@ -147,6 +149,19 @@ def result_payload(result: EvaluationResult) -> dict[str, Any]:
     architecture_verdict = (
         "BLOCK" if architecture and architecture.blocks else "PASS" if architecture else "MISSING"
     )
+    modularity = result.modularity
+    modularity_payload = (
+        {
+            "blocks": list(modularity.blocks),
+            "changed_paths": list(modularity.changed_paths),
+            "coupling_edges": [asdict(edge) for edge in modularity.coupling_edges],
+            "coverage": [asdict(item) for item in modularity.coverage],
+            "justifications": [asdict(item) for item in modularity.justifications],
+            "new_paths": list(modularity.new_paths),
+        }
+        if modularity
+        else None
+    )
     return {
         "base_contract_blob_sha": result.contract_blob_sha,
         "architecture": architecture_payload,
@@ -164,6 +179,7 @@ def result_payload(result: EvaluationResult) -> dict[str, Any]:
         "head_tree_sha": identity["head_tree_sha"],
         "high_risk_paths": list(result.high_risk_paths),
         "language": result.language,
+        "modularity": modularity_payload,
         "gate_coverage": [
             {"adapter": adapter, "paths": list(paths)} for adapter, paths in result.gate_coverage
         ],

--- a/src/supportability_gate/review_evidence.py
+++ b/src/supportability_gate/review_evidence.py
@@ -20,6 +20,7 @@ _LIST_FIELDS = {
     "architecture": ("reviewed_paths",),
     "review_handoff": ("remaining_risks",),
 }
+_MODULE_BOUNDARY_FIELDS = {"basis", "justification", "owner_path", "path"}
 
 ReviewEvidence = dict[str, object]
 
@@ -63,6 +64,24 @@ def _validate_text_list(value: object, location: str) -> None:
         raise ReviewEvidenceError("INSUFFICIENT", location)
 
 
+def _validate_module_boundaries(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ReviewEvidenceError("MALFORMED", "module_boundaries")
+    for index, item in enumerate(value):
+        location = f"module_boundaries[{index}]"
+        if not isinstance(item, dict):
+            raise ReviewEvidenceError("MALFORMED", location)
+        _require_keys(item, _MODULE_BOUNDARY_FIELDS, location)
+        for field in sorted(_MODULE_BOUNDARY_FIELDS):
+            _validate_text(item[field], f"{location}.{field}")
+        if item["basis"] not in {"domain", "responsibility"}:
+            raise ReviewEvidenceError("MALFORMED", f"{location}.basis")
+    paths = [item["path"] for item in value]
+    if len(paths) != len(set(paths)):
+        raise ReviewEvidenceError("MALFORMED", "module_boundaries.path")
+    return value
+
+
 def parse_review_evidence(content: bytes) -> ReviewEvidence:
     """Parse the only supported structured-review evidence schema."""
     try:
@@ -70,7 +89,13 @@ def parse_review_evidence(content: bytes) -> ReviewEvidence:
     except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
         raise ReviewEvidenceError("MALFORMED", "document") from error
     expected_sections = set(_TEXT_FIELDS) | set(_LIST_FIELDS)
-    _require_keys(data, {"schema_version", *expected_sections}, "review_evidence")
+    required = {"schema_version", *expected_sections}
+    missing = sorted(required - set(data))
+    unknown = sorted(set(data) - required - {"module_boundaries"})
+    if missing:
+        raise ReviewEvidenceError("MISSING", f"review_evidence.{missing[0]}")
+    if unknown:
+        raise ReviewEvidenceError("MALFORMED", f"review_evidence.{unknown[0]}")
     if data["schema_version"] != "1.0":
         raise ReviewEvidenceError("MALFORMED", "schema_version")
     for name in sorted(expected_sections):
@@ -82,6 +107,7 @@ def parse_review_evidence(content: bytes) -> ReviewEvidence:
             _validate_text(section[field], f"{name}.{field}")
         for field in list_fields:
             _validate_text_list(section[field], f"{name}.{field}")
+    data["module_boundaries"] = _validate_module_boundaries(data.get("module_boundaries", []))
     return data
 
 

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -17,7 +17,8 @@ def _verdict_summary(verdict: SemanticVerdict) -> str:
     for item in verdict.boundaries:
         lines.append(
             f"{item.path}:{item.start_line}-{item.end_line} {item.kind} {item.name} | "
-            f"owns: {item.owns} | does not own: {item.does_not_own}"
+            f"{item.basis} | owns: {item.owns} | does not own: {item.does_not_own} | "
+            f"evidence lines: {','.join(str(line) for line in item.evidence_lines)}"
         )
     lines.append(f"dependency direction: {verdict.dependency_direction}")
     lines.extend(

--- a/src/supportability_gate/semantic_contract.py
+++ b/src/supportability_gate/semantic_contract.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any
 
 MODEL = "gpt-5.6-sol"
-RUBRIC_VERSION = "dependency-direction.v1"
+RUBRIC_VERSION = "domain-modularization.v1"
 SCHEMA_VERSION = "semantic-review.v1"
 STANDARD_SHA256 = "81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2"
 SHA_PATTERN = re.compile(r"[0-9a-f]{40}\Z")
@@ -100,6 +100,8 @@ class BoundaryEvidence:
     name: str
     owns: str
     does_not_own: str
+    basis: str
+    evidence_lines: tuple[int, ...]
 
 
 @dataclass(frozen=True)
@@ -140,6 +142,11 @@ def result_schema() -> dict[str, Any]:
                     "name": {"type": "string"},
                     "owns": {"type": "string"},
                     "does_not_own": {"type": "string"},
+                    "basis": {"type": "string", "enum": ["domain", "responsibility"]},
+                    "evidence_lines": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                    },
                 },
                 "required": [
                     "path",
@@ -149,6 +156,8 @@ def result_schema() -> dict[str, Any]:
                     "name",
                     "owns",
                     "does_not_own",
+                    "basis",
+                    "evidence_lines",
                 ],
                 "additionalProperties": False,
             },
@@ -203,7 +212,12 @@ def request_payload(packet: EvidencePacket) -> dict[str, Any]:
         "Each reviewed source supplies trusted parser-derived boundaries. Return exactly every "
         "supplied function, module, or frontend component boundary, copying its name, kind, and "
         "inclusive line span. State one clear owned "
-        "responsibility plus specific responsibilities it does not own. BLOCK boundaries that own "
+        "responsibility plus specific responsibilities it does not own. Classify each boundary as "
+        "domain-based or responsibility-based and cite exact source lines proving that claim. BLOCK "
+        "new utils, helpers, common, misc, stuff, vague shared locations, unjustified parallel "
+        "packages, weak cohesion, and unjustified or excessive coupling. BLOCK candidate new-location "
+        "claims that do not resolve to an exact changed source path and source-backed owner. "
+        "BLOCK boundaries that own "
         "distinct parsing, validation, business-rule, persistence, external-call, logging, or "
         "presentation concerns together. Do not count delegated calls or the parsing, validation, "
         "serialization, and error handling needed to implement one named input/output boundary as "

--- a/src/supportability_gate/semantic_review.py
+++ b/src/supportability_gate/semantic_review.py
@@ -145,13 +145,39 @@ def _source_index(packet: EvidencePacket) -> dict[str, SourceIndex]:
     return dict(sorted(indexed.items()))
 
 
+def _ownership_lines(
+    value: object, cited_numbers: range, source_lines: dict[int, str]
+) -> tuple[int, ...]:
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(
+            type(line) is not int or line not in cited_numbers or line not in source_lines
+            for line in value
+        )
+        or value != sorted(set(value))
+    ):
+        raise SemanticReviewError("UNSUPPORTED_OWNERSHIP_CLAIM")
+    return tuple(value)
+
+
 def _boundary(item: object, sources: dict[str, SourceIndex]) -> BoundaryEvidence:
-    keys = {"path", "start_line", "end_line", "kind", "name", "owns", "does_not_own"}
+    keys = {
+        "path",
+        "start_line",
+        "end_line",
+        "kind",
+        "name",
+        "owns",
+        "does_not_own",
+        "basis",
+        "evidence_lines",
+    }
     if not isinstance(item, dict) or set(item) != keys:
         raise SemanticReviewError("MALFORMED_SCHEMA")
     if type(item["start_line"]) is not int or type(item["end_line"]) is not int:
         raise SemanticReviewError("MALFORMED_SCHEMA")
-    text_keys = keys - {"start_line", "end_line"}
+    text_keys = keys - {"start_line", "end_line", "evidence_lines"}
     if any(not isinstance(item[key], str) or not item[key].strip() for key in text_keys):
         raise SemanticReviewError("MALFORMED_SCHEMA")
     path = item["path"]
@@ -165,7 +191,10 @@ def _boundary(item: object, sources: dict[str, SourceIndex]) -> BoundaryEvidence
     ):
         raise SemanticReviewError("EVIDENCE_OUTSIDE_HEAD")
     kind, name = item["kind"], item["name"]
-    if kind not in {"function", "module", "component"}:
+    if kind not in {"function", "module", "component"} or item["basis"] not in {
+        "domain",
+        "responsibility",
+    }:
         raise SemanticReviewError("MALFORMED_SCHEMA")
     if path.endswith(".py") and kind == "component":
         raise SemanticReviewError("MALFORMED_SCHEMA")
@@ -173,6 +202,7 @@ def _boundary(item: object, sources: dict[str, SourceIndex]) -> BoundaryEvidence
         raise SemanticReviewError("UNSUPPORTED_OWNERSHIP_CLAIM")
     if item["owns"] == item["does_not_own"]:
         raise SemanticReviewError("VAGUE_BOUNDARY")
+    evidence_lines = _ownership_lines(item["evidence_lines"], cited_numbers, lines)
     return BoundaryEvidence(
         path=path,
         start_line=start_line,
@@ -181,6 +211,8 @@ def _boundary(item: object, sources: dict[str, SourceIndex]) -> BoundaryEvidence
         name=name,
         owns=item["owns"],
         does_not_own=item["does_not_own"],
+        basis=item["basis"],
+        evidence_lines=evidence_lines,
     )
 
 

--- a/tests/test_evaluate_complexity.py
+++ b/tests/test_evaluate_complexity.py
@@ -105,6 +105,20 @@ reviewability = "Change is small enough for direct review."
 """
 
 
+def _review_evidence_for_new_path(path: str) -> str:
+    return (
+        REVIEW_EVIDENCE
+        + f'''\
+
+[[module_boundaries]]
+path = "{path}"
+owner_path = "{path}"
+basis = "responsibility"
+justification = "Exact source path owns one cohesive fixture boundary."
+'''
+    )
+
+
 def _run_git(repository: Path, *arguments: str) -> str:
     completed = subprocess.run(
         ["git", *arguments],
@@ -175,6 +189,11 @@ def _repository(
         sample.unlink(missing_ok=True)
     else:
         _write(sample, head_source)
+        if base_source is None:
+            _write(
+                repository / ".supportability-review.toml",
+                _review_evidence_for_new_path("src/sample.py"),
+            )
     head_sha = _commit(repository, "head")
     return repository, base_sha, head_sha
 
@@ -195,6 +214,11 @@ def _typescript_repository(
         sample.unlink(missing_ok=True)
     else:
         _write(sample, head_source)
+        if base_source is None:
+            _write(
+                repository / ".supportability-review.toml",
+                _review_evidence_for_new_path(f"src/sample{extension}"),
+            )
     head_sha = _commit(repository, "head")
     return repository, base_sha, head_sha
 
@@ -233,6 +257,9 @@ def test_new_complexity_10_passes(tmp_path: Path) -> None:
     assert result["language"] == "python"
     assert result["architecture"]["executed"] is True
     assert result["architecture"]["covered_paths"] == ["src/sample.py"]
+    assert result["modularity"]["new_paths"] == ["src/sample.py"]
+    assert result["modularity"]["coverage"][0]["architecture"] is True
+    assert len(result["modularity"]["coverage"][0]["adapters"]) == 5
     assert (
         "changed production paths ['src/sample.py']" in result["dependency_direction_explanation"]
     )
@@ -495,14 +522,30 @@ def test_renamed_file_with_legacy_improvement_passes_progressively(tmp_path: Pat
     base_sha = _commit(repository, "base")
     _run_git(repository, "mv", "src/old.py", "src/new.py")
     _write(repository / "src" / "new.py", _function_source("legacy", 12))
+    _write(
+        repository / ".supportability-review.toml",
+        _review_evidence_for_new_path("src/new.py"),
+    )
     head_sha = _commit(repository, "head")
 
     exit_code, result = _evaluate(repository, base_sha, head_sha, tmp_path / "result")
 
     assert exit_code == 0
-    assert result["changed_files"][0]["status"] == "RENAMED"
+    assert any(item["status"] == "RENAMED" for item in result["changed_files"])
     assert result["rename_bindings"] == [{"old_path": "src/old.py", "new_path": "src/new.py"}]
     assert result["functions"][0]["decision"] == "PASS_PROGRESSIVE"
+
+
+def test_new_location_without_exact_justification_blocks(tmp_path: Path) -> None:
+    repository = _initialize_repository(tmp_path)
+    base_sha = _commit(repository, "base")
+    _write(repository / "src" / "unowned.py", _function_source("new", 1))
+    head_sha = _commit(repository, "head")
+
+    exit_code, result = _evaluate(repository, base_sha, head_sha, tmp_path / "result")
+
+    assert exit_code == 1
+    assert result["policy_blocks"] == ["MISSING_NEW_LOCATION_JUSTIFICATION:src/unowned.py"]
 
 
 def test_deleted_high_complexity_function_is_evidence_not_block(tmp_path: Path) -> None:

--- a/tests/test_modularity_policy.py
+++ b/tests/test_modularity_policy.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import pytest
+
+from supportability_gate.architecture_policy import ArchitectureResult, ImportEdge
+from supportability_gate.contract import parse_contract
+from supportability_gate.function_changes import ChangedFileAssessment
+from supportability_gate.git_changes import ChangedPath
+from supportability_gate.modularity_policy import evaluate_modularity
+
+
+def _policy():
+    return parse_contract(
+        b"""schema_version = "1.0"
+language = "python"
+production_paths = ["src"]
+high_risk_paths = []
+
+[[gates]]
+adapter = "python.c901-touched.v1"
+paths = ["src"]
+
+[[gates]]
+adapter = "python.import-linter.v1"
+paths = ["src"]
+
+[[gates]]
+adapter = "python.mypy-strict.v1"
+paths = ["src"]
+
+[[gates]]
+adapter = "python.pytest.v1"
+paths = ["src"]
+
+[[gates]]
+adapter = "python.ruff-lint.v1"
+paths = ["src"]
+
+[complexity]
+adapter = "python.c901-touched.v1"
+maximum = 10
+"""
+    )
+
+
+def _assessment(path: str) -> ChangedFileAssessment:
+    return ChangedFileAssessment(ChangedPath("ADDED", None, path), False, True, True, (1,))
+
+
+def _review(path: str, basis: str, owner_path: str | None = None) -> dict[str, object]:
+    return {
+        "module_boundaries": [
+            {
+                "path": path,
+                "owner_path": owner_path or path,
+                "basis": basis,
+                "justification": "Exact source path owns one cohesive boundary.",
+            }
+        ]
+    }
+
+
+def _architecture(path: str, *, covered: bool = True, owner_path: str | None = None):
+    nodes = tuple(sorted({path, *(value for value in [owner_path] if value)}))
+    return ArchitectureResult(
+        "python.import-linter.v1",
+        True,
+        (path,) if covered else (),
+        nodes,
+        (ImportEdge(path, owner_path, 1, "owner", True),) if owner_path else (),
+        (),
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "basis"),
+    [
+        ("src/validation/parser.py", "responsibility"),
+        ("src/orders/model.py", "domain"),
+    ],
+)
+def test_cohesive_owned_location_passes(path: str, basis: str) -> None:
+    result = evaluate_modularity(
+        _policy(), (_assessment(path),), _review(path, basis), _architecture(path)
+    )
+
+    assert result.blocks == ()
+    assert result.new_paths == (path,)
+    assert result.coverage[0].architecture is True
+    assert len(result.coverage[0].adapters) == 5
+
+
+@pytest.mark.parametrize("name", ["utils", "helpers", "common", "misc", "stuff"])
+def test_vague_new_location_blocks(name: str) -> None:
+    path = f"src/{name}/format.py"
+
+    result = evaluate_modularity(
+        _policy(), (_assessment(path),), _review(path, "responsibility"), _architecture(path)
+    )
+
+    assert result.blocks == (f"VAGUE_PRODUCTION_LOCATION:{path}:{name}",)
+
+
+def test_unjustified_parallel_package_blocks() -> None:
+    path = "src/order_copy/model.py"
+    owner = "src/orders/model.py"
+
+    result = evaluate_modularity(
+        _policy(),
+        (_assessment(path),),
+        _review(path, "domain", owner),
+        _architecture(path, owner_path=owner),
+    )
+
+    assert result.blocks == (f"PARALLEL_PACKAGE:{path}:{owner}",)
+    assert result.coupling_edges[0].target == owner
+
+
+def test_new_location_without_complete_architecture_coverage_blocks() -> None:
+    path = "src/orders/model.py"
+
+    result = evaluate_modularity(
+        _policy(),
+        (_assessment(path),),
+        _review(path, "domain"),
+        _architecture(path, covered=False),
+    )
+
+    assert result.blocks == (f"NEW_LOCATION_GATE_COVERAGE:{path}",)
+
+
+def test_missing_or_unresolved_justification_blocks() -> None:
+    path = "src/orders/model.py"
+    missing = evaluate_modularity(_policy(), (_assessment(path),), None, _architecture(path))
+    unresolved = evaluate_modularity(
+        _policy(),
+        (_assessment(path),),
+        _review(path, "domain", "src/orders/missing.py"),
+        _architecture(path),
+    )
+
+    assert missing.blocks == (f"MISSING_NEW_LOCATION_JUSTIFICATION:{path}",)
+    assert unresolved.blocks == (f"UNRESOLVED_MODULE_OWNER:{path}:src/orders/missing.py",)
+
+
+def test_modularity_evidence_is_deterministic() -> None:
+    path = "src/orders/model.py"
+    arguments = (_policy(), (_assessment(path),), _review(path, "domain"), _architecture(path))
+
+    assert evaluate_modularity(*arguments) == evaluate_modularity(*arguments)

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -30,6 +30,8 @@ PYTHON_BOUNDARY = {
     "name": "parse_input",
     "owns": "Parsing one input value.",
     "does_not_own": "Validation, persistence, logging, or presentation.",
+    "basis": "responsibility",
+    "evidence_lines": [1, 2],
 }
 
 
@@ -164,6 +166,8 @@ def test_focused_frontend_component_passes_with_line_evidence() -> None:
         "name": "SaveButton",
         "owns": "Rendering one save action.",
         "does_not_own": "Data loading, validation, state, domain rules, or client calls.",
+        "basis": "responsibility",
+        "evidence_lines": [1, 2, 3],
     }
     verdict = parse_response(
         packet,
@@ -233,6 +237,25 @@ def test_mixed_responsibilities_block_with_line_evidence(responsibilities: str) 
         ),
     )
     assert verdict.verdict == "BLOCK"
+
+
+def test_unjustified_or_excessive_coupling_blocks_with_source_evidence() -> None:
+    packet = _packet()
+    verdict = parse_response(
+        packet,
+        _response(packet, "BLOCK", [f"{PYTHON_PATH}:1-2 has unjustified excessive coupling."]),
+    )
+
+    assert verdict.verdict == "BLOCK"
+
+
+def test_ownership_claim_requires_source_lines() -> None:
+    packet = _packet()
+    boundary = copy.deepcopy(PYTHON_BOUNDARY)
+    boundary["evidence_lines"] = [3]
+
+    with pytest.raises(SemanticReviewError, match="UNSUPPORTED_OWNERSHIP_CLAIM"):
+        parse_response(packet, _response(packet, boundaries=[boundary]))
 
 
 @pytest.mark.parametrize("claim", ["unsupported ownership claim", "vague boundary claim"])
@@ -378,7 +401,7 @@ def test_complexity_anti_gaming_rubric_is_narrow_and_bound() -> None:
     packet = _packet({"diff": "+def handle_stuff(): pass"})
     payload = request_payload(packet)
 
-    assert RUBRIC_VERSION == "dependency-direction.v1"
+    assert RUBRIC_VERSION == "domain-modularization.v1"
     assert "vaguely named production helpers" in payload["instructions"]
     assert "separation of concerns" in payload["instructions"]
     assert "candidate-provided responsibility declarations" in payload["instructions"]


### PR DESCRIPTION
## Summary

- add deterministic exact-path module ownership, vague-location, parallel-package, coupling-edge, and new-location coverage evidence
- bind semantic domain/responsibility ownership claims to exact source lines and extend the rubric for cohesion/coupling
- activate the minimum Enforcement Milestone 6 repository directive

## Proof

- Python 3.12.13 exact lock
- 157 tests passed
- Ruff lint/format/C901, strict mypy, 2 Import Linter contracts, compileall
- wheel SHA-256 `3d94eebe7d8c8421326e42cbc4d4323975ab3dac10fb2042fb2a6d1e1ea4b499`
- repeated exact-base/head evidence SHA-256 `dd7652f0a6bb4ad7fbe44fef3d6655329c4d28708501577b57ea683fb670445a`
- immutable Standard SHA-256 preserved

Closes #21