### PR TITLE
Enforce focused runnable refactor increments

### DIFF
--- a/.github/workflows/organization-required.yml
+++ b/.github/workflows/organization-required.yml
@@ -206,7 +206,7 @@ jobs:
           name: characterization-head-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/head
 
-      - name: Verify exact base and head behavior
+      - name: Verify exact behavior and refactor policy
         env:
           BASE_ARTIFACT_DIGEST: ${{ needs.characterize-base.outputs.artifact-digest }}
           BASE_ARTIFACT_ID: ${{ needs.characterize-base.outputs.artifact-id }}
@@ -216,6 +216,7 @@ jobs:
           HEAD_ARTIFACT_ID: ${{ needs.characterize-head.outputs.artifact-id }}
           HEAD_CAPTURE_SHA256: ${{ needs.characterize-head.outputs.capture-sha256 }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
         working-directory: ${{ runner.temp }}
         run: |
           set +e
@@ -237,9 +238,17 @@ jobs:
             --head-artifact-digest "$HEAD_ARTIFACT_DIGEST" \
             --head-capture-sha256 "$HEAD_CAPTURE_SHA256" \
             --output "$RUNNER_TEMP/evidence/characterization-result.json"
-          status=$?
+          characterization_status=$?
           cat "$RUNNER_TEMP/evidence/characterization-result.json"
-          exit "$status"
+          "$RUNNER_TEMP/gate-venv/bin/python" -P -m supportability_gate.refactor_policy \
+            --repository "$GITHUB_WORKSPACE/target" \
+            --event "$GITHUB_EVENT_PATH" \
+            --characterization-result "$RUNNER_TEMP/evidence/characterization-result.json" \
+            --output "$RUNNER_TEMP/evidence/refactor-policy-result.json"
+          refactor_status=$?
+          cat "$RUNNER_TEMP/evidence/refactor-policy-result.json"
+          if [ "$characterization_status" -ne 0 ]; then exit "$characterization_status"; fi
+          exit "$refactor_status"
 
       - name: Evaluate immutable pull-request commits
         env:

--- a/.github/workflows/organization-required.yml
+++ b/.github/workflows/organization-required.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
 
 jobs:
   characterize-base:
@@ -216,6 +217,7 @@ jobs:
           HEAD_ARTIFACT_ID: ${{ needs.characterize-head.outputs.artifact-id }}
           HEAD_CAPTURE_SHA256: ${{ needs.characterize-head.outputs.capture-sha256 }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUNNER_ENVIRONMENT: ${{ runner.environment }}
         working-directory: ${{ runner.temp }}
         run: |

--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -6,7 +6,10 @@
         "src/supportability_gate/cli.py",
         "src/supportability_gate/complexity_metrics.py",
         "src/supportability_gate/contract.py",
-        "src/supportability_gate/git_changes.py"
+        "src/supportability_gate/git_changes.py",
+        "src/supportability_gate/github_app.py",
+        "src/supportability_gate/refactor_policy.py",
+        "src/supportability_gate/semantic_contract.py"
       ],
       "id": "gate-cli",
       "kind": "cli"

--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -6,12 +6,18 @@
         "src/supportability_gate/cli.py",
         "src/supportability_gate/complexity_metrics.py",
         "src/supportability_gate/contract.py",
-        "src/supportability_gate/git_changes.py",
+        "src/supportability_gate/git_changes.py"
+      ],
+      "id": "gate-cli",
+      "kind": "cli"
+    },
+    {
+      "covers": [
         "src/supportability_gate/github_app.py",
         "src/supportability_gate/refactor_policy.py",
         "src/supportability_gate/semantic_contract.py"
       ],
-      "id": "gate-cli",
+      "id": "refactor-policy",
       "kind": "cli"
     }
   ],

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -1,19 +1,19 @@
 schema_version = "1.0"
 
 [behavior]
-intended_behavior = "Milestones 1-6 remain enforced while risky changes require exact-base and exact-head characterization with compatible behavior."
-proof = "tests/test_characterization.py"
+intended_behavior = "Milestones 1-7 remain enforced while refactors require authenticated exact-head scope, parser-bounded targets, runnable behavior, and explicit strangler sequencing."
+proof = "tests/test_refactor_policy.py"
 
 [characterization]
-captured_behavior = "The pre-change 157-test suite and installed CLI behavior are the immutable base for Milestone 7."
-proof = "tests/test_characterization.py"
+captured_behavior = "The pre-change 177-test suite and existing Python and TypeScript characterization scenarios remain the immutable runnable base for Milestone 8."
+proof = "tests/test_refactor_policy.py"
 
 [separation_of_concerns]
-before = "Review text could claim characterization without authenticated base execution, exact artifact identity, replay, or post-change comparison."
-after = "The trusted organization workflow runs fixed Python or Node drivers twice in separate GitHub-hosted base and head jobs; characterization statically binds downloaded bytes to trusted job-output hashes and verifies identity, golden immutability, compatibility, and coverage without executing target code."
+before = "A refactor could supply nonempty review prose while changing unbounded targets, unrelated paths, or a non-runnable intermediate head."
+after = "One policy module binds GitHub-authenticated owner authorization to exact base, head, scope, parser-derived targets, characterization compatibility, and predecessor sequencing before existing gates run."
 
 [architecture]
-dependency_direction = "The organization workflow captures isolated behavior, then points to characterization for static verification; characterization depends only on immutable contract and Git evidence, and existing evaluator and semantic-review paths run after it passes."
+dependency_direction = "The organization workflow obtains authenticated behavior, then refactor_policy statically verifies exact Git scope and parser-derived boundaries using contract, function_changes, and git_changes; existing evaluator and semantic-review paths remain later independent gates."
 reviewed_paths = [
     "src/supportability_gate/characterization.py",
     "src/supportability_gate/architecture_policy.py",
@@ -22,29 +22,36 @@ reviewed_paths = [
     "src/supportability_gate/git_changes.py",
     "src/supportability_gate/github_app.py",
     "src/supportability_gate/reporting.py",
+    "src/supportability_gate/refactor_policy.py",
     "src/supportability_gate/semantic_cli.py",
     "src/supportability_gate/semantic_contract.py",
     "src/supportability_gate/semantic_review.py",
 ]
 
 [responsibility_boundary]
-path = "src/supportability_gate/characterization.py"
-owns = "Static authentication, artifact identity, compatibility, golden immutability, replay, and coverage verification for captured characterization evidence."
-does_not_own = "Target execution, general quality-gate execution, semantic model transport, GitHub authentication, or check publication."
+path = "src/supportability_gate/refactor_policy.py"
+owns = "Authenticated owner authorization, exact diff focus, parser-derived target boundedness, characterization-backed runnability, and predecessor sequence verification."
+does_not_own = "Target execution, characterization capture, general quality-gate execution, semantic model transport, GitHub check publication, or waivers."
 
 [incremental_refactor]
-target = "Require one authenticated exact-base and exact-head characterization stage before the existing evaluator."
-completed_step = "Added one static verifier and one trusted hosted capture script with separate base and head jobs and raw-capture hashes, without target-supplied commands, new dependencies, contract changes, or later-milestone gate execution."
+target = "Require one authenticated, bounded, focused, runnable strangler step before the existing evaluator."
+completed_step = "Added one static policy module and one workflow invocation reusing exact Git, parser, and characterization evidence; no new dependency, command override, waiver, or Milestone 9 gate execution."
 
 [review_handoff]
-summary = "Review hosted-runner enforcement, exact checkout identity, isolated base/head execution, job-output capture hashes, immutable artifact handoff, fixed Python and Node commands, golden immutability, deterministic replay, compatibility, and changed/high-risk path coverage."
-remaining_risks = ["A missing or malformed manifest, driver, golden file, capture, or artifact identity intentionally fails the required workflow closed."]
+summary = "Review trusted owner identity, exact base/head authorization, exact changed-path scope, parser-derived target identity, broad-scope handling, characterization-backed runnability, sequence binding, deterministic evidence, and unchanged downstream gates."
+remaining_risks = ["Missing or malformed authorization, scope, target, predecessor, GitHub event, or characterization evidence intentionally fails the required workflow closed."]
 
 [human_review]
-naming = "Characterization names describe captures, manifests, golden outputs, behavior fingerprints, artifact identity, compatibility, and replay drift."
-cohesion = "One production module statically verifies Milestone 7 evidence; one trusted workflow script owns isolated hosted capture; existing evaluator and semantic modules remain unchanged."
-intended_behavior = "Existing enforcement remains; fixed Python and TypeScript characterization now blocks missing, stale, unauthenticated, changed, drifting, or incompatible evidence."
-reviewability = "Focused fixtures cover both supported profiles, existing and new scenarios, exact identity, all required blocks, coverage, and deterministic verification."
+naming = "Refactor-policy names directly describe authorization, bounded targets, diff focus, runnability, and strangler sequencing."
+cohesion = "One production module owns deterministic Milestone 8 verification; existing characterization, evaluator, reporting, semantic, and Git evidence retain their responsibilities."
+intended_behavior = "Existing enforcement remains; Python and TypeScript refactors now block missing, stale, broad, unfocused, unbounded, non-runnable, or invalidly sequenced evidence."
+reviewability = "Focused fixtures cover both supported profiles, narrow and broad authorization, all required blocks, exact identities, and deterministic verification."
+
+[[module_boundaries]]
+path = "src/supportability_gate/refactor_policy.py"
+owner_path = "src/supportability_gate/refactor_policy.py"
+basis = "responsibility"
+justification = "Owns deterministic Milestone 8 authorization, boundedness, focus, runnability, and sequence verification without executing target code."
 
 [[module_boundaries]]
 path = "src/supportability_gate/characterization.py"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 ## Product boundary
 
-- Execute Enforcement Milestone 7 only under `docs/enforcement_milestone_7.md`.
+- Execute Enforcement Milestone 8 only under `docs/enforcement_milestone_8.md`.
 - Never import or execute target repository code.
 - Git and Ruff use fixed argument vectors, finite timeouts, captured output, and no shell.
 - Do not add commands, executable paths, environment controls, exclusions, waivers, or threshold
@@ -26,7 +26,7 @@ Before planning or editing, read:
 2. `docs/supportability_standard.md`
 3. `docs/fixed_roadmap.md`
 4. `docs/product_completion_contract.md`
-5. `docs/enforcement_milestone_7.md` while Enforcement Milestone 7 is active
+5. `docs/enforcement_milestone_8.md` while Enforcement Milestone 8 is active
 
 Before editing, report:
 

--- a/docs/enforcement_milestone_8.md
+++ b/docs/enforcement_milestone_8.md
@@ -1,0 +1,56 @@
+# Enforcement Milestone 8 Execution Directive
+
+## Authority
+
+- Owner authorization: 2026-07-28 owner execution prompt.
+- Repository: `mbh-solutions/supportability-gate`.
+- Successor project: https://github.com/orgs/mbh-solutions/projects/3.
+- Active issue: https://github.com/mbh-solutions/supportability-gate/issues/23.
+- Historical Project #2 must remain unchanged.
+- Required immutable-standard SHA-256:
+  `81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2`.
+
+## Terminal capability
+
+Block big-bang or unfocused rewrites unless an exact owner directive authorizes them. Require one
+bounded target, runnable logical steps, focused diff evidence, and incremental strangler sequencing.
+
+## Approved scope
+
+- Target boundedness, diff focus, logical-step runnability, authorization identity, exact-head
+  relevance, and incremental strangler sequencing.
+- Minimum integration with existing evaluator, characterization, reporting, semantic-review,
+  workflow, Git evidence, and GitHub enforcement paths.
+- Focused Python and TypeScript tests and protected canaries required for direct proof.
+
+## Excluded scope
+
+- Waivers, report-only pass conversion, or weakening any other Standard clause.
+- General stack-native quality-gate execution assigned to Milestone 9.
+- Enforcement Milestones 9–11.
+- Changes to `docs/supportability_standard.md` or `docs/fixed_roadmap.md`.
+- Target-code import or execution outside isolated GitHub-hosted jobs; arbitrary repository commands,
+  executable paths, environment controls, exclusions, threshold overrides, cleanup, redesign,
+  generalized frameworks, speculative infrastructure, or new dependencies.
+
+## Required direct proof
+
+- A small bounded runnable refactor passes.
+- Repo-wide cleanup, unrelated churn, multiple unbounded targets, non-runnable intermediate state,
+  and missing owner authorization block.
+- Broad authorization is authenticated, exact-scope, exact-head relevant, and cannot waive another
+  Standard clause.
+- Target boundedness, diff focus, logical-step runnability, and sequencing are independently
+  verifiable.
+- Passing Python and TypeScript canaries merge normally; required failing canaries cannot merge
+  normally.
+- Milestones 1–7 remain intact and every source-proof command in `AGENTS.md` passes with Python 3.12
+  and the exact lock.
+
+## Closure
+
+Record exact commits, pull requests, runs, jobs/checks, Apps, rulesets, workflow pins, canaries,
+merge decisions, bounded-target, focus, runnability, authorization, sequencing, validation, and gaps
+in issue #23. Then update only Milestone 8 ledger fields; verify every Milestone 8 pull request is
+linked; set Status `Complete`, Evidence `Complete`, Scope `On scope`, Stop confirmed `Yes`; close
+issue #23; prove Project #2 and Milestones 9–11 unchanged; stop.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ layers = [
     "supportability_gate.modularity_policy",
     "supportability_gate.architecture_policy | supportability_gate.gate_policy | supportability_gate.complexity_policy",
     "supportability_gate.complexity_metrics",
+    "supportability_gate.refactor_policy",
     "supportability_gate.function_changes",
     "supportability_gate.characterization",
     "supportability_gate.clause_inventory | supportability_gate.contract | supportability_gate.git_changes | supportability_gate.review_evidence",

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -21,7 +21,12 @@ from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from supportability_gate.architecture_policy import source_imports
 from supportability_gate.contract import ContractError, parse_contract
 from supportability_gate.function_changes import PythonSourceError, responsibility_spans
-from supportability_gate.semantic_contract import SHA_PATTERN, EvidencePacket, SemanticReviewError
+from supportability_gate.semantic_contract import (
+    SHA_PATTERN,
+    TRUSTED_OWNER_ID,
+    EvidencePacket,
+    SemanticReviewError,
+)
 
 API = "https://api.github.com"
 CHECK_NAME = "Supportability Semantic Review"
@@ -178,6 +183,7 @@ class GitHubApp:
         _, files = self._comparison_evidence(repository, str(base_sha), str(head_sha), token)
         reviewed_sources = self._reviewed_sources(repository, str(base_sha), files, token)
         review_diff = self._review_diff(files)
+        comments = self.issue_comments(repository, number, token)
         return EvidencePacket(
             repository,
             str(base_sha),
@@ -186,13 +192,16 @@ class GitHubApp:
             {
                 "diff": review_diff,
                 "pull_request": number,
-                "refactor_context": self._refactor_context(pull, files),
+                "refactor_context": self._refactor_context(pull, files, comments),
                 "reviewed_sources": reviewed_sources,
             },
         )
 
     def _refactor_context(
-        self, pull: dict[str, Any], files: tuple[dict[str, Any], ...]
+        self,
+        pull: dict[str, Any],
+        files: tuple[dict[str, Any], ...],
+        comments: tuple[dict[str, Any], ...],
     ) -> dict[str, object]:
         """Return authenticated author identity plus exact changed-file metadata."""
         user = pull.get("user")
@@ -201,12 +210,36 @@ class GitHubApp:
             "author_association": pull.get("author_association"),
             "author_id": author.get("id"),
             "author_login": author.get("login"),
-            "authorization": pull.get("body"),
+            "authorization_comments": [
+                {
+                    "body": item.get("body"),
+                    "id": item.get("id"),
+                    "user_id": item.get("user", {}).get("id"),
+                }
+                for item in sorted(comments, key=lambda value: int(value.get("id", 0)))
+                if isinstance(item.get("user"), dict)
+            ],
             "changed_files": [
                 {"path": item.get("filename"), "status": item.get("status")}
                 for item in sorted(files, key=lambda value: str(value.get("filename")))
             ],
+            "trusted_owner_id": TRUSTED_OWNER_ID,
         }
+
+    def issue_comments(
+        self, repository: str, pull_number: int, token: str
+    ) -> tuple[dict[str, Any], ...]:
+        """Return authenticated issue comments used for owner authorization."""
+        result = self._request(
+            "GET", f"/repos/{repository}/issues/{pull_number}/comments?per_page=100", token
+        )
+        if (
+            not isinstance(result, list)
+            or len(result) >= 100
+            or any(not isinstance(item, dict) for item in result)
+        ):
+            raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
+        return tuple(result)
 
     def _comparison_evidence(
         self, repository: str, base_sha: str, head_sha: str, token: str

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -183,8 +183,30 @@ class GitHubApp:
             str(base_sha),
             str(head_sha),
             self.app_id,
-            {"diff": review_diff, "pull_request": number, "reviewed_sources": reviewed_sources},
+            {
+                "diff": review_diff,
+                "pull_request": number,
+                "refactor_context": self._refactor_context(pull, files),
+                "reviewed_sources": reviewed_sources,
+            },
         )
+
+    def _refactor_context(
+        self, pull: dict[str, Any], files: tuple[dict[str, Any], ...]
+    ) -> dict[str, object]:
+        """Return authenticated author identity plus exact changed-file metadata."""
+        user = pull.get("user")
+        author = user if isinstance(user, dict) else {}
+        return {
+            "author_association": pull.get("author_association"),
+            "author_id": author.get("id"),
+            "author_login": author.get("login"),
+            "authorization": pull.get("body"),
+            "changed_files": [
+                {"path": item.get("filename"), "status": item.get("status")}
+                for item in sorted(files, key=lambda value: str(value.get("filename")))
+            ],
+        }
 
     def _comparison_evidence(
         self, repository: str, base_sha: str, head_sha: str, token: str

--- a/src/supportability_gate/refactor_policy.py
+++ b/src/supportability_gate/refactor_policy.py
@@ -174,9 +174,7 @@ def _event_values(event: dict[str, Any]) -> tuple[str, str, str, dict[str, Any]]
 def _authorization_blocks(event: dict[str, Any], authorization: Authorization) -> list[str]:
     repository, base_sha, head_sha, author = _event_values(event)
     blocks: list[str] = []
-    if author.get("id") != TRUSTED_OWNER_ID or author.get("login") != TRUSTED_OWNER_LOGIN:
-        blocks.append("UNAUTHENTICATED_OWNER_AUTHORIZATION")
-    if event["pull_request"].get("author_association") not in {"MEMBER", "OWNER"}:
+    if author.get("id") != TRUSTED_OWNER_ID:
         blocks.append("UNAUTHENTICATED_OWNER_AUTHORIZATION")
     if authorization.repository != repository:
         blocks.append("AUTHORIZATION_REPOSITORY_MISMATCH")

--- a/src/supportability_gate/refactor_policy.py
+++ b/src/supportability_gate/refactor_policy.py
@@ -1,0 +1,411 @@
+"""Verify authenticated, focused, runnable strangler-refactor increments."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from supportability_gate import contract, function_changes, git_changes
+
+AUTHORIZATION_PREFIX = "Supportability-Refactor-Authorization: "
+AUTHORIZATION_SCHEMA = "1.0"
+RESULT_SCHEMA = "refactor-policy-result.v1"
+CHARACTERIZATION_SCHEMA = "characterization-result.v1"
+TRUSTED_OWNER_ID = 229662739
+TRUSTED_OWNER_LOGIN = "markheck-solutions"
+SHA = re.compile(r"[0-9a-f]{40}\Z")
+MAX_JSON_BYTES = 1_000_000
+
+
+class RefactorPolicyError(ValueError):
+    """One fail-closed refactor-policy evidence error."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class Sequence:
+    """One logical step tied to its immutable predecessor."""
+
+    step: int
+    predecessor_sha: str
+
+
+@dataclass(frozen=True)
+class Authorization:
+    """Exact owner-authored pull-request authorization."""
+
+    repository: str
+    base_sha: str
+    head_sha: str
+    broad: bool
+    scope: tuple[str, ...]
+    targets: tuple[str, ...]
+    sequence: Sequence
+
+
+def _read_json(path: Path, code: str) -> tuple[dict[str, Any], bytes]:
+    try:
+        content = path.read_bytes()
+        value = json.loads(content)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise RefactorPolicyError(code) from error
+    if not content or len(content) > MAX_JSON_BYTES or not isinstance(value, dict):
+        raise RefactorPolicyError(code)
+    return value, content
+
+
+def _exact_keys(value: object, keys: set[str], code: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise RefactorPolicyError(code)
+    return value
+
+
+def _path_list(value: object, field: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise RefactorPolicyError("MALFORMED_OWNER_AUTHORIZATION")
+    try:
+        paths = tuple(contract.normalize_repository_path(item, field) for item in value)
+    except contract.ContractError as error:
+        raise RefactorPolicyError("MALFORMED_OWNER_AUTHORIZATION") from error
+    if list(paths) != sorted(set(paths)):
+        raise RefactorPolicyError("MALFORMED_OWNER_AUTHORIZATION")
+    return paths
+
+
+def _target_list(value: object) -> tuple[str, ...]:
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not isinstance(item, str) or "::" not in item for item in value)
+        or value != sorted(set(value))
+    ):
+        raise RefactorPolicyError("MALFORMED_OWNER_AUTHORIZATION")
+    return tuple(value)
+
+
+def _parse_authorization(body: object) -> Authorization:
+    if not isinstance(body, str):
+        raise RefactorPolicyError("MISSING_OWNER_AUTHORIZATION")
+    rows = [
+        line.removeprefix(AUTHORIZATION_PREFIX)
+        for line in body.splitlines()
+        if line.startswith(AUTHORIZATION_PREFIX)
+    ]
+    if not rows:
+        raise RefactorPolicyError("MISSING_OWNER_AUTHORIZATION")
+    if len(rows) != 1:
+        raise RefactorPolicyError("MALFORMED_OWNER_AUTHORIZATION")
+    try:
+        data = json.loads(rows[0])
+    except json.JSONDecodeError as error:
+        raise RefactorPolicyError("MALFORMED_OWNER_AUTHORIZATION") from error
+    row = _exact_keys(
+        data,
+        {
+            "base_sha",
+            "broad",
+            "head_sha",
+            "repository",
+            "schema_version",
+            "scope",
+            "sequence",
+            "targets",
+        },
+        "MALFORMED_OWNER_AUTHORIZATION",
+    )
+    sequence = _exact_keys(
+        row["sequence"], {"predecessor_sha", "step"}, "MALFORMED_OWNER_AUTHORIZATION"
+    )
+    if (
+        row["schema_version"] != AUTHORIZATION_SCHEMA
+        or not isinstance(row["repository"], str)
+        or SHA.fullmatch(str(row["base_sha"])) is None
+        or SHA.fullmatch(str(row["head_sha"])) is None
+        or type(row["broad"]) is not bool
+        or type(sequence["step"]) is not int
+        or sequence["step"] < 1
+        or SHA.fullmatch(str(sequence["predecessor_sha"])) is None
+    ):
+        raise RefactorPolicyError("MALFORMED_OWNER_AUTHORIZATION")
+    return Authorization(
+        row["repository"],
+        row["base_sha"],
+        row["head_sha"],
+        row["broad"],
+        _path_list(row["scope"], "authorization.scope"),
+        _target_list(row["targets"]),
+        Sequence(sequence["step"], sequence["predecessor_sha"]),
+    )
+
+
+def _pull_request(event: dict[str, Any]) -> dict[str, Any]:
+    pull = event.get("pull_request")
+    repository = event.get("repository")
+    if not isinstance(pull, dict) or not isinstance(repository, dict):
+        raise RefactorPolicyError("UNAUTHENTICATED_OWNER_AUTHORIZATION")
+    return pull
+
+
+def _event_values(event: dict[str, Any]) -> tuple[str, str, str, dict[str, Any]]:
+    pull = _pull_request(event)
+    try:
+        repository = event["repository"]["full_name"]
+        base_sha = pull["base"]["sha"]
+        head_sha = pull["head"]["sha"]
+        author = pull["user"]
+    except (KeyError, TypeError) as error:
+        raise RefactorPolicyError("UNAUTHENTICATED_OWNER_AUTHORIZATION") from error
+    if not all(
+        isinstance(item, str) for item in (repository, base_sha, head_sha)
+    ) or not isinstance(author, dict):
+        raise RefactorPolicyError("UNAUTHENTICATED_OWNER_AUTHORIZATION")
+    return repository, base_sha, head_sha, author
+
+
+def _authorization_blocks(event: dict[str, Any], authorization: Authorization) -> list[str]:
+    repository, base_sha, head_sha, author = _event_values(event)
+    blocks: list[str] = []
+    if author.get("id") != TRUSTED_OWNER_ID or author.get("login") != TRUSTED_OWNER_LOGIN:
+        blocks.append("UNAUTHENTICATED_OWNER_AUTHORIZATION")
+    if event["pull_request"].get("author_association") not in {"MEMBER", "OWNER"}:
+        blocks.append("UNAUTHENTICATED_OWNER_AUTHORIZATION")
+    if authorization.repository != repository:
+        blocks.append("AUTHORIZATION_REPOSITORY_MISMATCH")
+    if authorization.base_sha != base_sha or authorization.head_sha != head_sha:
+        blocks.append("STALE_OWNER_AUTHORIZATION")
+    if authorization.sequence.predecessor_sha != base_sha:
+        blocks.append("INVALID_STRANGLER_SEQUENCE")
+    return blocks
+
+
+def _profile_source(path: str, language: str) -> bool:
+    suffixes = (".py", ".pyi") if language == "python" else (".cts", ".mts", ".ts", ".tsx")
+    return path.endswith(suffixes)
+
+
+def _changed_scope(changes: tuple[git_changes.ChangedPath, ...]) -> tuple[str, ...]:
+    return tuple(
+        sorted({path for item in changes for path in (item.old_path, item.new_path) if path})
+    )
+
+
+def _target_identities(
+    repository: Path,
+    identity: git_changes.RepositoryIdentity,
+    policy: contract.Contract,
+    changes: tuple[git_changes.ChangedPath, ...],
+    records: list[git_changes.CommandRecord],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    targets: list[str] = []
+    unbounded: list[str] = []
+    for change in changes:
+        path = change.new_path
+        if path is None or not policy.is_production_path(path):
+            if change.old_path and policy.is_production_path(change.old_path):
+                unbounded.append(change.old_path)
+            continue
+        if not _profile_source(path, policy.language):
+            unbounded.append(path)
+            continue
+        lines = git_changes.changed_head_lines(
+            repository, identity.base_sha, identity.head_sha, path, records
+        )
+        blob = git_changes.read_regular_blob(repository, identity.head_sha, path, records)
+        spans = function_changes.responsibility_spans(path, blob.content, set(lines))
+        targets.extend(
+            f"{path}::{item.kind}:{item.name}:{item.start_line}-{item.end_line}" for item in spans
+        )
+    return tuple(sorted(targets)), tuple(sorted(unbounded))
+
+
+def _proof_path(path: str) -> bool:
+    return path in {
+        ".supportability-characterization.json",
+        ".supportability-review.toml",
+    } or path.startswith("tests/characterization/")
+
+
+def _focus_blocks(
+    authorization: Authorization,
+    actual_scope: tuple[str, ...],
+    targets: tuple[str, ...],
+    unbounded: tuple[str, ...],
+    policy: contract.Contract,
+) -> list[str]:
+    blocks: list[str] = []
+    if authorization.scope != actual_scope:
+        blocks.append("UNFOCUSED_DIFF_SCOPE")
+    if authorization.targets != targets or unbounded:
+        blocks.append("UNVERIFIABLE_BOUNDED_TARGET")
+    production_paths = {item.split("::", 1)[0] for item in targets}
+    unrelated = [
+        path for path in actual_scope if path not in production_paths and not _proof_path(path)
+    ]
+    broad_required = len(targets) != 1 or len(production_paths) != 1 or bool(unrelated)
+    if broad_required and not authorization.broad:
+        blocks.append("BROAD_AUTHORIZATION_REQUIRED")
+    if not targets or any(not policy.is_production_path(path) for path in production_paths):
+        blocks.append("MISSING_BOUNDED_PRODUCTION_TARGET")
+    return blocks
+
+
+def _characterization_blocks(
+    value: dict[str, Any],
+    repository: str,
+    base_sha: str,
+    head_sha: str,
+    production_paths: tuple[str, ...],
+) -> list[str]:
+    blocks: list[str] = []
+    if value.get("schema_version") != CHARACTERIZATION_SCHEMA:
+        return ["UNAUTHENTICATED_RUNNABILITY_EVIDENCE"]
+    if (
+        value.get("repository") != f"github.com/{repository}"
+        or value.get("base_sha") != base_sha
+        or value.get("head_sha") != head_sha
+    ):
+        blocks.append("STALE_RUNNABILITY_EVIDENCE")
+    if value.get("overall_result") != "PASS" or value.get("policy_blocks") != []:
+        blocks.append("NON_RUNNABLE_LOGICAL_STEP")
+    coverage = value.get("coverage")
+    if not isinstance(coverage, dict):
+        return [*blocks, "UNAUTHENTICATED_RUNNABILITY_EVIDENCE"]
+    required, covered = coverage.get("required_paths"), coverage.get("covered_paths")
+    if (
+        not isinstance(required, list)
+        or not isinstance(covered, list)
+        or any(path not in required or path not in covered for path in production_paths)
+    ):
+        blocks.append("MISSING_RUNNABILITY_COVERAGE")
+    scenarios = value.get("scenarios")
+    if (
+        not isinstance(scenarios, list)
+        or not scenarios
+        or any(
+            not isinstance(item, dict) or item.get("compatibility") != "PASS" for item in scenarios
+        )
+    ):
+        blocks.append("NON_RUNNABLE_LOGICAL_STEP")
+    return blocks
+
+
+def verify_refactor(
+    repository: Path,
+    event: dict[str, Any],
+    characterization: dict[str, Any],
+) -> dict[str, object]:
+    """Return deterministic M8 authorization, focus, runnability, and sequence evidence."""
+    records: list[git_changes.CommandRecord] = []
+    repository = git_changes.validate_repository(repository, records)
+    repository_name, base_sha, head_sha, _ = _event_values(event)
+    identity = git_changes.inspect_repository(repository, base_sha, head_sha, records)
+    policy_blob = git_changes.read_regular_blob(
+        repository, base_sha, ".supportability.toml", records
+    )
+    policy = contract.parse_contract(policy_blob.content)
+    changes = git_changes.changed_paths(repository, base_sha, head_sha, records)
+    actual_scope = _changed_scope(changes)
+    targets, unbounded = _target_identities(repository, identity, policy, changes, records)
+    applicable = bool(targets or unbounded)
+    pull = _pull_request(event)
+    blocks: list[str] = []
+    authorization: Authorization | None = None
+    if applicable:
+        try:
+            authorization = _parse_authorization(pull.get("body"))
+            blocks.extend(_authorization_blocks(event, authorization))
+            blocks.extend(_focus_blocks(authorization, actual_scope, targets, unbounded, policy))
+        except RefactorPolicyError as error:
+            blocks.append(error.code)
+    production_paths = tuple(sorted({item.split("::", 1)[0] for item in targets}))
+    blocks.extend(
+        _characterization_blocks(
+            characterization, repository_name, base_sha, head_sha, production_paths
+        )
+    )
+    unique_blocks = sorted(set(blocks))
+    return {
+        "applicable": applicable,
+        "authorization": (
+            {
+                "base_sha": authorization.base_sha,
+                "broad": authorization.broad,
+                "head_sha": authorization.head_sha,
+                "repository": authorization.repository,
+                "scope": list(authorization.scope),
+                "sequence": {
+                    "predecessor_sha": authorization.sequence.predecessor_sha,
+                    "step": authorization.sequence.step,
+                },
+                "targets": list(authorization.targets),
+            }
+            if authorization
+            else None
+        ),
+        "base_sha": base_sha,
+        "characterization_sha256": hashlib.sha256(
+            json.dumps(
+                characterization, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+            ).encode()
+        ).hexdigest(),
+        "changed_paths": list(actual_scope),
+        "head_sha": head_sha,
+        "other_standard_clauses_waived": False,
+        "overall_result": "BLOCK" if unique_blocks else "PASS",
+        "policy_blocks": unique_blocks,
+        "repository": repository_name,
+        "schema_version": RESULT_SCHEMA,
+        "targets": list(targets),
+        "unbounded_paths": list(unbounded),
+    }
+
+
+def _write_result(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True).encode() + b"\n"
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="supportability-refactor-policy")
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--characterization-result", required=True)
+    parser.add_argument("--output", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Verify one GitHub-hosted refactor increment without executing target code."""
+    arguments = _parser().parse_args(argv)
+    try:
+        if (
+            os.environ.get("RUNNER_ENVIRONMENT") != "github-hosted"
+            or os.environ.get("GITHUB_EVENT_NAME") != "pull_request"
+        ):
+            raise RefactorPolicyError("UNAUTHENTICATED_HOSTED_CONTEXT")
+        event, _ = _read_json(Path(arguments.event), "MALFORMED_GITHUB_EVENT")
+        characterization, _ = _read_json(
+            Path(arguments.characterization_result), "MALFORMED_CHARACTERIZATION_RESULT"
+        )
+        result = verify_refactor(Path(arguments.repository), event, characterization)
+        _write_result(Path(arguments.output), result)
+    except Exception as error:  # fail closed at hosted-job boundary
+        print(getattr(error, "code", "TECHNICAL_FAILURE"))
+        return 2
+    print(result["overall_result"])
+    return 1 if result["overall_result"] == "BLOCK" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/supportability_gate/refactor_policy.py
+++ b/src/supportability_gate/refactor_policy.py
@@ -7,6 +7,8 @@ import hashlib
 import json
 import os
 import re
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -18,7 +20,6 @@ AUTHORIZATION_SCHEMA = "1.0"
 RESULT_SCHEMA = "refactor-policy-result.v1"
 CHARACTERIZATION_SCHEMA = "characterization-result.v1"
 TRUSTED_OWNER_ID = 229662739
-TRUSTED_OWNER_LOGIN = "markheck-solutions"
 SHA = re.compile(r"[0-9a-f]{40}\Z")
 MAX_JSON_BYTES = 1_000_000
 
@@ -155,27 +156,26 @@ def _pull_request(event: dict[str, Any]) -> dict[str, Any]:
     return pull
 
 
-def _event_values(event: dict[str, Any]) -> tuple[str, str, str, dict[str, Any]]:
+def _event_values(event: dict[str, Any]) -> tuple[str, str, str, int]:
     pull = _pull_request(event)
     try:
         repository = event["repository"]["full_name"]
         base_sha = pull["base"]["sha"]
         head_sha = pull["head"]["sha"]
-        author = pull["user"]
+        number = pull["number"]
     except (KeyError, TypeError) as error:
         raise RefactorPolicyError("UNAUTHENTICATED_OWNER_AUTHORIZATION") from error
-    if not all(
-        isinstance(item, str) for item in (repository, base_sha, head_sha)
-    ) or not isinstance(author, dict):
+    if (
+        not all(isinstance(item, str) for item in (repository, base_sha, head_sha))
+        or type(number) is not int
+    ):
         raise RefactorPolicyError("UNAUTHENTICATED_OWNER_AUTHORIZATION")
-    return repository, base_sha, head_sha, author
+    return repository, base_sha, head_sha, number
 
 
 def _authorization_blocks(event: dict[str, Any], authorization: Authorization) -> list[str]:
-    repository, base_sha, head_sha, author = _event_values(event)
+    repository, base_sha, head_sha, _ = _event_values(event)
     blocks: list[str] = []
-    if author.get("id") != TRUSTED_OWNER_ID:
-        blocks.append("UNAUTHENTICATED_OWNER_AUTHORIZATION")
     if authorization.repository != repository:
         blocks.append("AUTHORIZATION_REPOSITORY_MISMATCH")
     if authorization.base_sha != base_sha or authorization.head_sha != head_sha:
@@ -183,6 +183,76 @@ def _authorization_blocks(event: dict[str, Any], authorization: Authorization) -
     if authorization.sequence.predecessor_sha != base_sha:
         blocks.append("INVALID_STRANGLER_SEQUENCE")
     return blocks
+
+
+def _owner_authorization(
+    event: dict[str, Any], comments: tuple[dict[str, Any], ...]
+) -> tuple[Authorization, int]:
+    _, _, head_sha, _ = _event_values(event)
+    candidates: list[tuple[Authorization, int]] = []
+    stale = False
+    untrusted = False
+    for comment in comments:
+        user = comment.get("user")
+        if not isinstance(user, dict) or user.get("id") != TRUSTED_OWNER_ID:
+            body = comment.get("body")
+            untrusted = untrusted or (
+                isinstance(body, str)
+                and any(line.startswith(AUTHORIZATION_PREFIX) for line in body.splitlines())
+            )
+            continue
+        try:
+            authorization = _parse_authorization(comment.get("body"))
+        except RefactorPolicyError as error:
+            if error.code == "MISSING_OWNER_AUTHORIZATION":
+                continue
+            raise
+        comment_id = comment.get("id")
+        if type(comment_id) is not int:
+            raise RefactorPolicyError("UNAUTHENTICATED_OWNER_AUTHORIZATION")
+        if authorization.head_sha == head_sha:
+            candidates.append((authorization, comment_id))
+        else:
+            stale = True
+    if not candidates:
+        raise RefactorPolicyError(
+            "UNAUTHENTICATED_OWNER_AUTHORIZATION"
+            if untrusted
+            else "STALE_OWNER_AUTHORIZATION"
+            if stale
+            else "MISSING_OWNER_AUTHORIZATION"
+        )
+    if len(candidates) != 1:
+        raise RefactorPolicyError("MALFORMED_OWNER_AUTHORIZATION")
+    return candidates[0]
+
+
+def _github_comments(
+    repository: str,
+    pull_number: int,
+    token: str,
+    opener: Any = urllib.request.urlopen,
+) -> tuple[dict[str, Any], ...]:
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repository}/issues/{pull_number}/comments?per_page=100",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with opener(request, timeout=30) as response:
+            value = json.loads(response.read())
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError) as error:
+        raise RefactorPolicyError("GITHUB_AUTHORIZATION_EVIDENCE_FAILURE") from error
+    if (
+        not isinstance(value, list)
+        or len(value) >= 100
+        or any(not isinstance(item, dict) for item in value)
+    ):
+        raise RefactorPolicyError("GITHUB_AUTHORIZATION_EVIDENCE_FAILURE")
+    return tuple(value)
 
 
 def _profile_source(path: str, language: str) -> bool:
@@ -300,6 +370,7 @@ def verify_refactor(
     repository: Path,
     event: dict[str, Any],
     characterization: dict[str, Any],
+    comments: tuple[dict[str, Any], ...],
 ) -> dict[str, object]:
     """Return deterministic M8 authorization, focus, runnability, and sequence evidence."""
     records: list[git_changes.CommandRecord] = []
@@ -314,12 +385,12 @@ def verify_refactor(
     actual_scope = _changed_scope(changes)
     targets, unbounded = _target_identities(repository, identity, policy, changes, records)
     applicable = bool(targets or unbounded)
-    pull = _pull_request(event)
     blocks: list[str] = []
     authorization: Authorization | None = None
+    authorization_comment_id: int | None = None
     if applicable:
         try:
-            authorization = _parse_authorization(pull.get("body"))
+            authorization, authorization_comment_id = _owner_authorization(event, comments)
             blocks.extend(_authorization_blocks(event, authorization))
             blocks.extend(_focus_blocks(authorization, actual_scope, targets, unbounded, policy))
         except RefactorPolicyError as error:
@@ -349,6 +420,7 @@ def verify_refactor(
             if authorization
             else None
         ),
+        "authorization_comment_id": authorization_comment_id,
         "base_sha": base_sha,
         "characterization_sha256": hashlib.sha256(
             json.dumps(
@@ -396,7 +468,12 @@ def main(argv: list[str] | None = None) -> int:
         characterization, _ = _read_json(
             Path(arguments.characterization_result), "MALFORMED_CHARACTERIZATION_RESULT"
         )
-        result = verify_refactor(Path(arguments.repository), event, characterization)
+        repository_name, _, _, pull_number = _event_values(event)
+        token = os.environ.get("GITHUB_TOKEN")
+        if not token:
+            raise RefactorPolicyError("GITHUB_AUTHORIZATION_EVIDENCE_FAILURE")
+        comments = _github_comments(repository_name, pull_number, token)
+        result = verify_refactor(Path(arguments.repository), event, characterization, comments)
         _write_result(Path(arguments.output), result)
     except Exception as error:  # fail closed at hosted-job boundary
         print(getattr(error, "code", "TECHNICAL_FAILURE"))

--- a/src/supportability_gate/semantic_contract.py
+++ b/src/supportability_gate/semantic_contract.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any
 
 MODEL = "gpt-5.6-sol"
-RUBRIC_VERSION = "domain-modularization.v1"
+RUBRIC_VERSION = "incremental-strangler.v1"
 SCHEMA_VERSION = "semantic-review.v1"
 STANDARD_SHA256 = "81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2"
 SHA_PATTERN = re.compile(r"[0-9a-f]{40}\Z")
@@ -209,6 +209,12 @@ def request_payload(packet: EvidencePacket) -> dict[str, Any]:
         "vaguely named production helpers whose names do not express one concrete responsibility, "
         "including numbered parts, generic helper/handler/processor names, misc/stuff, or equivalent "
         "obfuscation. Clear responsibility-named extraction passes this narrow rubric. "
+        "For incremental refactoring, require one parser-bounded production target, exact diff "
+        "scope, compatible runnable base/head behavior, and an immutable predecessor/head sequence. "
+        "BLOCK repo-wide cleanup, unrelated churn, multiple unbounded targets, or non-runnable "
+        "steps unless trusted owner metadata contains exact broad scope for this head. Broad "
+        "authorization never waives complexity, architecture, characterization, modularity, or "
+        "any other Supportability Standard clause. "
         "Each reviewed source supplies trusted parser-derived boundaries. Return exactly every "
         "supplied function, module, or frontend component boundary, copying its name, kind, and "
         "inclusive line span. State one clear owned "

--- a/src/supportability_gate/semantic_contract.py
+++ b/src/supportability_gate/semantic_contract.py
@@ -12,6 +12,7 @@ MODEL = "gpt-5.6-sol"
 RUBRIC_VERSION = "incremental-strangler.v1"
 SCHEMA_VERSION = "semantic-review.v1"
 STANDARD_SHA256 = "81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2"
+TRUSTED_OWNER_ID = 229662739
 SHA_PATTERN = re.compile(r"[0-9a-f]{40}\Z")
 REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\Z")
 
@@ -214,7 +215,7 @@ def request_payload(packet: EvidencePacket) -> dict[str, Any]:
         "BLOCK repo-wide cleanup, unrelated churn, multiple unbounded targets, or non-runnable "
         "steps unless trusted owner metadata contains exact broad scope for this head. Broad "
         "authorization never waives complexity, architecture, characterization, modularity, or "
-        "any other Supportability Standard clause. "
+        f"any other Supportability Standard clause. Trusted owner GitHub user ID is {TRUSTED_OWNER_ID}. "
         "Each reviewed source supplies trusted parser-derived boundaries. Return exactly every "
         "supplied function, module, or frontend component boundary, copying its name, kind, and "
         "inclusive line span. State one clear owned "

--- a/tests/characterization/refactor-policy.characterization.py
+++ b/tests/characterization/refactor-policy.characterization.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    target = Path(os.environ["SUPPORTABILITY_CHARACTERIZATION_TARGET"])
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(target / "src")
+    completed = subprocess.run(
+        [sys.executable, "-P", "-m", "supportability_gate", "--help"],
+        cwd=target,
+        env=environment,
+        check=False,
+        capture_output=True,
+        timeout=30,
+    )
+    behavior = {
+        "exit_code": completed.returncode,
+        "stderr_sha256": hashlib.sha256(completed.stderr.replace(b"\r\n", b"\n")).hexdigest(),
+        "stdout_sha256": hashlib.sha256(completed.stdout.replace(b"\r\n", b"\n")).hexdigest(),
+    }
+    print(
+        json.dumps(
+            {"behavior": behavior, "scenario": "refactor-policy", "schema_version": "1.0"},
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/characterization/refactor-policy.golden.json
+++ b/tests/characterization/refactor-policy.golden.json
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "stdout_sha256": "c10d466d329e36f9a2cc7659851c8792e1b4a63cee26190ef0f0600bebbda36b"
+}

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -177,8 +177,11 @@ def test_compare_evidence_and_check_bind_exact_head_app_and_hash() -> None:
     app = GitHubApp(42, 7, b"unused", opener=open_request)
     pull: dict[str, Any] = {
         "number": 3,
+        "author_association": "MEMBER",
         "base": {"sha": "a" * 40},
+        "body": "Supportability-Refactor-Authorization: {}",
         "head": {"sha": "b" * 40},
+        "user": {"id": 229662739, "login": "markheck-solutions"},
     }
     packet = app.evidence_packet("mbh-solutions/supportability-gate", pull, "token")
     result = app.publish_check(packet, "token", "success", "PASS")
@@ -200,6 +203,13 @@ def test_compare_evidence_and_check_bind_exact_head_app_and_hash() -> None:
             "path": "src/a.py",
         }
     ]
+    assert packet.evidence["refactor_context"] == {
+        "author_association": "MEMBER",
+        "author_id": 229662739,
+        "author_login": "markheck-solutions",
+        "authorization": "Supportability-Refactor-Authorization: {}",
+        "changed_files": [{"path": "src/a.py", "status": "modified"}],
+    }
 
 
 def test_frontend_component_boundary_uses_complete_parser_span() -> None:

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -156,6 +156,16 @@ def test_compare_evidence_and_check_bind_exact_head_app_and_hash() -> None:
             return _Reply(_blob_payload(CONTRACT))
         if request.full_url.endswith(f"/git/blobs/{source_sha}"):
             return _Reply(_blob_payload(source))
+        if "/issues/3/comments" in request.full_url:
+            return _Reply(
+                [
+                    {
+                        "body": "Supportability-Refactor-Authorization: {}",
+                        "id": 11,
+                        "user": {"id": 229662739},
+                    }
+                ]
+            )
         if "/compare/" in request.full_url:
             if request.get_header("Accept") != "application/vnd.github.v3.diff":
                 return _Reply(
@@ -207,8 +217,15 @@ def test_compare_evidence_and_check_bind_exact_head_app_and_hash() -> None:
         "author_association": "MEMBER",
         "author_id": 229662739,
         "author_login": "markheck-solutions",
-        "authorization": "Supportability-Refactor-Authorization: {}",
+        "authorization_comments": [
+            {
+                "body": "Supportability-Refactor-Authorization: {}",
+                "id": 11,
+                "user_id": 229662739,
+            }
+        ],
         "changed_files": [{"path": "src/a.py", "status": "modified"}],
+        "trusted_owner_id": 229662739,
     }
 
 
@@ -254,6 +271,8 @@ def test_binary_marker_inside_source_text_is_evidence() -> None:
     diff = f"diff --git a/src/a.py b/src/a.py\n{patch}"
 
     def open_request(request: Any, **kwargs: object) -> _Reply:
+        if "/issues/3/comments" in request.full_url:
+            return _Reply([])
         if "/contents/.supportability.toml" in request.full_url:
             return _Reply({"sha": contract_sha})
         if request.full_url.endswith(f"/git/blobs/{contract_sha}"):
@@ -298,6 +317,8 @@ def test_invalid_exact_head_source_blob_blocks() -> None:
     contract_sha = _blob_sha(CONTRACT)
 
     def open_request(request: Any, **kwargs: object) -> _Reply:
+        if "/issues/3/comments" in request.full_url:
+            return _Reply([])
         if "/contents/.supportability.toml" in request.full_url:
             return _Reply({"sha": contract_sha})
         if request.full_url.endswith(f"/git/blobs/{contract_sha}"):
@@ -329,6 +350,8 @@ def test_only_base_contract_production_paths_are_reviewed() -> None:
     contract_sha = _blob_sha(CONTRACT)
 
     def open_request(request: Any, **kwargs: object) -> _Reply:
+        if "/issues/3/comments" in request.full_url:
+            return _Reply([])
         if "/contents/.supportability.toml" in request.full_url:
             return _Reply({"sha": contract_sha})
         if request.full_url.endswith(f"/git/blobs/{contract_sha}"):
@@ -347,6 +370,8 @@ def test_only_base_contract_production_paths_are_reviewed() -> None:
 
 def test_removed_source_needs_no_outside_head_evidence() -> None:
     def open_request(request: Any, **kwargs: object) -> _Reply:
+        if "/issues/3/comments" in request.full_url:
+            return _Reply([])
         if request.get_header("Accept") == "application/vnd.github.v3.diff":
             return _RawReply("diff --git a/src/a.py b/src/a.py\n-deleted")
         return _Reply({"files": [{"filename": "src/a.py", "sha": None, "status": "removed"}]})

--- a/tests/test_refactor_policy.py
+++ b/tests/test_refactor_policy.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from supportability_gate import refactor_policy
+
+PYTHON_CONTRACT = """\
+schema_version = "1.0"
+language = "python"
+production_paths = ["src"]
+high_risk_paths = []
+
+[[gates]]
+adapter = "python.pytest.v1"
+paths = ["src"]
+
+[complexity]
+adapter = "python.c901-touched.v1"
+maximum = 10
+"""
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return result.stdout.strip()
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _commit(repository: Path, message: str) -> str:
+    _git(repository, "add", "--all")
+    _git(repository, "commit", "-m", message)
+    return _git(repository, "rev-parse", "HEAD")
+
+
+def _repository(tmp_path: Path, language: str = "python") -> tuple[Path, str, str]:
+    repository = tmp_path / "fixture"
+    repository.mkdir()
+    _git(repository, "init", "--initial-branch=main")
+    _git(repository, "config", "user.name", "Fixture")
+    _git(repository, "config", "user.email", "fixture@example.invalid")
+    _git(repository, "config", "core.autocrlf", "false")
+    _git(repository, "remote", "add", "origin", "https://github.com/example/fixture.git")
+    contract = PYTHON_CONTRACT
+    path = "src/sample.py"
+    source = "def calculate(value: int) -> int:\n    return value + 1\n"
+    if language == "typescript":
+        contract = contract.replace('language = "python"', 'language = "typescript"').replace(
+            'adapter = "python.c901-touched.v1"',
+            'adapter = "typescript.c901-equivalent-touched.v1"',
+        )
+        path = "src/sample.ts"
+        source = "export function calculate(value: number): number {\n  return value + 1;\n}\n"
+    _write(repository / ".supportability.toml", contract)
+    _write(repository / path, source)
+    base_sha = _commit(repository, "base")
+    _write(repository / path, source.replace("+ 1", "+ 2"))
+    head_sha = _commit(repository, "head")
+    return repository, base_sha, head_sha
+
+
+def _authorization(
+    base_sha: str,
+    head_sha: str,
+    scope: list[str],
+    targets: list[str],
+    *,
+    broad: bool = False,
+    predecessor_sha: str | None = None,
+) -> str:
+    value = {
+        "base_sha": base_sha,
+        "broad": broad,
+        "head_sha": head_sha,
+        "repository": "example/fixture",
+        "schema_version": "1.0",
+        "scope": sorted(scope),
+        "sequence": {"predecessor_sha": predecessor_sha or base_sha, "step": 1},
+        "targets": sorted(targets),
+    }
+    return refactor_policy.AUTHORIZATION_PREFIX + json.dumps(value, separators=(",", ":"))
+
+
+def _event(base_sha: str, head_sha: str, body: str | None) -> dict[str, object]:
+    return {
+        "repository": {"full_name": "example/fixture"},
+        "pull_request": {
+            "author_association": "MEMBER",
+            "base": {"sha": base_sha},
+            "body": body,
+            "head": {"sha": head_sha},
+            "user": {
+                "id": refactor_policy.TRUSTED_OWNER_ID,
+                "login": refactor_policy.TRUSTED_OWNER_LOGIN,
+            },
+        },
+    }
+
+
+def _characterization(
+    base_sha: str,
+    head_sha: str,
+    paths: list[str],
+    *,
+    runnable: bool = True,
+) -> dict[str, object]:
+    return {
+        "base_sha": base_sha,
+        "coverage": {"covered_paths": paths, "required_paths": paths},
+        "head_sha": head_sha,
+        "overall_result": "PASS" if runnable else "BLOCK",
+        "policy_blocks": [] if runnable else ["GOLDEN_BEHAVIOR_MISMATCH:sample"],
+        "repository": "github.com/example/fixture",
+        "scenarios": [{"compatibility": "PASS" if runnable else "BLOCK"}],
+        "schema_version": refactor_policy.CHARACTERIZATION_SCHEMA,
+    }
+
+
+@pytest.mark.parametrize(
+    ("language", "path"), [("python", "src/sample.py"), ("typescript", "src/sample.ts")]
+)
+def test_bounded_runnable_python_and_typescript_refactors_pass(
+    tmp_path: Path, language: str, path: str
+) -> None:
+    repository, base_sha, head_sha = _repository(tmp_path, language)
+    end_line = 2 if language == "python" else 3
+    target = f"{path}::function:calculate:1-{end_line}"
+    event = _event(base_sha, head_sha, _authorization(base_sha, head_sha, [path], [target]))
+    characterization = _characterization(base_sha, head_sha, [path])
+
+    first = refactor_policy.verify_refactor(repository, event, characterization)
+    second = refactor_policy.verify_refactor(repository, event, characterization)
+
+    assert first == second
+    assert first["overall_result"] == "PASS"
+    assert first["targets"] == [target]
+    assert first["other_standard_clauses_waived"] is False
+
+
+def test_repo_wide_cleanup_requires_exact_broad_authorization(tmp_path: Path) -> None:
+    repository, base_sha, _ = _repository(tmp_path)
+    _git(repository, "reset", "--hard", base_sha)
+    _write(
+        repository / "src/sample.py", "def calculate(value: int) -> int:\n    return value + 2\n"
+    )
+    _write(repository / "src/other.py", "def normalize(value: int) -> int:\n    return value + 1\n")
+    head_sha = _commit(repository, "wide")
+    paths = ["src/other.py", "src/sample.py"]
+    targets = [
+        "src/other.py::function:normalize:1-2",
+        "src/sample.py::function:calculate:1-2",
+    ]
+    event = _event(base_sha, head_sha, _authorization(base_sha, head_sha, paths, targets))
+
+    result = refactor_policy.verify_refactor(
+        repository, event, _characterization(base_sha, head_sha, paths)
+    )
+
+    assert result["overall_result"] == "BLOCK"
+    assert "BROAD_AUTHORIZATION_REQUIRED" in result["policy_blocks"]
+
+
+def test_exact_broad_authorization_cannot_waive_other_clauses(tmp_path: Path) -> None:
+    repository, base_sha, _ = _repository(tmp_path)
+    _git(repository, "reset", "--hard", base_sha)
+    _write(
+        repository / "src/sample.py", "def calculate(value: int) -> int:\n    return value + 2\n"
+    )
+    _write(repository / "src/other.py", "def normalize(value: int) -> int:\n    return value + 1\n")
+    head_sha = _commit(repository, "wide")
+    paths = ["src/other.py", "src/sample.py"]
+    targets = [
+        "src/other.py::function:normalize:1-2",
+        "src/sample.py::function:calculate:1-2",
+    ]
+    event = _event(
+        base_sha,
+        head_sha,
+        _authorization(base_sha, head_sha, paths, targets, broad=True),
+    )
+
+    result = refactor_policy.verify_refactor(
+        repository, event, _characterization(base_sha, head_sha, paths)
+    )
+
+    assert result["overall_result"] == "PASS"
+    assert result["other_standard_clauses_waived"] is False
+
+
+def test_unrelated_churn_requires_broad_authorization(tmp_path: Path) -> None:
+    repository, base_sha, _ = _repository(tmp_path)
+    _git(repository, "reset", "--hard", base_sha)
+    _write(
+        repository / "src/sample.py", "def calculate(value: int) -> int:\n    return value + 2\n"
+    )
+    _write(repository / "docs/churn.md", "unrelated\n")
+    head_sha = _commit(repository, "churn")
+    scope = ["docs/churn.md", "src/sample.py"]
+    target = "src/sample.py::function:calculate:1-2"
+    event = _event(base_sha, head_sha, _authorization(base_sha, head_sha, scope, [target]))
+
+    result = refactor_policy.verify_refactor(
+        repository, event, _characterization(base_sha, head_sha, ["src/sample.py"])
+    )
+
+    assert "BROAD_AUTHORIZATION_REQUIRED" in result["policy_blocks"]
+
+
+def test_multiple_unbounded_targets_block(tmp_path: Path) -> None:
+    repository, base_sha, _ = _repository(tmp_path)
+    _git(repository, "reset", "--hard", base_sha)
+    _write(
+        repository / "src/sample.py",
+        "def calculate(value: int) -> int:\n    return value + 2\n\n"
+        "def normalize(value: int) -> int:\n    return value + 1\n",
+    )
+    head_sha = _commit(repository, "multiple")
+    event = _event(
+        base_sha,
+        head_sha,
+        _authorization(
+            base_sha,
+            head_sha,
+            ["src/sample.py"],
+            ["src/sample.py::module:*:1-1"],
+        ),
+    )
+
+    result = refactor_policy.verify_refactor(
+        repository, event, _characterization(base_sha, head_sha, ["src/sample.py"])
+    )
+
+    assert "UNVERIFIABLE_BOUNDED_TARGET" in result["policy_blocks"]
+    assert "BROAD_AUTHORIZATION_REQUIRED" in result["policy_blocks"]
+
+
+def test_non_runnable_intermediate_state_blocks(tmp_path: Path) -> None:
+    repository, base_sha, head_sha = _repository(tmp_path)
+    path = "src/sample.py"
+    target = f"{path}::function:calculate:1-2"
+    event = _event(base_sha, head_sha, _authorization(base_sha, head_sha, [path], [target]))
+
+    result = refactor_policy.verify_refactor(
+        repository,
+        event,
+        _characterization(base_sha, head_sha, [path], runnable=False),
+    )
+
+    assert "NON_RUNNABLE_LOGICAL_STEP" in result["policy_blocks"]
+
+
+def test_missing_owner_authorization_blocks(tmp_path: Path) -> None:
+    repository, base_sha, head_sha = _repository(tmp_path)
+    result = refactor_policy.verify_refactor(
+        repository,
+        _event(base_sha, head_sha, None),
+        _characterization(base_sha, head_sha, ["src/sample.py"]),
+    )
+    assert result["policy_blocks"] == ["MISSING_OWNER_AUTHORIZATION"]
+
+
+def test_non_production_change_is_not_a_refactor(tmp_path: Path) -> None:
+    repository, base_sha, _ = _repository(tmp_path)
+    _git(repository, "reset", "--hard", base_sha)
+    _write(repository / "docs/evidence.md", "record\n")
+    head_sha = _commit(repository, "evidence")
+
+    result = refactor_policy.verify_refactor(
+        repository,
+        _event(base_sha, head_sha, None),
+        _characterization(base_sha, head_sha, []),
+    )
+
+    assert result["applicable"] is False
+    assert result["overall_result"] == "PASS"
+
+
+@pytest.mark.parametrize(
+    ("defect", "code"),
+    [
+        ("identity", "UNAUTHENTICATED_OWNER_AUTHORIZATION"),
+        ("head", "STALE_OWNER_AUTHORIZATION"),
+        ("scope", "UNFOCUSED_DIFF_SCOPE"),
+        ("target", "UNVERIFIABLE_BOUNDED_TARGET"),
+        ("sequence", "INVALID_STRANGLER_SEQUENCE"),
+    ],
+)
+def test_authorization_focus_and_sequence_are_exact(tmp_path: Path, defect: str, code: str) -> None:
+    repository, base_sha, head_sha = _repository(tmp_path)
+    path = "src/sample.py"
+    targets = [f"{path}::function:calculate:1-2"]
+    scope = [path]
+    authorized_head = "f" * 40 if defect == "head" else head_sha
+    authorized_scope = ["docs/outside.md"] if defect == "scope" else scope
+    authorized_targets = [f"{path}::function:wrong:1-2"] if defect == "target" else targets
+    predecessor = "e" * 40 if defect == "sequence" else base_sha
+    event = _event(
+        base_sha,
+        head_sha,
+        _authorization(
+            base_sha,
+            authorized_head,
+            authorized_scope,
+            authorized_targets,
+            predecessor_sha=predecessor,
+        ),
+    )
+    if defect == "identity":
+        event["pull_request"]["user"]["id"] = 1  # type: ignore[index]
+
+    result = refactor_policy.verify_refactor(
+        repository, event, _characterization(base_sha, head_sha, scope)
+    )
+
+    assert code in result["policy_blocks"]

--- a/tests/test_refactor_policy.py
+++ b/tests/test_refactor_policy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -22,6 +23,20 @@ paths = ["src"]
 adapter = "python.c901-touched.v1"
 maximum = 10
 """
+
+
+class _Reply:
+    def __init__(self, value: object) -> None:
+        self.content = json.dumps(value).encode()
+
+    def __enter__(self) -> _Reply:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.content
 
 
 def _git(repository: Path, *arguments: str) -> str:
@@ -103,9 +118,10 @@ def _event(base_sha: str, head_sha: str, body: str | None) -> dict[str, object]:
             "base": {"sha": base_sha},
             "body": body,
             "head": {"sha": head_sha},
+            "number": 7,
             "user": {
                 "id": refactor_policy.TRUSTED_OWNER_ID,
-                "login": refactor_policy.TRUSTED_OWNER_LOGIN,
+                "login": "markheck-solutions",
             },
         },
     }
@@ -130,6 +146,18 @@ def _characterization(
     }
 
 
+def _verify(
+    repository: Path,
+    event: dict[str, object],
+    characterization: dict[str, object],
+    *,
+    owner_id: int = refactor_policy.TRUSTED_OWNER_ID,
+) -> dict[str, object]:
+    body = event["pull_request"]["body"]  # type: ignore[index]
+    comments = () if body is None else ({"body": body, "id": 11, "user": {"id": owner_id}},)
+    return refactor_policy.verify_refactor(repository, event, characterization, comments)
+
+
 @pytest.mark.parametrize(
     ("language", "path"), [("python", "src/sample.py"), ("typescript", "src/sample.ts")]
 )
@@ -142,8 +170,8 @@ def test_bounded_runnable_python_and_typescript_refactors_pass(
     event = _event(base_sha, head_sha, _authorization(base_sha, head_sha, [path], [target]))
     characterization = _characterization(base_sha, head_sha, [path])
 
-    first = refactor_policy.verify_refactor(repository, event, characterization)
-    second = refactor_policy.verify_refactor(repository, event, characterization)
+    first = _verify(repository, event, characterization)
+    second = _verify(repository, event, characterization)
 
     assert first == second
     assert first["overall_result"] == "PASS"
@@ -166,9 +194,7 @@ def test_repo_wide_cleanup_requires_exact_broad_authorization(tmp_path: Path) ->
     ]
     event = _event(base_sha, head_sha, _authorization(base_sha, head_sha, paths, targets))
 
-    result = refactor_policy.verify_refactor(
-        repository, event, _characterization(base_sha, head_sha, paths)
-    )
+    result = _verify(repository, event, _characterization(base_sha, head_sha, paths))
 
     assert result["overall_result"] == "BLOCK"
     assert "BROAD_AUTHORIZATION_REQUIRED" in result["policy_blocks"]
@@ -193,9 +219,7 @@ def test_exact_broad_authorization_cannot_waive_other_clauses(tmp_path: Path) ->
         _authorization(base_sha, head_sha, paths, targets, broad=True),
     )
 
-    result = refactor_policy.verify_refactor(
-        repository, event, _characterization(base_sha, head_sha, paths)
-    )
+    result = _verify(repository, event, _characterization(base_sha, head_sha, paths))
 
     assert result["overall_result"] == "PASS"
     assert result["other_standard_clauses_waived"] is False
@@ -213,9 +237,7 @@ def test_unrelated_churn_requires_broad_authorization(tmp_path: Path) -> None:
     target = "src/sample.py::function:calculate:1-2"
     event = _event(base_sha, head_sha, _authorization(base_sha, head_sha, scope, [target]))
 
-    result = refactor_policy.verify_refactor(
-        repository, event, _characterization(base_sha, head_sha, ["src/sample.py"])
-    )
+    result = _verify(repository, event, _characterization(base_sha, head_sha, ["src/sample.py"]))
 
     assert "BROAD_AUTHORIZATION_REQUIRED" in result["policy_blocks"]
 
@@ -240,9 +262,7 @@ def test_multiple_unbounded_targets_block(tmp_path: Path) -> None:
         ),
     )
 
-    result = refactor_policy.verify_refactor(
-        repository, event, _characterization(base_sha, head_sha, ["src/sample.py"])
-    )
+    result = _verify(repository, event, _characterization(base_sha, head_sha, ["src/sample.py"]))
 
     assert "UNVERIFIABLE_BOUNDED_TARGET" in result["policy_blocks"]
     assert "BROAD_AUTHORIZATION_REQUIRED" in result["policy_blocks"]
@@ -254,7 +274,7 @@ def test_non_runnable_intermediate_state_blocks(tmp_path: Path) -> None:
     target = f"{path}::function:calculate:1-2"
     event = _event(base_sha, head_sha, _authorization(base_sha, head_sha, [path], [target]))
 
-    result = refactor_policy.verify_refactor(
+    result = _verify(
         repository,
         event,
         _characterization(base_sha, head_sha, [path], runnable=False),
@@ -265,7 +285,7 @@ def test_non_runnable_intermediate_state_blocks(tmp_path: Path) -> None:
 
 def test_missing_owner_authorization_blocks(tmp_path: Path) -> None:
     repository, base_sha, head_sha = _repository(tmp_path)
-    result = refactor_policy.verify_refactor(
+    result = _verify(
         repository,
         _event(base_sha, head_sha, None),
         _characterization(base_sha, head_sha, ["src/sample.py"]),
@@ -279,7 +299,7 @@ def test_non_production_change_is_not_a_refactor(tmp_path: Path) -> None:
     _write(repository / "docs/evidence.md", "record\n")
     head_sha = _commit(repository, "evidence")
 
-    result = refactor_policy.verify_refactor(
+    result = _verify(
         repository,
         _event(base_sha, head_sha, None),
         _characterization(base_sha, head_sha, []),
@@ -287,6 +307,21 @@ def test_non_production_change_is_not_a_refactor(tmp_path: Path) -> None:
 
     assert result["applicable"] is False
     assert result["overall_result"] == "PASS"
+
+
+def test_github_comment_evidence_uses_fixed_authenticated_endpoint() -> None:
+    requests: list[Any] = []
+
+    def opener(request: Any, **kwargs: object) -> _Reply:
+        requests.append(request)
+        assert kwargs == {"timeout": 30}
+        return _Reply([{"body": "authorization", "id": 11, "user": {"id": 7}}])
+
+    comments = refactor_policy._github_comments("example/fixture", 7, "token", opener)
+
+    assert comments[0]["id"] == 11
+    assert requests[0].full_url.endswith("/repos/example/fixture/issues/7/comments?per_page=100")
+    assert requests[0].get_header("Authorization") == "Bearer token"
 
 
 @pytest.mark.parametrize(
@@ -319,11 +354,11 @@ def test_authorization_focus_and_sequence_are_exact(tmp_path: Path, defect: str,
             predecessor_sha=predecessor,
         ),
     )
-    if defect == "identity":
-        event["pull_request"]["user"]["id"] = 1  # type: ignore[index]
-
-    result = refactor_policy.verify_refactor(
-        repository, event, _characterization(base_sha, head_sha, scope)
+    result = _verify(
+        repository,
+        event,
+        _characterization(base_sha, head_sha, scope),
+        owner_id=1 if defect == "identity" else refactor_policy.TRUSTED_OWNER_ID,
     )
 
     assert code in result["policy_blocks"]

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -397,14 +397,16 @@ def test_prompt_injection_stays_untrusted_data(injection: str) -> None:
     assert payload["text"]["format"]["strict"] is True
 
 
-def test_complexity_anti_gaming_rubric_is_narrow_and_bound() -> None:
+def test_incremental_strangler_rubric_is_narrow_and_bound() -> None:
     packet = _packet({"diff": "+def handle_stuff(): pass"})
     payload = request_payload(packet)
 
-    assert RUBRIC_VERSION == "domain-modularization.v1"
+    assert RUBRIC_VERSION == "incremental-strangler.v1"
     assert "vaguely named production helpers" in payload["instructions"]
     assert "separation of concerns" in payload["instructions"]
     assert "candidate-provided responsibility declarations" in payload["instructions"]
+    assert "one parser-bounded production target" in payload["instructions"]
+    assert "Broad authorization never waives" in payload["instructions"]
     assert RUBRIC_VERSION in packet.canonical_bytes().decode()
 
 


### PR DESCRIPTION
## Summary

- Enforce authenticated exact-head refactor authorization, parser-bounded targets, focused scope, runnable characterization, and predecessor sequencing.
- Read authorization only from GitHub issue comments authored by immutable owner ID; PR body text is not trusted authorization.
- Preserve every Milestone 1-7 gate; broad authorization cannot waive another Standard clause.

## Proof

- Python 3.12.13 exact lock: Ruff lint/format/C901, strict mypy, Import Linter, 192 pytest tests, compileall, wheel build/fresh install/CLI smoke, Standard tamper test, and exact-range whitespace all pass.
- Repeated exact-head self-evaluation is byte-identical.

Closes #23