### PR TITLE
DIAGNOSTIC — DO NOT MERGE: M9 coverage-proof falsification

### DIFF
--- a/.github/workflows/organization-required.yml
+++ b/.github/workflows/organization-required.yml
@@ -162,9 +162,78 @@ jobs:
           path: ${{ runner.temp }}/head/characterization.json
           if-no-files-found: error
 
+  quality-profile:
+    name: Quality Profile
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      artifact-digest: ${{ steps.upload.outputs.artifact-digest }}
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
+      capture-sha256: ${{ steps.capture.outputs.sha256 }}
+    steps:
+      - name: Check out exact target head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: target
+
+      - name: Check out exact gate source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: mbh-solutions/supportability-gate
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          path: gate
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+
+      - name: Install exact quality runner dependencies
+        run: python -m pip install --disable-pip-version-check --require-hashes -r gate/requirements-dev.lock
+
+      - name: Capture fixed stack-native quality profile
+        id: capture
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PYTHONPATH: ${{ github.workspace }}/gate/src
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
+        run: |
+          set +e
+          python -P "$GITHUB_WORKSPACE/gate/tests/hosted_quality_profile.py" \
+            --repository "$GITHUB_WORKSPACE/target" \
+            --repository-name "$GITHUB_REPOSITORY" \
+            --repository-id "$GITHUB_REPOSITORY_ID" \
+            --base-ref "$BASE_SHA" \
+            --head-ref "$HEAD_SHA" \
+            --workflow-sha "$GITHUB_WORKFLOW_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --output "$RUNNER_TEMP/quality/quality-gates.json"
+          echo "status=$?" >> "$GITHUB_OUTPUT"
+          echo "sha256=$(sha256sum "$RUNNER_TEMP/quality/quality-gates.json" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload authenticated quality evidence
+        id: upload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: quality-profile-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/quality/quality-gates.json
+          if-no-files-found: error
+
   supportability-gate:
     name: Supportability Gate
-    needs: [characterize-base, characterize-head]
+    needs: [characterize-base, characterize-head, quality-profile]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -206,6 +275,12 @@ jobs:
         with:
           name: characterization-head-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/head
+
+      - name: Download authenticated quality evidence
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: quality-profile-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/quality
 
       - name: Verify exact behavior and refactor policy
         env:
@@ -256,6 +331,9 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          QUALITY_ARTIFACT_DIGEST: ${{ needs.quality-profile.outputs.artifact-digest }}
+          QUALITY_ARTIFACT_ID: ${{ needs.quality-profile.outputs.artifact-id }}
+          QUALITY_CAPTURE_SHA256: ${{ needs.quality-profile.outputs.capture-sha256 }}
         working-directory: ${{ runner.temp }}
         run: |
           set +e
@@ -264,6 +342,16 @@ jobs:
             --base-ref "$BASE_SHA" \
             --head-ref "$HEAD_SHA" \
             --contract-path .supportability.toml \
+            --quality-evidence "$RUNNER_TEMP/quality/quality-gates.json" \
+            --quality-repository "$GITHUB_REPOSITORY" \
+            --quality-repository-id "$GITHUB_REPOSITORY_ID" \
+            --quality-run-id "$GITHUB_RUN_ID" \
+            --quality-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --quality-job quality-profile \
+            --quality-artifact-id "$QUALITY_ARTIFACT_ID" \
+            --quality-artifact-digest "$QUALITY_ARTIFACT_DIGEST" \
+            --quality-capture-sha256 "$QUALITY_CAPTURE_SHA256" \
+            --workflow-sha "$GITHUB_WORKFLOW_SHA" \
             --output-directory "$RUNNER_TEMP/evidence"
           status=$?
           cat "$RUNNER_TEMP/evidence/complexity-result.json"

--- a/.github/workflows/source-validation.yml
+++ b/.github/workflows/source-validation.yml
@@ -46,6 +46,8 @@ jobs:
         run: lint-imports --no-cache
 
       - name: Pytest
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: python -m pytest -q
 
       - name: Compileall

--- a/.github/workflows/source-validation.yml
+++ b/.github/workflows/source-validation.yml
@@ -25,6 +25,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up Node.js 24
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+
       - name: Install exact dependencies
         run: |
           python -m pip install --disable-pip-version-check --require-hashes -r requirements-dev.lock
@@ -47,8 +52,21 @@ jobs:
 
       - name: Pytest
         env:
+          M9_COVERAGE_RECEIPT_DIRECTORY: ${{ runner.temp }}/m9-coverage-receipts
           RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: python -m pytest -q
+
+      - name: Verify candidate production source is unchanged
+        env:
+          M9_CANDIDATE_HEAD: 86c6f2b808c68094127c0f07cc9ad57fd5bef763
+        run: git diff --quiet "$M9_CANDIDATE_HEAD" HEAD -- src
+
+      - name: Upload M9 coverage-falsification receipts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: m9-coverage-falsification-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/m9-coverage-receipts/*.json
+          if-no-files-found: error
 
       - name: Compileall
         run: python -m compileall -q src tests

--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -19,6 +19,14 @@
       ],
       "id": "refactor-policy",
       "kind": "cli"
+    },
+    {
+      "covers": [
+        "src/supportability_gate/quality_profile.py",
+        "src/supportability_gate/reporting.py"
+      ],
+      "id": "m9-quality-profile",
+      "kind": "cli"
     }
   ],
   "schema_version": "1.0"

--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -22,6 +22,13 @@
     },
     {
       "covers": [
+        "src/supportability_gate/responses_transport.py"
+      ],
+      "id": "semantic-transport",
+      "kind": "regression"
+    },
+    {
+      "covers": [
         "src/supportability_gate/quality_profile.py",
         "src/supportability_gate/reporting.py"
       ],

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -1,19 +1,19 @@
 schema_version = "1.0"
 
 [behavior]
-intended_behavior = "Milestones 1-7 remain enforced while refactors require authenticated exact-head scope, parser-bounded targets, runnable behavior, and explicit strangler sequencing."
-proof = "tests/test_refactor_policy.py"
+intended_behavior = "Milestones 1-8 remain enforced while fixed Python and TypeScript quality profiles execute only on GitHub-hosted runners and bind exact command, result, coverage, threshold, exclusion, and commit evidence."
+proof = "tests/test_quality_profile.py"
 
 [characterization]
-captured_behavior = "The pre-change 177-test suite and existing Python and TypeScript characterization scenarios remain the immutable runnable base for Milestone 8."
-proof = "tests/test_refactor_policy.py"
+captured_behavior = "The pre-change 192-test suite and existing Python and TypeScript characterization scenarios remain the immutable runnable base for Milestone 9."
+proof = "tests/test_quality_profile.py"
 
 [separation_of_concerns]
-before = "A refactor could supply nonempty review prose while changing unbounded targets, unrelated paths, or a non-runnable intermediate head."
-after = "One policy module binds GitHub-authenticated owner authorization to exact base, head, scope, parser-derived targets, characterization compatibility, and predecessor sequencing before existing gates run."
+before = "Declared gate adapters proved configured coverage but did not prove every stack-native command actually executed successfully in an isolated hosted job."
+after = "A disposable hosted job owns fixed no-shell command execution; the production quality-profile module only authenticates the resulting GitHub artifact and verifies its exact-head attestation before the existing evaluator can pass."
 
 [architecture]
-dependency_direction = "The organization workflow obtains authenticated behavior, then refactor_policy statically verifies exact Git scope and parser-derived boundaries using contract, function_changes, and git_changes; existing evaluator and semantic-review paths remain later independent gates."
+dependency_direction = "The organization workflow captures behavior, runs the fixed hosted quality profile, then the existing CLI verifies its immutable attestation before complexity, architecture, modularity, reporting, and semantic-review paths complete."
 reviewed_paths = [
     "src/supportability_gate/characterization.py",
     "src/supportability_gate/architecture_policy.py",
@@ -21,6 +21,7 @@ reviewed_paths = [
     "src/supportability_gate/gate_policy.py",
     "src/supportability_gate/git_changes.py",
     "src/supportability_gate/github_app.py",
+    "src/supportability_gate/quality_profile.py",
     "src/supportability_gate/reporting.py",
     "src/supportability_gate/refactor_policy.py",
     "src/supportability_gate/semantic_cli.py",
@@ -29,23 +30,29 @@ reviewed_paths = [
 ]
 
 [responsibility_boundary]
-path = "src/supportability_gate/refactor_policy.py"
-owns = "Authenticated owner authorization, exact diff focus, parser-derived target boundedness, characterization-backed runnability, and predecessor sequence verification."
-does_not_own = "Target execution, characterization capture, general quality-gate execution, semantic model transport, GitHub check publication, or waivers."
+path = "src/supportability_gate/quality_profile.py"
+owns = "GitHub artifact authentication, exact result attestation, immutable identity binding, coverage verification, and quality anti-weakening."
+does_not_own = "Target command execution, repository policy configuration, characterization capture, refactor authorization, semantic model transport, GitHub check publication, or waivers."
 
 [incremental_refactor]
-target = "Require one authenticated, bounded, focused, runnable strangler step before the existing evaluator."
-completed_step = "Added one static policy module and one workflow invocation reusing exact Git, parser, and characterization evidence; no new dependency, command override, waiver, or Milestone 9 gate execution."
+target = "Require one complete fixed stack-native quality profile and exact attestation before the existing evaluator can pass."
+completed_step = "Added one disposable hosted execution job and one verification-only production responsibility reusing existing contract, Git identity, artifact, evaluator, reporting, and enforcement paths; no package, shell, waiver, exclusion, or repository command control."
 
 [review_handoff]
-summary = "Review trusted owner identity, exact base/head authorization, exact changed-path scope, parser-derived target identity, broad-scope handling, characterization-backed runnability, sequence binding, deterministic evidence, and unchanged downstream gates."
-remaining_risks = ["Missing or malformed authorization, scope, target, predecessor, GitHub event, or characterization evidence intentionally fails the required workflow closed."]
+summary = "Review hosted-only execution, immutable command vectors, finite timeouts, captured result hashes, exact identity binding, complete changed/high-risk coverage, anti-weakening, deterministic evidence, and unchanged downstream gates."
+remaining_risks = ["Missing, malformed, unexecuted, failed, uncovered, excluded, weakened, narrowed, moved-outside-scope, or non-hosted quality evidence intentionally fails the required workflow closed."]
 
 [human_review]
-naming = "Refactor-policy names directly describe authorization, bounded targets, diff focus, runnability, and strangler sequencing."
-cohesion = "One production module owns deterministic Milestone 8 verification; existing characterization, evaluator, reporting, semantic, and Git evidence retain their responsibilities."
-intended_behavior = "Existing enforcement remains; Python and TypeScript refactors now block missing, stale, broad, unfocused, unbounded, non-runnable, or invalidly sequenced evidence."
-reviewability = "Focused fixtures cover both supported profiles, narrow and broad authorization, all required blocks, exact identities, and deterministic verification."
+naming = "Quality-profile names directly describe fixed commands, hosted execution, attestation identity, coverage, and anti-weakening."
+cohesion = "One production module owns deterministic Milestone 9 artifact authentication and verification; the disposable hosted runner owns target execution, while existing characterization, refactor, evaluator, reporting, semantic, and Git evidence retain their responsibilities."
+intended_behavior = "Existing enforcement remains; Python and TypeScript quality claims now block every missing, failed, unexecuted, uncovered, excluded, weakened, narrowed, moved, malformed, stale, or non-hosted condition."
+reviewability = "Focused fixtures cover both fixed profiles, all required failure classes, exact identities and vectors, workstation refusal, and byte-identical evidence."
+
+[[module_boundaries]]
+path = "src/supportability_gate/quality_profile.py"
+owner_path = "src/supportability_gate/quality_profile.py"
+basis = "responsibility"
+justification = "Owns GitHub-authenticated quality artifact and exact attestation verification without executing target code or adding repository-controlled commands, paths, environments, exclusions, waivers, or thresholds."
 
 [[module_boundaries]]
 path = "src/supportability_gate/refactor_policy.py"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 ## Product boundary
 
-- Execute Enforcement Milestone 8 only under `docs/enforcement_milestone_8.md`.
+- Execute Enforcement Milestone 9 only under `docs/enforcement_milestone_9.md`.
 - Never import or execute target repository code.
 - Git and Ruff use fixed argument vectors, finite timeouts, captured output, and no shell.
 - Do not add commands, executable paths, environment controls, exclusions, waivers, or threshold
@@ -26,7 +26,7 @@ Before planning or editing, read:
 2. `docs/supportability_standard.md`
 3. `docs/fixed_roadmap.md`
 4. `docs/product_completion_contract.md`
-5. `docs/enforcement_milestone_8.md` while Enforcement Milestone 8 is active
+5. `docs/enforcement_milestone_9.md` while Enforcement Milestone 9 is active
 
 Before editing, report:
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # Supportability Gate
 
-`supportability-gate` produces deterministic PASS or BLOCK evidence from immutable Git commits
-without importing or executing target repository code. Successor enforcement work is mapping every
-normative Supportability Standard clause before adding later clause-specific enforcement.
+`supportability-gate` produces deterministic PASS or BLOCK evidence from immutable Git commits.
+Static evaluation never imports target code; fixed stack-native quality commands run only in
+isolated GitHub-hosted jobs.
 
 ## Status
 
-- Completed successor scope: Supportability Standard Enforcement Milestones 1–4
-- Current authorized work: None; Enforcement Milestone 5 is not authorized
-- Completed capability: clause inventory, trusted semantic review, touched-function complexity,
-  and exact-head responsibility boundaries
+- Completed successor scope: Supportability Standard Enforcement Milestones 1–8
+- Current authorized work: Enforcement Milestone 9 — executed quality gates
+- Completed capability: clause inventory through authenticated incremental-refactor enforcement
 - Existing complexity adapter: `python.c901-touched.v1`; maximum complexity: `10`
 - Full Supportability Standard runtime: **incomplete**
 
@@ -31,6 +30,16 @@ python -m supportability_gate evaluate-complexity `
   --base-ref <full-commit-sha> `
   --head-ref <full-commit-sha> `
   --contract-path .supportability.toml `
+  --quality-evidence C:\absolute\quality-gates.json `
+  --quality-repository owner/repository `
+  --quality-repository-id <github-repository-id> `
+  --quality-run-id <github-actions-run-id> `
+  --quality-run-attempt <github-actions-run-attempt> `
+  --quality-job quality-profile `
+  --quality-artifact-id <github-artifact-id> `
+  --quality-artifact-digest <github-artifact-digest> `
+  --quality-capture-sha256 <quality-evidence-sha256> `
+  --workflow-sha <full-workflow-commit-sha> `
   --output-directory C:\absolute\evidence-directory
 ```
 

--- a/docs/enforcement_milestone_9.md
+++ b/docs/enforcement_milestone_9.md
@@ -1,0 +1,84 @@
+# Enforcement Milestone 9 Execution Directive
+
+## Authority
+
+- Owner authorization: 2026-07-29 owner execution prompt.
+- Repository: `mbh-solutions/supportability-gate`.
+- Successor project: https://github.com/orgs/mbh-solutions/projects/3.
+- Active issue: https://github.com/mbh-solutions/supportability-gate/issues/24.
+- Historical Project #2 must remain unchanged.
+- Required immutable-standard SHA-256:
+  `81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2`.
+
+## Terminal capability
+
+Run approved stack-native lint, format, complexity, type, test, build/package, and architecture
+gates. Prove changed-file and highest-risk-file coverage plus exclusions, thresholds, and scope
+anti-weakening. No quality claim passes unless every required gate ran successfully and covered
+every changed and highest-risk production path.
+
+## Approved scope
+
+- Fixed approved Python and frontend/component validation profiles.
+- Isolated GitHub-hosted execution and exact gate-result attestation.
+- Changed/high-risk path coverage mapping and anti-weakening.
+- Minimum integration with the existing evaluator, reporting, characterization, refactor policy,
+  semantic review, organization workflow, and GitHub enforcement.
+- Focused tests and protected Python/TypeScript canaries required for direct proof.
+
+## Excluded scope
+
+- Arbitrary repository-controlled shell commands, executable paths, environment controls, command
+  substitution, or shell execution.
+- New exclusions, waivers, threshold overrides, or scope narrowing.
+- Target-code import or execution on the owner workstation.
+- Semantic review-handoff truth assigned to Milestone 10.
+- Enforcement Milestones 10–11.
+- Cleanup, redesign, generalized frameworks, speculative infrastructure, optional configuration,
+  or new dependencies not strictly required.
+- Changes to `docs/supportability_standard.md` or `docs/fixed_roadmap.md`.
+
+## Required direct proof
+
+- Complete Python profile runs every approved lint, format, C901/complexity, strict type, test,
+  build/package, and architecture gate.
+- Complete frontend/component profile runs every approved lint, format, complexity-equivalent,
+  typecheck, test, build, and architecture/import-boundary gate.
+- Authoritative evidence binds exact repository, base SHA, head SHA, workflow SHA, commands,
+  results, files, scopes, thresholds, exclusions, changed paths, high-risk paths, and untested areas.
+- Passing Python and TypeScript protected canaries merge normally.
+- Declared-but-unexecuted tool, failed or missing command, uncovered changed or high-risk production
+  file, added exclusion, threshold weakening, gate-scope narrowing, and production movement outside
+  governed scope block deterministically.
+- Each required protected failing canary fails the required check, rejects a normal merge, closes
+  unmerged, and deletes its branch.
+- Every source-proof command in `AGENTS.md` passes with Python 3.12 and the exact lock; direct M9
+  evaluation is byte-identical across at least two runs.
+
+Approved target commands run only through fixed argument vectors, finite timeouts, captured output,
+and isolated GitHub-hosted jobs. Never execute target code on the owner workstation.
+
+## Protected delivery
+
+- Deliver implementation through branch `codex/enforcement-milestone-9` and one normally protected
+  implementation pull request that references, but does not close, issue #24.
+- Bind exact authenticated owner authorization to repository, base, head, scope, targets, sequence,
+  and GitHub user ID `229662739` when Milestone 8 policy applies.
+- Require exact-head Source Validation, characterization base/head, Supportability Gate, and
+  Supportability Semantic Review evidence before normal merge.
+- Pin organization ruleset `19929500` to the exact merged M9 workflow SHA without changing active
+  enforcement, repository scope, workflow identity, or zero-bypass state.
+- Reuse the retained Python and TypeScript proof repositories unless direct evidence proves them
+  insufficient.
+- After runtime proof, use a separate ledger-only evidence branch and protected pull request with
+  `Closes #24`; update only Milestone 9 ledger/status/evidence/remaining-work, product status,
+  current directive, and next-authorized-milestone fields.
+
+## Closure
+
+Record exact commits, pull requests, runs, jobs/checks, Apps, artifacts, digests, authorization,
+rulesets, workflow pin, canaries, commands/results, coverage, exclusions, thresholds, untested
+areas, deterministic evidence hashes, cleanup, and remaining product gap in issue #24. Then verify
+both M9 pull requests are linked; set M9 Status `Complete`, Evidence `Complete`, Scope `On scope`,
+Stop confirmed `Yes`; close issue #24; prove Project #2 byte-identical and Milestones 10–11
+unchanged; verify clean local/origin/GitHub main and proof environments; stop before Milestone 10.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ layers = [
     "supportability_gate.cli",
     "supportability_gate.reporting",
     "supportability_gate.modularity_policy",
-    "supportability_gate.architecture_policy | supportability_gate.gate_policy | supportability_gate.complexity_policy",
+    "supportability_gate.quality_profile | supportability_gate.architecture_policy | supportability_gate.gate_policy | supportability_gate.complexity_policy",
     "supportability_gate.complexity_metrics",
     "supportability_gate.refactor_policy",
     "supportability_gate.function_changes",

--- a/src/supportability_gate/cli.py
+++ b/src/supportability_gate/cli.py
@@ -16,6 +16,7 @@ from supportability_gate import (
     gate_policy,
     git_changes,
     modularity_policy,
+    quality_profile,
     reporting,
     review_evidence,
 )
@@ -48,6 +49,16 @@ def _parser() -> argparse.ArgumentParser:
     evaluate.add_argument("--head-ref", required=True)
     evaluate.add_argument("--contract-path", required=True)
     evaluate.add_argument("--output-directory", required=True)
+    evaluate.add_argument("--quality-evidence", required=True)
+    evaluate.add_argument("--quality-repository", required=True)
+    evaluate.add_argument("--quality-repository-id", required=True)
+    evaluate.add_argument("--quality-run-id", required=True)
+    evaluate.add_argument("--quality-run-attempt", required=True)
+    evaluate.add_argument("--quality-job", required=True)
+    evaluate.add_argument("--quality-artifact-id", required=True)
+    evaluate.add_argument("--quality-artifact-digest", required=True)
+    evaluate.add_argument("--quality-capture-sha256", required=True)
+    evaluate.add_argument("--workflow-sha", required=True)
     return parser
 
 
@@ -199,6 +210,8 @@ def _result(
     review_blocks: tuple[str, ...],
     architecture: architecture_policy.ArchitectureResult,
     modularity: modularity_policy.ModularityResult,
+    quality: quality_profile.QualityEvidence,
+    quality_blocks: tuple[str, ...],
 ) -> reporting.EvaluationResult:
     if any(
         contract_path in {item.change.old_path, item.change.new_path}
@@ -227,12 +240,14 @@ def _result(
             structured_review,
             policy.language,
             architecture,
+            quality_profile=quality,
         )
     policy_blocks = (
         *gate_policy.evaluate_contract(policy, analyzed.assessments),
         *architecture.blocks,
         *modularity.blocks,
         *review_blocks,
+        *quality_blocks,
     )
     if policy_blocks:
         return reporting.EvaluationResult(
@@ -256,6 +271,7 @@ def _result(
             policy.language,
             architecture,
             modularity,
+            quality,
         )
     base_definitions = _all_definitions(analyzed.analyses, "base")
     head_definitions = _all_definitions(analyzed.analyses, "head")
@@ -299,6 +315,7 @@ def _result(
         policy.language,
         architecture,
         modularity,
+        quality,
     )
 
 
@@ -392,6 +409,29 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
             records,
         )
         assessments = _classify_changes(repository, identity, policy, changes, records)
+        quality_path = Path(arguments.quality_evidence)
+        if not quality_path.is_absolute():
+            raise quality_profile.QualityProfileError(
+                "RELATIVE_QUALITY_EVIDENCE", "quality evidence path must be absolute"
+            )
+        quality = quality_profile.authenticate_evidence(
+            quality_path,
+            repository=str(arguments.quality_repository),
+            repository_id=str(arguments.quality_repository_id),
+            run_id=str(arguments.quality_run_id),
+            run_attempt=str(arguments.quality_run_attempt),
+            job=str(arguments.quality_job),
+            artifact_id=str(arguments.quality_artifact_id),
+            artifact_digest=str(arguments.quality_artifact_digest),
+            capture_sha256=str(arguments.quality_capture_sha256),
+        )
+        quality_blocks = quality_profile.evidence_blocks(
+            quality,
+            policy,
+            identity,
+            assessments,
+            str(arguments.workflow_sha),
+        )
         structured_review, review_blocks = _read_review_evidence(
             repository,
             identity.head_sha,
@@ -448,6 +488,8 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
             review_blocks,
             architecture,
             modularity,
+            quality,
+            quality_blocks,
         )
     except Exception as error:  # fail closed at the CLI trust boundary
         return _technical_result(

--- a/src/supportability_gate/quality_profile.py
+++ b/src/supportability_gate/quality_profile.py
@@ -1,0 +1,810 @@
+"""Run and verify fixed GitHub-hosted stack-native quality profiles."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import sys
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+
+from supportability_gate import contract, git_changes
+from supportability_gate.function_changes import ChangedFileAssessment
+
+SCHEMA_VERSION = "quality-gates.v1"
+TIMEOUT_SECONDS = 180
+_FULL_SHA = re.compile(r"[0-9a-f]{40}|[0-9a-f]{64}")
+_SOURCE_SUFFIXES = {
+    "python": (".py", ".pyi"),
+    "typescript": (".cts", ".js", ".jsx", ".mts", ".ts", ".tsx"),
+}
+_PYTHON_COMMANDS = (
+    (
+        "python.ruff-lint.v1",
+        (
+            "$PYTHON",
+            "-m",
+            "ruff",
+            "check",
+            "src",
+            "tests",
+            "--select",
+            "E4,E7,E9,F,I,UP",
+            "--line-length",
+            "100",
+            "--target-version",
+            "py312",
+            "--isolated",
+            "--no-cache",
+        ),
+    ),
+    (
+        "python.ruff-format.v1",
+        (
+            "$PYTHON",
+            "-m",
+            "ruff",
+            "format",
+            "--check",
+            "src",
+            "tests",
+            "--line-length",
+            "100",
+            "--target-version",
+            "py312",
+            "--isolated",
+            "--no-cache",
+        ),
+    ),
+    (
+        "python.c901-touched.v1",
+        (
+            "$PYTHON",
+            "-m",
+            "ruff",
+            "check",
+            "src",
+            "--select",
+            "C901",
+            "--config",
+            "lint.mccabe.max-complexity = 10",
+            "--target-version",
+            "py312",
+            "--isolated",
+            "--no-cache",
+        ),
+    ),
+    (
+        "python.mypy-strict.v1",
+        (
+            "$PYTHON",
+            "-m",
+            "mypy",
+            "--config-file",
+            "$OUTPUT/mypy.ini",
+            "--cache-dir",
+            "$OUTPUT/mypy-cache",
+            "src",
+        ),
+    ),
+    (
+        "python.pytest.v1",
+        ("$PYTHON", "-m", "pytest", "-q", "-c", "$OUTPUT/pytest.ini"),
+    ),
+    (
+        "python.build-wheel.v1",
+        (
+            "$PYTHON",
+            "-m",
+            "build",
+            "--wheel",
+            "--no-isolation",
+            "--outdir",
+            "$OUTPUT/wheel",
+        ),
+    ),
+    (
+        "python.import-linter.v1",
+        ("$LINT_IMPORTS", "--config", "$OUTPUT/importlinter.ini", "--no-cache"),
+    ),
+)
+_TYPESCRIPT_COMMANDS = (
+    (
+        "typescript.tool-install.v1",
+        (
+            "$NPM",
+            "install",
+            "--prefix",
+            "$TOOLS",
+            "--ignore-scripts",
+            "--no-audit",
+            "--no-fund",
+            "eslint@9.39.3",
+            "@typescript-eslint/parser@8.65.0",
+            "prettier@3.9.6",
+            "typescript@5.9.3",
+            "dependency-cruiser@18.1.0",
+        ),
+    ),
+    (
+        "typescript.eslint.v1",
+        (
+            "$TOOLS/node_modules/.bin/eslint",
+            "--config",
+            "$TOOLS/eslint.config.mjs",
+            "--no-config-lookup",
+            "--no-ignore",
+            "--no-inline-config",
+            "src",
+            "tests",
+        ),
+    ),
+    (
+        "typescript.prettier.v1",
+        (
+            "$TOOLS/node_modules/.bin/prettier",
+            "--check",
+            "--config",
+            "$TOOLS/prettier.json",
+            "--ignore-path",
+            "$TOOLS/prettier.ignore",
+            "src",
+            "tests",
+        ),
+    ),
+    (
+        "typescript.c901-equivalent-touched.v1",
+        (
+            "$TOOLS/node_modules/.bin/eslint",
+            "--config",
+            "$TOOLS/eslint.config.mjs",
+            "--no-config-lookup",
+            "--no-ignore",
+            "--no-inline-config",
+            "--rule",
+            "complexity: [error, 10]",
+            "src",
+            "tests",
+        ),
+    ),
+    (
+        "typescript.typecheck.v1",
+        ("$TOOLS/node_modules/.bin/tsc", "--project", "$OUTPUT/tsconfig-check.json"),
+    ),
+    ("typescript.test.v1", ("$NODE", "--test", "$TEST_FILES")),
+    (
+        "typescript.build.v1",
+        ("$TOOLS/node_modules/.bin/tsc", "--project", "$OUTPUT/tsconfig-build.json"),
+    ),
+    (
+        "typescript.import-boundaries.v1",
+        (
+            "$TOOLS/node_modules/.bin/depcruise",
+            "--config",
+            "$TOOLS/dependency-cruiser.json",
+            "--ts-config",
+            "$OUTPUT/tsconfig-check.json",
+            "--",
+            "src",
+        ),
+    ),
+)
+
+
+class QualityProfileError(ValueError):
+    """Fail-closed quality-profile evidence error."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """One fixed command result."""
+
+    adapter: str
+    arguments: tuple[str, ...]
+    covered_paths: tuple[str, ...]
+    executed: bool
+    exit_code: int
+    stderr_sha256: str
+    stdout_sha256: str
+
+
+@dataclass(frozen=True)
+class QualityEvidence:
+    """Exact immutable quality-profile attestation."""
+
+    base_sha: str
+    changed_paths: tuple[str, ...]
+    commands: tuple[GateResult, ...]
+    exclusions: tuple[str, ...]
+    head_sha: str
+    high_risk_paths: tuple[str, ...]
+    language: str
+    maximum_complexity: int
+    production_files: tuple[str, ...]
+    production_paths: tuple[str, ...]
+    repository: str
+    repository_id: str
+    repository_remote: str
+    run_attempt: str
+    run_id: str
+    runner_environment: str
+    schema_version: str
+    untested_areas: tuple[str, ...]
+    workflow_sha: str
+    job: str
+    artifact_id: str
+    artifact_digest: str
+    capture_sha256: str
+
+
+@dataclass(frozen=True)
+class _CommandPlan:
+    adapter: str
+    actual: tuple[str, ...]
+    evidence: tuple[str, ...]
+    covered_paths: tuple[str, ...]
+
+
+def command_templates(language: str) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Return the immutable approved command templates for one stack."""
+    if language == "python":
+        return _PYTHON_COMMANDS
+    if language == "typescript":
+        return _TYPESCRIPT_COMMANDS
+    raise QualityProfileError("UNSUPPORTED_LANGUAGE", f"unsupported language: {language}")
+
+
+def required_adapters(language: str) -> tuple[str, ...]:
+    """Return required gate identities, including fixed TypeScript tool installation."""
+    return tuple(adapter for adapter, _ in command_templates(language))
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _string_tuple(value: object, field: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise QualityProfileError("MALFORMED_QUALITY_EVIDENCE", f"{field} must be a string list")
+    return tuple(value)
+
+
+def _gate_result(value: object) -> GateResult:
+    if not isinstance(value, dict) or set(value) != {
+        "adapter",
+        "arguments",
+        "covered_paths",
+        "executed",
+        "exit_code",
+        "stderr_sha256",
+        "stdout_sha256",
+    }:
+        raise QualityProfileError("MALFORMED_QUALITY_EVIDENCE", "invalid command result")
+    if (
+        not isinstance(value["adapter"], str)
+        or type(value["executed"]) is not bool
+        or type(value["exit_code"]) is not int
+        or not isinstance(value["stdout_sha256"], str)
+        or not isinstance(value["stderr_sha256"], str)
+    ):
+        raise QualityProfileError("MALFORMED_QUALITY_EVIDENCE", "invalid command result types")
+    return GateResult(
+        value["adapter"],
+        _string_tuple(value["arguments"], "arguments"),
+        _string_tuple(value["covered_paths"], "covered_paths"),
+        value["executed"],
+        value["exit_code"],
+        value["stderr_sha256"],
+        value["stdout_sha256"],
+    )
+
+
+def _parse_evidence(data: object) -> QualityEvidence:
+    expected = {
+        "base_sha",
+        "changed_paths",
+        "commands",
+        "exclusions",
+        "head_sha",
+        "high_risk_paths",
+        "language",
+        "maximum_complexity",
+        "production_files",
+        "production_paths",
+        "repository",
+        "repository_id",
+        "repository_remote",
+        "run_attempt",
+        "run_id",
+        "runner_environment",
+        "schema_version",
+        "untested_areas",
+        "workflow_sha",
+        "job",
+        "artifact_id",
+        "artifact_digest",
+        "capture_sha256",
+    }
+    if not isinstance(data, dict) or set(data) != expected:
+        raise QualityProfileError("MALFORMED_QUALITY_EVIDENCE", "quality evidence keys mismatch")
+    scalar_strings = (
+        "base_sha",
+        "head_sha",
+        "language",
+        "repository",
+        "repository_id",
+        "repository_remote",
+        "run_attempt",
+        "run_id",
+        "runner_environment",
+        "schema_version",
+        "workflow_sha",
+        "job",
+        "artifact_id",
+        "artifact_digest",
+        "capture_sha256",
+    )
+    if any(not isinstance(data[field], str) for field in scalar_strings):
+        raise QualityProfileError("MALFORMED_QUALITY_EVIDENCE", "invalid quality identity")
+    if type(data["maximum_complexity"]) is not int or not isinstance(data["commands"], list):
+        raise QualityProfileError("MALFORMED_QUALITY_EVIDENCE", "invalid quality values")
+    return QualityEvidence(
+        data["base_sha"],
+        _string_tuple(data["changed_paths"], "changed_paths"),
+        tuple(_gate_result(item) for item in data["commands"]),
+        _string_tuple(data["exclusions"], "exclusions"),
+        data["head_sha"],
+        _string_tuple(data["high_risk_paths"], "high_risk_paths"),
+        data["language"],
+        data["maximum_complexity"],
+        _string_tuple(data["production_files"], "production_files"),
+        _string_tuple(data["production_paths"], "production_paths"),
+        data["repository"],
+        data["repository_id"],
+        data["repository_remote"],
+        data["run_attempt"],
+        data["run_id"],
+        data["runner_environment"],
+        data["schema_version"],
+        _string_tuple(data["untested_areas"], "untested_areas"),
+        data["workflow_sha"],
+        data["job"],
+        data["artifact_id"],
+        data["artifact_digest"],
+        data["capture_sha256"],
+    )
+
+
+def load_evidence(path: Path) -> QualityEvidence:
+    """Load strict quality evidence without accepting unknown fields."""
+    try:
+        data = json.loads(path.read_bytes())
+    except (OSError, json.JSONDecodeError) as error:
+        raise QualityProfileError("MISSING_QUALITY_EVIDENCE", str(error)) from error
+    return _parse_evidence(data)
+
+
+def authenticate_evidence(
+    path: Path,
+    *,
+    repository: str,
+    repository_id: str,
+    run_id: str,
+    run_attempt: str,
+    job: str,
+    artifact_id: str,
+    artifact_digest: str,
+    capture_sha256: str,
+) -> QualityEvidence:
+    """Bind one downloaded GitHub Actions artifact to trusted workflow metadata."""
+    try:
+        content = path.read_bytes()
+        evidence = _parse_evidence(json.loads(content))
+    except (OSError, json.JSONDecodeError) as error:
+        raise QualityProfileError("MISSING_QUALITY_EVIDENCE", str(error)) from error
+    expected = (repository, repository_id, run_id, run_attempt, job, "github-hosted")
+    actual = (
+        evidence.repository,
+        evidence.repository_id,
+        evidence.run_id,
+        evidence.run_attempt,
+        evidence.job,
+        evidence.runner_environment,
+    )
+    if actual != expected:
+        raise QualityProfileError("QUALITY_ARTIFACT_BINDING_MISMATCH", "artifact identity mismatch")
+    if any((evidence.artifact_id, evidence.artifact_digest, evidence.capture_sha256)):
+        raise QualityProfileError(
+            "SELF_DECLARED_QUALITY_ARTIFACT", "artifact metadata must be external"
+        )
+    if (
+        not artifact_id.isdigit()
+        or re.fullmatch(r"[0-9a-f]{64}", artifact_digest) is None
+        or _FULL_SHA.fullmatch(capture_sha256) is None
+        or len(capture_sha256) != 64
+        or _sha256(content) != capture_sha256
+    ):
+        raise QualityProfileError("UNAUTHENTICATED_QUALITY_ARTIFACT", "artifact proof mismatch")
+    return replace(
+        evidence,
+        artifact_id=artifact_id,
+        artifact_digest=artifact_digest,
+        capture_sha256=capture_sha256,
+    )
+
+
+def _changed_production_paths(
+    assessments: tuple[ChangedFileAssessment, ...],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                path
+                for item in assessments
+                for path, production in (
+                    (item.change.old_path, item.base_production),
+                    (item.change.new_path, item.head_production),
+                )
+                if path and production
+            }
+        )
+    )
+
+
+def _moved_outside_scope(
+    assessments: tuple[ChangedFileAssessment, ...],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            item.change.new_path
+            for item in assessments
+            if item.base_production
+            and not item.head_production
+            and item.change.new_path is not None
+        )
+    )
+
+
+def _changed_head_production_paths(
+    assessments: tuple[ChangedFileAssessment, ...],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            item.change.new_path
+            for item in assessments
+            if item.head_production and item.change.new_path is not None
+        )
+    )
+
+
+def _verify_evidence_identity(
+    evidence: QualityEvidence,
+    policy: contract.Contract,
+    identity: git_changes.RepositoryIdentity,
+    workflow_sha: str,
+) -> None:
+    if _FULL_SHA.fullmatch(workflow_sha) is None:
+        raise QualityProfileError("INVALID_WORKFLOW_SHA", "workflow SHA must be immutable")
+    expected_identity = (
+        identity.remote,
+        identity.base_sha,
+        identity.head_sha,
+        policy.language,
+        workflow_sha,
+    )
+    actual_identity = (
+        evidence.repository_remote,
+        evidence.base_sha,
+        evidence.head_sha,
+        evidence.language,
+        evidence.workflow_sha,
+    )
+    if actual_identity != expected_identity:
+        raise QualityProfileError("QUALITY_EVIDENCE_BINDING_MISMATCH", "quality identity mismatch")
+    if evidence.schema_version != SCHEMA_VERSION or evidence.runner_environment != "github-hosted":
+        raise QualityProfileError("UNTRUSTED_QUALITY_ENVIRONMENT", "untrusted quality runtime")
+    if (
+        not evidence.artifact_id.isdigit()
+        or re.fullmatch(r"[0-9a-f]{64}", evidence.artifact_digest) is None
+        or len(evidence.capture_sha256) != 64
+        or _FULL_SHA.fullmatch(evidence.capture_sha256) is None
+    ):
+        raise QualityProfileError("UNAUTHENTICATED_QUALITY_ARTIFACT", "artifact proof missing")
+
+
+def _covers(result: GateResult, path: str) -> bool:
+    return any(path == root or path.startswith(f"{root}/") for root in result.covered_paths)
+
+
+def _command_blocks(
+    evidence: QualityEvidence,
+    policy: contract.Contract,
+    changed_paths: tuple[str, ...],
+) -> list[str]:
+    expected = dict(command_templates(policy.language))
+    commands = {item.adapter: item for item in evidence.commands}
+    if len(commands) != len(evidence.commands):
+        raise QualityProfileError("DUPLICATE_QUALITY_COMMAND", "duplicate quality command")
+    blocks = [
+        f"MISSING_QUALITY_COMMAND:{adapter}" for adapter in expected if adapter not in commands
+    ]
+    blocks.extend(
+        f"UNAPPROVED_QUALITY_COMMAND:{adapter}" for adapter in sorted(set(commands) - set(expected))
+    )
+    for adapter, arguments in expected.items():
+        result = commands.get(adapter)
+        if result is None:
+            continue
+        if result.arguments != arguments:
+            blocks.append(f"QUALITY_COMMAND_VECTOR_MISMATCH:{adapter}")
+        if not result.executed:
+            blocks.append(f"DECLARED_TOOL_NOT_EXECUTED:{adapter}")
+        elif result.exit_code:
+            blocks.append(f"QUALITY_GATE_FAILED:{adapter}")
+        blocks.extend(
+            f"QUALITY_CHANGED_FILE_COVERAGE:{adapter}:{path}"
+            for path in changed_paths
+            if not _covers(result, path)
+        )
+        blocks.extend(
+            f"QUALITY_HIGH_RISK_FILE_COVERAGE:{adapter}:{path}"
+            for path in policy.high_risk_paths
+            if not _covers(result, path)
+        )
+    return blocks
+
+
+def _policy_blocks(
+    evidence: QualityEvidence,
+    policy: contract.Contract,
+    assessments: tuple[ChangedFileAssessment, ...],
+) -> list[str]:
+    blocks: list[str] = []
+    changed_paths = _changed_production_paths(assessments)
+    if evidence.production_paths != policy.production_paths:
+        blocks.append("QUALITY_SCOPE_NARROWING")
+    if evidence.maximum_complexity > policy.maximum:
+        blocks.append("QUALITY_THRESHOLD_WEAKENING")
+    elif evidence.maximum_complexity != policy.maximum:
+        blocks.append("QUALITY_THRESHOLD_MISMATCH")
+    blocks.extend(f"QUALITY_EXCLUSION_ADDED:{path}" for path in evidence.exclusions)
+    blocks.extend(f"UNTESTED_AREA:{path}" for path in evidence.untested_areas)
+    blocks.extend(
+        f"PRODUCTION_PATH_MOVED_OUTSIDE_SCOPE:{path}" for path in _moved_outside_scope(assessments)
+    )
+    head_paths = _changed_head_production_paths(assessments)
+    blocks.extend(
+        f"QUALITY_CHANGED_FILE_NOT_ATTESTED:{path}"
+        for path in head_paths
+        if path.endswith(_SOURCE_SUFFIXES[policy.language])
+        and path not in evidence.production_files
+    )
+    blocks.extend(
+        f"QUALITY_HIGH_RISK_FILE_NOT_ATTESTED:{path}"
+        for path in policy.high_risk_paths
+        if path.endswith(_SOURCE_SUFFIXES[policy.language])
+        and path not in evidence.production_files
+    )
+    if (
+        evidence.changed_paths != changed_paths
+        or evidence.high_risk_paths != policy.high_risk_paths
+    ):
+        blocks.append("QUALITY_COVERAGE_MAPPING_MISMATCH")
+    return blocks
+
+
+def evidence_blocks(
+    evidence: QualityEvidence,
+    policy: contract.Contract,
+    identity: git_changes.RepositoryIdentity,
+    assessments: tuple[ChangedFileAssessment, ...],
+    workflow_sha: str,
+) -> tuple[str, ...]:
+    """Bind exact attestation identity and return deterministic quality blocks."""
+    _verify_evidence_identity(evidence, policy, identity, workflow_sha)
+    changed_paths = _changed_production_paths(assessments)
+    blocks = _command_blocks(evidence, policy, changed_paths)
+    blocks.extend(_policy_blocks(evidence, policy, assessments))
+    return tuple(sorted(set(blocks)))
+
+
+def _fixed_environment(output: Path, repository: Path) -> dict[str, str]:
+    keys = ("HOME", "PATH", "SystemRoot", "WINDIR")
+    environment = {key: os.environ[key] for key in keys if key in os.environ}
+    environment.update(
+        {
+            "CI": "true",
+            "NO_COLOR": "1",
+            "PYTHONHASHSEED": "0",
+            "PYTHONPATH": str(repository / "src"),
+            "PYTHONPYCACHEPREFIX": str(output / "pycache"),
+        }
+    )
+    return environment
+
+
+def _replace_tokens(arguments: tuple[str, ...], values: dict[str, str]) -> tuple[str, ...]:
+    replaced: list[str] = []
+    for argument in arguments:
+        if argument == "$TEST_FILES":
+            replaced.extend(values[argument].split("\0") if values[argument] else ())
+        else:
+            value = argument
+            for token, replacement in values.items():
+                value = value.replace(token, replacement)
+            replaced.append(value)
+    return tuple(replaced)
+
+
+def _write_typescript_configs(tools: Path, output: Path, source_files: tuple[str, ...]) -> None:
+    tools.mkdir(parents=True, exist_ok=True)
+    output.mkdir(parents=True, exist_ok=True)
+    parser_url = (
+        tools / "node_modules" / "@typescript-eslint" / "parser" / "dist" / "index.js"
+    ).as_uri()
+    (tools / "eslint.config.mjs").write_text(
+        "import parser from " + json.dumps(parser_url) + ";\n"
+        "export default [{ files: ['**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}'], "
+        "languageOptions: { parser, parserOptions: { ecmaVersion: 'latest', sourceType: 'module' } }, "
+        "rules: { 'no-constant-condition': 'error', 'no-debugger': 'error', "
+        "'no-duplicate-case': 'error', 'no-unreachable': 'error' } }];\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    (tools / "prettier.json").write_text("{}\n", encoding="utf-8", newline="\n")
+    (tools / "prettier.ignore").write_text("\n", encoding="utf-8", newline="\n")
+    cruiser = {
+        "forbidden": [
+            {"name": "no-circular", "severity": "error", "from": {}, "to": {"circular": True}},
+            {
+                "name": "domain-stays-inward",
+                "severity": "error",
+                "from": {"path": "^src/domain"},
+                "to": {"path": "^src/(application|infrastructure|presentation)"},
+            },
+            {
+                "name": "application-stays-inward",
+                "severity": "error",
+                "from": {"path": "^src/application"},
+                "to": {"path": "^src/(infrastructure|presentation)"},
+            },
+        ],
+        "options": {"doNotFollow": {"path": "node_modules"}},
+    }
+    (tools / "dependency-cruiser.json").write_text(
+        json.dumps(cruiser, indent=2, sort_keys=True) + "\n", encoding="utf-8", newline="\n"
+    )
+    check = {
+        "compilerOptions": {
+            "allowImportingTsExtensions": True,
+            "module": "NodeNext",
+            "moduleResolution": "NodeNext",
+            "noEmit": True,
+            "skipLibCheck": True,
+            "strict": True,
+            "target": "ES2022",
+        },
+        "files": list(source_files),
+    }
+    build = json.loads(json.dumps(check))
+    build["compilerOptions"].update(
+        {
+            "allowImportingTsExtensions": False,
+            "declaration": True,
+            "noEmit": False,
+            "outDir": str(output / "build"),
+        }
+    )
+    (output / "tsconfig-check.json").write_text(
+        json.dumps(check, indent=2, sort_keys=True) + "\n", encoding="utf-8", newline="\n"
+    )
+    (output / "tsconfig-build.json").write_text(
+        json.dumps(build, indent=2, sort_keys=True) + "\n", encoding="utf-8", newline="\n"
+    )
+
+
+def _write_python_configs(output: Path, source_files: tuple[str, ...]) -> None:
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "mypy.ini").write_text(
+        "[mypy]\npython_version = 3.12\nstrict = True\nmypy_path = src\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    (output / "pytest.ini").write_text(
+        "[pytest]\ntestpaths = tests\npythonpath = src\naddopts = -p no:cacheprovider\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    roots = tuple(
+        sorted(
+            {
+                Path(path).parts[1]
+                for path in source_files
+                if len(Path(path).parts) > 2 and Path(path).name == "__init__.py"
+            }
+        )
+    )
+    packages = roots or ("missing_quality_root",)
+    indented = "\n".join(f"    {item}" for item in packages)
+    (output / "importlinter.ini").write_text(
+        "[importlinter]\nroot_packages =\n"
+        + indented
+        + "\n\n[importlinter:contract:quality-acyclic]\n"
+        + "name = Fixed quality profile has no sibling cycles\n"
+        + "type = acyclic_siblings\nancestors =\n"
+        + indented
+        + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _command_plans(
+    language: str,
+    repository: Path,
+    output: Path,
+    test_files: tuple[str, ...],
+    source_files: tuple[str, ...],
+) -> tuple[_CommandPlan, ...]:
+    tools = output / "quality-tools"
+    if language == "typescript":
+        _write_typescript_configs(
+            tools,
+            output,
+            tuple(str((repository / path).resolve()) for path in source_files),
+        )
+    else:
+        _write_python_configs(output, source_files)
+    lint_imports = shutil.which("lint-imports") or str(
+        Path(sys.executable).with_name("lint-imports")
+    )
+    values = {
+        "$LINT_IMPORTS": lint_imports,
+        "$NODE": shutil.which("node") or "node",
+        "$NPM": shutil.which("npm") or "npm",
+        "$OUTPUT": str(output),
+        "$PYTHON": sys.executable,
+        "$TEST_FILES": "\0".join(str((repository / path).resolve()) for path in test_files),
+        "$TOOLS": str(tools),
+    }
+    return tuple(
+        _CommandPlan(adapter, _replace_tokens(arguments, values), arguments, ("src",))
+        for adapter, arguments in command_templates(language)
+    )
+
+
+def _profile_files(
+    repository: Path,
+    head_sha: str,
+    policy: contract.Contract,
+    records: list[git_changes.CommandRecord],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    production = git_changes.list_regular_blobs(
+        repository, head_sha, policy.production_paths, records
+    )
+    tests = git_changes.list_regular_blobs(repository, head_sha, ("tests",), records)
+    suffixes = _SOURCE_SUFFIXES[policy.language]
+    source_files = tuple(item.path for item in production if item.path.endswith(suffixes))
+    test_files = tuple(
+        item.path
+        for item in tests
+        if item.path.endswith(
+            (".test.js", ".test.mjs", ".test.cjs", ".test.ts", ".test.mts", ".test.cts")
+        )
+    )
+    return source_files, test_files
+
+
+def write_evidence(evidence: QualityEvidence, output: Path) -> bytes:
+    """Write byte-stable attestation JSON."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    payload = (json.dumps(asdict(evidence), indent=2, sort_keys=True) + "\n").encode()
+    output.write_bytes(payload)
+    return payload

--- a/src/supportability_gate/reporting.py
+++ b/src/supportability_gate/reporting.py
@@ -13,6 +13,7 @@ from supportability_gate.complexity_policy import FunctionDecision
 from supportability_gate.function_changes import ChangedFileAssessment
 from supportability_gate.git_changes import CommandRecord, RepositoryIdentity
 from supportability_gate.modularity_policy import ModularityResult
+from supportability_gate.quality_profile import QualityEvidence
 from supportability_gate.review_evidence import ReviewEvidence
 
 STANDARD_SHA256 = "81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2"
@@ -50,6 +51,7 @@ class EvaluationResult:
     language: str | None = None
     architecture: ArchitectureResult | None = None
     modularity: ModularityResult | None = None
+    quality_profile: QualityEvidence | None = None
 
 
 def _span_metric(metric: object | None) -> dict[str, Any] | None:
@@ -187,6 +189,7 @@ def result_payload(result: EvaluationResult) -> dict[str, Any]:
         "overall_result": result.overall_result,
         "policy_blocks": list(result.policy_blocks),
         "production_paths": list(result.production_paths),
+        "quality_profile": asdict(result.quality_profile) if result.quality_profile else None,
         "rename_bindings": renames,
         "repository_remote": identity["remote"],
         "review_evidence": result.review_evidence,

--- a/src/supportability_gate/responses_transport.py
+++ b/src/supportability_gate/responses_transport.py
@@ -52,7 +52,7 @@ def _decoded_response(body: bytes) -> object:
 def request_response(
     packet: EvidencePacket,
     *,
-    timeout_seconds: float = 120.0,
+    timeout_seconds: float = 480.0,
     opener: Callable[..., Any] = LOCAL_OPENER,
 ) -> object:
     """Return one decoded response from the fixed localhost transport."""

--- a/tests/characterization/m9-quality-profile.characterization.py
+++ b/tests/characterization/m9-quality-profile.characterization.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    target = Path(os.environ["SUPPORTABILITY_CHARACTERIZATION_TARGET"])
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(target / "src")
+    completed = subprocess.run(
+        [sys.executable, "-P", "-m", "supportability_gate", "--help"],
+        cwd=target,
+        env=environment,
+        check=False,
+        capture_output=True,
+        timeout=30,
+    )
+    behavior = {
+        "exit_code": completed.returncode,
+        "stderr_sha256": hashlib.sha256(completed.stderr.replace(b"\r\n", b"\n")).hexdigest(),
+        "stdout_sha256": hashlib.sha256(completed.stdout.replace(b"\r\n", b"\n")).hexdigest(),
+    }
+    print(
+        json.dumps(
+            {"behavior": behavior, "scenario": "m9-quality-profile", "schema_version": "1.0"},
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/characterization/m9-quality-profile.golden.json
+++ b/tests/characterization/m9-quality-profile.golden.json
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "stdout_sha256": "c10d466d329e36f9a2cc7659851c8792e1b4a63cee26190ef0f0600bebbda36b"
+}

--- a/tests/characterization/semantic-transport.characterization.py
+++ b/tests/characterization/semantic-transport.characterization.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import urllib.request
+
+from supportability_gate.responses_transport import request_response
+from supportability_gate.semantic_contract import EvidencePacket
+
+
+class Reply:
+    def __enter__(self) -> Reply:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return b'{"error":null,"model":"gpt-5.6-sol","output":[],"status":"completed"}'
+
+
+def main() -> None:
+    observed: dict[str, object] = {}
+
+    def open_request(request: urllib.request.Request, *, timeout: float) -> Reply:
+        payload = json.loads(bytes(request.data or b"{}"))
+        observed.update(
+            {
+                "authorization": request.get_header("Authorization") == "Bearer sk-dummy",
+                "method": request.method,
+                "model": payload.get("model"),
+                "timeout_seconds": timeout,
+                "url": request.full_url,
+            }
+        )
+        return Reply()
+
+    response = request_response(
+        EvidencePacket("owner/repository", "a" * 40, "b" * 40, 42, {"diff": ""}),
+        timeout_seconds=1.0,
+        opener=open_request,
+    )
+    observed["response_status"] = response["status"]
+    print(
+        json.dumps(
+            {"behavior": observed, "scenario": "semantic-transport", "schema_version": "1.0"},
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/characterization/semantic-transport.golden.json
+++ b/tests/characterization/semantic-transport.golden.json
@@ -1,0 +1,8 @@
+{
+  "authorization": true,
+  "method": "POST",
+  "model": "gpt-5.6-sol",
+  "response_status": "completed",
+  "timeout_seconds": 1.0,
+  "url": "http://127.0.0.1:8317/v1/responses"
+}

--- a/tests/hosted_quality_profile.py
+++ b/tests/hosted_quality_profile.py
@@ -1,0 +1,155 @@
+"""Trusted GitHub-hosted quality command runner."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+from pathlib import Path
+
+from supportability_gate import contract, git_changes, quality_profile
+
+
+def _run_command(
+    plan: quality_profile._CommandPlan, repository: Path, output: Path
+) -> quality_profile.GateResult:
+    try:
+        completed = subprocess.run(
+            plan.actual,
+            cwd=repository,
+            env=quality_profile._fixed_environment(output, repository),
+            check=False,
+            capture_output=True,
+            timeout=quality_profile.TIMEOUT_SECONDS,
+        )
+        return quality_profile.GateResult(
+            plan.adapter,
+            plan.evidence,
+            plan.covered_paths,
+            True,
+            completed.returncode,
+            quality_profile._sha256(completed.stderr),
+            quality_profile._sha256(completed.stdout),
+        )
+    except subprocess.TimeoutExpired as error:
+        return quality_profile.GateResult(
+            plan.adapter,
+            plan.evidence,
+            plan.covered_paths,
+            True,
+            -1,
+            quality_profile._sha256(error.stderr or b""),
+            quality_profile._sha256(error.stdout or b""),
+        )
+    except OSError as error:
+        return quality_profile.GateResult(
+            plan.adapter,
+            plan.evidence,
+            plan.covered_paths,
+            False,
+            -127,
+            quality_profile._sha256(str(error).encode()),
+            quality_profile._sha256(b""),
+        )
+
+
+def run_profile(arguments: argparse.Namespace) -> quality_profile.QualityEvidence:
+    """Execute fixed commands in the disposable quality job and return its capture."""
+    if os.environ.get("RUNNER_ENVIRONMENT") != "github-hosted":
+        raise quality_profile.QualityProfileError(
+            "NON_HOSTED_TARGET_EXECUTION", "quality profiles require a GitHub-hosted runner"
+        )
+    records: list[git_changes.CommandRecord] = []
+    target = git_changes.validate_repository(Path(arguments.repository), records)
+    identity = git_changes.inspect_repository(
+        target, str(arguments.base_ref), str(arguments.head_ref), records
+    )
+    workflow_sha = str(arguments.workflow_sha)
+    if (
+        workflow_sha.lower() != workflow_sha
+        or quality_profile._FULL_SHA.fullmatch(workflow_sha) is None
+    ):
+        raise quality_profile.QualityProfileError(
+            "INVALID_WORKFLOW_SHA", "workflow SHA must be immutable"
+        )
+    policy = contract.parse_contract(
+        git_changes.read_regular_blob(
+            target, identity.base_sha, ".supportability.toml", records
+        ).content
+    )
+    changes = git_changes.changed_paths(target, identity.base_sha, identity.head_sha, records)
+    changed_paths = tuple(
+        sorted(
+            {
+                path
+                for change in changes
+                for path in (change.old_path, change.new_path)
+                if path and policy.is_production_path(path)
+            }
+        )
+    )
+    output = Path(arguments.output)
+    source_files, test_files = quality_profile._profile_files(
+        target, identity.head_sha, policy, records
+    )
+    plans = quality_profile._command_plans(
+        policy.language, target, output.parent, test_files, source_files
+    )
+    results = tuple(_run_command(plan, target, output.parent) for plan in plans)
+    failed = any(not item.executed or item.exit_code for item in results)
+    return quality_profile.QualityEvidence(
+        base_sha=identity.base_sha,
+        changed_paths=changed_paths,
+        commands=results,
+        exclusions=(),
+        head_sha=identity.head_sha,
+        high_risk_paths=policy.high_risk_paths,
+        language=policy.language,
+        maximum_complexity=policy.maximum,
+        production_files=source_files,
+        production_paths=policy.production_paths,
+        repository=str(arguments.repository_name),
+        repository_id=str(arguments.repository_id),
+        repository_remote=identity.remote,
+        run_attempt=str(arguments.run_attempt),
+        run_id=str(arguments.run_id),
+        runner_environment="github-hosted",
+        schema_version=quality_profile.SCHEMA_VERSION,
+        untested_areas=source_files if failed else (),
+        workflow_sha=workflow_sha,
+        job="quality-profile",
+        artifact_id="",
+        artifact_digest="",
+        capture_sha256="",
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--repository-name", required=True)
+    parser.add_argument("--repository-id", required=True)
+    parser.add_argument("--base-ref", required=True)
+    parser.add_argument("--head-ref", required=True)
+    parser.add_argument("--workflow-sha", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--run-attempt", required=True)
+    parser.add_argument("--output", required=True)
+    return parser
+
+
+def main() -> int:
+    arguments = _parser().parse_args()
+    output = Path(arguments.output)
+    if not output.is_absolute():
+        return 2
+    try:
+        evidence = run_profile(arguments)
+        quality_profile.write_evidence(evidence, output)
+    except Exception:
+        return 2
+    return 1 if evidence.untested_areas else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_evaluate_complexity.py
+++ b/tests/test_evaluate_complexity.py
@@ -11,9 +11,14 @@ from supportability_gate import (
     cli,
     complexity_metrics,
     complexity_policy,
+    contract,
     function_changes,
+    git_changes,
+    quality_profile,
     reporting,
 )
+
+WORKFLOW_SHA = "f" * 40
 
 CONTRACT = """\
 schema_version = "1.0"
@@ -226,6 +231,81 @@ def _typescript_repository(
 def _evaluate(
     repository: Path, base_sha: str, head_sha: str, output: Path
 ) -> tuple[int, dict[str, object]]:
+    quality_path = output.parent / f"{output.name}-quality.json"
+    try:
+        records: list[git_changes.CommandRecord] = []
+        identity = git_changes.inspect_repository(repository, base_sha, head_sha, records)
+        policy = contract.parse_contract(
+            git_changes.read_regular_blob(
+                repository, identity.base_sha, ".supportability.toml", records
+            ).content
+        )
+        changes = git_changes.changed_paths(repository, base_sha, head_sha, records)
+        changed_paths = tuple(
+            sorted(
+                {
+                    path
+                    for change in changes
+                    for path in (change.old_path, change.new_path)
+                    if path and policy.is_production_path(path)
+                }
+            )
+        )
+        suffixes = (
+            (".py", ".pyi")
+            if policy.language == "python"
+            else (".cts", ".js", ".jsx", ".mts", ".ts", ".tsx")
+        )
+        production_files = tuple(
+            item.path
+            for item in git_changes.list_regular_blobs(
+                repository, head_sha, policy.production_paths, records
+            )
+            if item.path.endswith(suffixes)
+        )
+        commands = tuple(
+            quality_profile.GateResult(
+                adapter,
+                arguments,
+                ("src",),
+                True,
+                0,
+                hashlib.sha256(b"").hexdigest(),
+                hashlib.sha256(b"").hexdigest(),
+            )
+            for adapter, arguments in quality_profile.command_templates(policy.language)
+        )
+        quality_profile.write_evidence(
+            quality_profile.QualityEvidence(
+                base_sha=base_sha,
+                changed_paths=changed_paths,
+                commands=commands,
+                exclusions=(),
+                head_sha=head_sha,
+                high_risk_paths=policy.high_risk_paths,
+                language=policy.language,
+                maximum_complexity=policy.maximum,
+                production_files=production_files,
+                production_paths=policy.production_paths,
+                repository="example/fixture",
+                repository_id="123",
+                repository_remote=identity.remote,
+                run_attempt="1",
+                run_id="456",
+                runner_environment="github-hosted",
+                schema_version=quality_profile.SCHEMA_VERSION,
+                untested_areas=(),
+                workflow_sha=WORKFLOW_SHA,
+                job="quality-profile",
+                artifact_id="",
+                artifact_digest="",
+                capture_sha256="",
+            ),
+            quality_path,
+        )
+    except Exception:
+        quality_path.parent.mkdir(parents=True, exist_ok=True)
+        quality_path.write_text("{}\n", encoding="utf-8")
     exit_code = cli.main(
         [
             "evaluate-complexity",
@@ -239,6 +319,26 @@ def _evaluate(
             ".supportability.toml",
             "--output-directory",
             str(output.resolve()),
+            "--quality-evidence",
+            str(quality_path.resolve()),
+            "--quality-repository",
+            "example/fixture",
+            "--quality-repository-id",
+            "123",
+            "--quality-run-id",
+            "456",
+            "--quality-run-attempt",
+            "1",
+            "--quality-job",
+            "quality-profile",
+            "--quality-artifact-id",
+            "789",
+            "--quality-artifact-digest",
+            "d" * 64,
+            "--quality-capture-sha256",
+            hashlib.sha256(quality_path.read_bytes()).hexdigest(),
+            "--workflow-sha",
+            WORKFLOW_SHA,
         ]
     )
     result = json.loads((output / "complexity-result.json").read_text(encoding="utf-8"))

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from supportability_gate import contract, git_changes, quality_profile
+from supportability_gate.function_changes import ChangedFileAssessment
+
+BASE_SHA = "a" * 40
+HEAD_SHA = "b" * 40
+WORKFLOW_SHA = "c" * 40
+EMPTY_SHA = hashlib.sha256(b"").hexdigest()
+POLICY = contract.parse_contract(
+    b"""schema_version = "1.0"
+language = "python"
+production_paths = ["src"]
+high_risk_paths = ["src/risk.py"]
+
+[[gates]]
+adapter = "python.c901-touched.v1"
+paths = ["src"]
+
+[[gates]]
+adapter = "python.import-linter.v1"
+paths = ["src"]
+
+[[gates]]
+adapter = "python.mypy-strict.v1"
+paths = ["src"]
+
+[[gates]]
+adapter = "python.pytest.v1"
+paths = ["src"]
+
+[[gates]]
+adapter = "python.ruff-lint.v1"
+paths = ["src"]
+
+[complexity]
+adapter = "python.c901-touched.v1"
+maximum = 10
+"""
+)
+IDENTITY = git_changes.RepositoryIdentity(
+    "github.com/example/fixture",
+    BASE_SHA,
+    "d" * 40,
+    HEAD_SHA,
+    "e" * 40,
+    "git version fixture",
+)
+
+
+def _commands() -> tuple[quality_profile.GateResult, ...]:
+    return tuple(
+        quality_profile.GateResult(
+            adapter,
+            arguments,
+            ("src",),
+            True,
+            0,
+            EMPTY_SHA,
+            EMPTY_SHA,
+        )
+        for adapter, arguments in quality_profile.command_templates("python")
+    )
+
+
+def _evidence(**changes: object) -> quality_profile.QualityEvidence:
+    values: dict[str, object] = {
+        "base_sha": BASE_SHA,
+        "changed_paths": (),
+        "commands": _commands(),
+        "exclusions": (),
+        "head_sha": HEAD_SHA,
+        "high_risk_paths": ("src/risk.py",),
+        "language": "python",
+        "maximum_complexity": 10,
+        "production_files": ("src/risk.py",),
+        "production_paths": ("src",),
+        "repository": "example/fixture",
+        "repository_id": "123",
+        "repository_remote": "github.com/example/fixture",
+        "run_attempt": "1",
+        "run_id": "456",
+        "runner_environment": "github-hosted",
+        "schema_version": quality_profile.SCHEMA_VERSION,
+        "untested_areas": (),
+        "workflow_sha": WORKFLOW_SHA,
+        "job": "quality-profile",
+        "artifact_id": "789",
+        "artifact_digest": "d" * 64,
+        "capture_sha256": "e" * 64,
+    }
+    values.update(changes)
+    return quality_profile.QualityEvidence(**values)  # type: ignore[arg-type]
+
+
+def _assessment(
+    old_path: str | None,
+    new_path: str | None,
+    base_production: bool,
+    head_production: bool,
+) -> ChangedFileAssessment:
+    return ChangedFileAssessment(
+        git_changes.ChangedPath("RENAMED", old_path, new_path),
+        base_production,
+        head_production,
+        True,
+        (1,),
+    )
+
+
+def _blocks(
+    evidence: quality_profile.QualityEvidence,
+    assessments: tuple[ChangedFileAssessment, ...] = (),
+) -> tuple[str, ...]:
+    return quality_profile.evidence_blocks(evidence, POLICY, IDENTITY, assessments, WORKFLOW_SHA)
+
+
+def test_complete_fixed_python_profile_passes() -> None:
+    assert _blocks(_evidence()) == ()
+
+
+def test_missing_required_command_blocks() -> None:
+    assert "MISSING_QUALITY_COMMAND:python.ruff-lint.v1" in _blocks(
+        _evidence(commands=_commands()[1:])
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        ("executed", False, "DECLARED_TOOL_NOT_EXECUTED:python.ruff-lint.v1"),
+        ("exit_code", 1, "QUALITY_GATE_FAILED:python.ruff-lint.v1"),
+        (
+            "arguments",
+            ("python", "unsafe.py"),
+            "QUALITY_COMMAND_VECTOR_MISMATCH:python.ruff-lint.v1",
+        ),
+    ],
+)
+def test_untrusted_command_result_blocks(field: str, value: object, code: str) -> None:
+    first = replace(_commands()[0], **{field: value})
+    assert code in _blocks(_evidence(commands=(first, *_commands()[1:])))
+
+
+def test_uncovered_changed_and_high_risk_paths_block() -> None:
+    assessment = _assessment("src/changed.py", "src/changed.py", True, True)
+    commands = tuple(replace(item, covered_paths=("other",)) for item in _commands())
+    blocks = _blocks(
+        _evidence(changed_paths=("src/changed.py",), commands=commands),
+        (assessment,),
+    )
+    assert "QUALITY_CHANGED_FILE_COVERAGE:python.ruff-lint.v1:src/changed.py" in blocks
+    assert "QUALITY_HIGH_RISK_FILE_COVERAGE:python.ruff-lint.v1:src/risk.py" in blocks
+
+
+@pytest.mark.parametrize(
+    ("changes", "code"),
+    [
+        ({"exclusions": ("src/generated.py",)}, "QUALITY_EXCLUSION_ADDED:src/generated.py"),
+        ({"maximum_complexity": 11}, "QUALITY_THRESHOLD_WEAKENING"),
+        ({"production_paths": ("src/package",)}, "QUALITY_SCOPE_NARROWING"),
+        ({"untested_areas": ("src/risk.py",)}, "UNTESTED_AREA:src/risk.py"),
+    ],
+)
+def test_anti_weakening_blocks(changes: dict[str, object], code: str) -> None:
+    assert code in _blocks(_evidence(**changes))
+
+
+def test_production_move_outside_scope_blocks() -> None:
+    assessment = _assessment("src/risk.py", "legacy/risk.py", True, False)
+    evidence = _evidence(changed_paths=("src/risk.py",))
+    assert "PRODUCTION_PATH_MOVED_OUTSIDE_SCOPE:legacy/risk.py" in _blocks(evidence, (assessment,))
+
+
+def test_quality_evidence_is_byte_identical(tmp_path: Path) -> None:
+    first = quality_profile.write_evidence(_evidence(), tmp_path / "first.json")
+    second = quality_profile.write_evidence(_evidence(), tmp_path / "second.json")
+    assert first == second
+
+
+def test_quality_artifact_requires_external_github_binding(tmp_path: Path) -> None:
+    path = tmp_path / "quality-gates.json"
+    raw = replace(_evidence(), artifact_id="", artifact_digest="", capture_sha256="")
+    content = quality_profile.write_evidence(raw, path)
+    authenticated = quality_profile.authenticate_evidence(
+        path,
+        repository="example/fixture",
+        repository_id="123",
+        run_id="456",
+        run_attempt="1",
+        job="quality-profile",
+        artifact_id="789",
+        artifact_digest="d" * 64,
+        capture_sha256=hashlib.sha256(content).hexdigest(),
+    )
+    assert authenticated.artifact_id == "789"
+
+
+def test_self_declared_quality_artifact_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "quality-gates.json"
+    quality_profile.write_evidence(_evidence(), path)
+    with pytest.raises(quality_profile.QualityProfileError) as caught:
+        quality_profile.authenticate_evidence(
+            path,
+            repository="example/fixture",
+            repository_id="123",
+            run_id="456",
+            run_attempt="1",
+            job="quality-profile",
+            artifact_id="789",
+            artifact_digest="d" * 64,
+            capture_sha256=hashlib.sha256(path.read_bytes()).hexdigest(),
+        )
+    assert caught.value.code == "SELF_DECLARED_QUALITY_ARTIFACT"
+
+
+def test_target_profile_refuses_owner_workstation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("RUNNER_ENVIRONMENT", raising=False)
+    runner = Path(__file__).with_name("hosted_quality_profile.py")
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-P",
+            str(runner),
+            "--repository",
+            str(Path.cwd()),
+            "--repository-name",
+            "example/fixture",
+            "--repository-id",
+            "123",
+            "--base-ref",
+            BASE_SHA,
+            "--head-ref",
+            HEAD_SHA,
+            "--workflow-sha",
+            WORKFLOW_SHA,
+            "--run-id",
+            "456",
+            "--run-attempt",
+            "1",
+            "--output",
+            str(Path.cwd() / "evidence.json"),
+        ],
+        check=False,
+        capture_output=True,
+        timeout=10,
+    )
+    assert completed.returncode == 2
+    assert not hasattr(quality_profile, "run_profile")
+
+
+def test_fixed_vectors_never_invoke_a_shell() -> None:
+    commands = [
+        command
+        for language in ("python", "typescript")
+        for _, command in quality_profile.command_templates(language)
+    ]
+    arguments = [argument for command in commands for argument in command]
+    assert all(command[0] not in {"bash", "cmd", "pwsh", "sh"} for command in commands)
+    assert all("$(" not in argument and "`" not in argument for argument in arguments)
+
+
+def test_fixed_environment_imports_only_the_target_source(tmp_path: Path) -> None:
+    repository = tmp_path / "target"
+    environment = quality_profile._fixed_environment(tmp_path / "output", repository)
+
+    assert environment["PYTHONPATH"] == str(repository / "src")
+
+
+def _run_git(repository: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return completed.stdout.strip()
+
+
+@pytest.mark.skipif(
+    os.environ.get("RUNNER_ENVIRONMENT") != "github-hosted",
+    reason="target quality commands are forbidden outside GitHub-hosted runners",
+)
+def test_typescript_profile_executes_every_fixed_gate_on_hosted_runner(tmp_path: Path) -> None:
+    repository = tmp_path / "typescript-target"
+    repository.mkdir()
+    _run_git(repository, "init", "--initial-branch=main")
+    _run_git(repository, "config", "user.name", "Fixture")
+    _run_git(repository, "config", "user.email", "fixture@example.invalid")
+    _run_git(repository, "remote", "add", "origin", "https://github.com/example/typescript.git")
+    (repository / ".supportability.toml").write_text(
+        """schema_version = "1.0"
+language = "typescript"
+production_paths = ["src"]
+high_risk_paths = ["src/domain/model.ts"]
+
+[[gates]]
+adapter = "typescript.c901-equivalent-touched.v1"
+paths = ["src"]
+
+[[gates]]
+adapter = "typescript.import-boundaries.v1"
+paths = ["src"]
+
+[complexity]
+adapter = "typescript.c901-equivalent-touched.v1"
+maximum = 10
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+    source = repository / "src" / "domain" / "model.ts"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        "export function score(value: number): number {\n  return value;\n}\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    tests = repository / "tests"
+    tests.mkdir()
+    (tests / "quality.test.mjs").write_text(
+        'import assert from "node:assert/strict";\n'
+        'import test from "node:test";\n\n'
+        'import { score } from "../src/domain/model.ts";\n\n'
+        'test("score", () => {\n  assert.equal(score(1), 2);\n});\n',
+        encoding="utf-8",
+        newline="\n",
+    )
+    _run_git(repository, "add", "--all")
+    _run_git(repository, "commit", "-m", "base")
+    base_sha = _run_git(repository, "rev-parse", "HEAD")
+    source.write_text(
+        "export function score(value: number): number {\n  return value + 1;\n}\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    _run_git(repository, "add", "--all")
+    _run_git(repository, "commit", "-m", "head")
+    head_sha = _run_git(repository, "rev-parse", "HEAD")
+
+    output = tmp_path / "evidence" / "quality-gates.json"
+    runner = Path(__file__).with_name("hosted_quality_profile.py")
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-P",
+            str(runner),
+            "--repository",
+            str(repository.resolve()),
+            "--repository-name",
+            "example/typescript",
+            "--repository-id",
+            "123",
+            "--base-ref",
+            base_sha,
+            "--head-ref",
+            head_sha,
+            "--workflow-sha",
+            WORKFLOW_SHA,
+            "--run-id",
+            "456",
+            "--run-attempt",
+            "1",
+            "--output",
+            str(output.resolve()),
+        ],
+        check=False,
+        capture_output=True,
+        timeout=quality_profile.TIMEOUT_SECONDS,
+    )
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    evidence = quality_profile.load_evidence(output)
+
+    assert evidence.untested_areas == ()
+    assert all(command.executed and command.exit_code == 0 for command in evidence.commands)

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -379,12 +379,28 @@ def _write_coverage_receipt(
     receipt_directory = os.environ.get("M9_COVERAGE_RECEIPT_DIRECTORY")
     if receipt_directory is None:
         return
+    command_claims = [
+        {
+            key: value
+            for key, value in asdict(command).items()
+            if key not in {"stderr_sha256", "stdout_sha256"}
+        }
+        for command in evidence.commands
+    ]
+    failed_claims = [
+        {
+            key: value
+            for key, value in asdict(command).items()
+            if key not in {"stderr_sha256", "stdout_sha256"}
+        }
+        for command in failed.commands
+    ]
     payload = {
         "changed_paths": list(evidence.changed_paths),
-        "commands": [asdict(command) for command in evidence.commands],
+        "commands": command_claims,
         "declared_untested_blocks": list(declared_untested_blocks),
         "failed_control": {
-            "commands": [asdict(command) for command in failed.commands],
+            "commands": failed_claims,
             "untested_areas": list(failed.untested_areas),
         },
         "high_risk_paths": list(evidence.high_risk_paths),
@@ -398,9 +414,34 @@ def _write_coverage_receipt(
         "untested_areas": list(evidence.untested_areas),
     }
     content = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    output_hashes = {
+        "failed": [
+            {
+                "adapter": command.adapter,
+                "stderr_sha256": command.stderr_sha256,
+                "stdout_sha256": command.stdout_sha256,
+            }
+            for command in failed.commands
+        ],
+        "language": language,
+        "passing": [
+            {
+                "adapter": command.adapter,
+                "stderr_sha256": command.stderr_sha256,
+                "stdout_sha256": command.stdout_sha256,
+            }
+            for command in evidence.commands
+        ],
+        "schema_version": "m9-coverage-output-hashes.v1",
+    }
     destination = Path(receipt_directory)
     destination.mkdir(parents=True, exist_ok=True)
     (destination / f"{language}.json").write_text(content, encoding="utf-8", newline="\n")
+    (destination / f"{language}-output-hashes.json").write_text(
+        json.dumps(output_hashes, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
 
 
 def _assert_coverage_falsification(

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
+import shutil
 import subprocess
 import sys
-from dataclasses import replace
+from dataclasses import asdict, replace
 from pathlib import Path
 
 import pytest
@@ -277,9 +279,17 @@ def test_fixed_environment_imports_only_the_target_source(tmp_path: Path) -> Non
 
 
 def _run_git(repository: Path, *arguments: str) -> str:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "GIT_AUTHOR_DATE": "2026-01-01T00:00:00Z",
+            "GIT_COMMITTER_DATE": "2026-01-01T00:00:00Z",
+        }
+    )
     completed = subprocess.run(
         ["git", *arguments],
         cwd=repository,
+        env=environment,
         check=True,
         capture_output=True,
         text=True,
@@ -288,13 +298,298 @@ def _run_git(repository: Path, *arguments: str) -> str:
     return completed.stdout.strip()
 
 
+def _hosted_root(language: str) -> Path:
+    runner_temp = Path(os.environ["RUNNER_TEMP"]).resolve()
+    repository = runner_temp / f"m9-coverage-{language}"
+    if repository.exists():
+        shutil.rmtree(repository)
+    repository.mkdir()
+    return repository
+
+
+def _run_hosted_profile(
+    repository: Path, base_sha: str, head_sha: str, output: Path, name: str
+) -> tuple[subprocess.CompletedProcess[bytes], quality_profile.QualityEvidence]:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-P",
+            str(Path(__file__).with_name("hosted_quality_profile.py")),
+            "--repository",
+            str(repository),
+            "--repository-name",
+            name,
+            "--repository-id",
+            "123",
+            "--base-ref",
+            base_sha,
+            "--head-ref",
+            head_sha,
+            "--workflow-sha",
+            WORKFLOW_SHA,
+            "--run-id",
+            "456",
+            "--run-attempt",
+            "1",
+            "--output",
+            str(output),
+        ],
+        check=False,
+        capture_output=True,
+        timeout=quality_profile.TIMEOUT_SECONDS,
+    )
+    return completed, quality_profile.load_evidence(output)
+
+
+def _coverage_blocks(
+    evidence: quality_profile.QualityEvidence,
+    repository: Path,
+    base_sha: str,
+    head_sha: str,
+    poison_path: str,
+) -> tuple[str, ...]:
+    records: list[git_changes.CommandRecord] = []
+    identity = git_changes.inspect_repository(repository, base_sha, head_sha, records)
+    policy = contract.parse_contract((repository / ".supportability.toml").read_bytes())
+    trusted = replace(
+        evidence,
+        artifact_id="789",
+        artifact_digest="d" * 64,
+        capture_sha256="e" * 64,
+    )
+    assessment = ChangedFileAssessment(
+        git_changes.ChangedPath("MODIFIED", poison_path, poison_path),
+        True,
+        True,
+        True,
+        (1,),
+    )
+    return quality_profile.evidence_blocks(trusted, policy, identity, (assessment,), WORKFLOW_SHA)
+
+
+def _write_coverage_receipt(
+    language: str,
+    poison_path: str,
+    evidence: quality_profile.QualityEvidence,
+    original_blocks: tuple[str, ...],
+    removed_claim_blocks: tuple[str, ...],
+    declared_untested_blocks: tuple[str, ...],
+    failed: quality_profile.QualityEvidence,
+) -> None:
+    receipt_directory = os.environ.get("M9_COVERAGE_RECEIPT_DIRECTORY")
+    if receipt_directory is None:
+        return
+    payload = {
+        "changed_paths": list(evidence.changed_paths),
+        "commands": [asdict(command) for command in evidence.commands],
+        "declared_untested_blocks": list(declared_untested_blocks),
+        "failed_control": {
+            "commands": [asdict(command) for command in failed.commands],
+            "untested_areas": list(failed.untested_areas),
+        },
+        "high_risk_paths": list(evidence.high_risk_paths),
+        "language": language,
+        "original_blocks": list(original_blocks),
+        "poison_path": poison_path,
+        "poison_proof": "top-level exception plus passing test command proves non-execution",
+        "production_files": list(evidence.production_files),
+        "removed_claim_blocks": list(removed_claim_blocks),
+        "schema_version": "m9-coverage-falsification.v1",
+        "untested_areas": list(evidence.untested_areas),
+    }
+    content = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    destination = Path(receipt_directory)
+    destination.mkdir(parents=True, exist_ok=True)
+    (destination / f"{language}.json").write_text(content, encoding="utf-8", newline="\n")
+
+
+def _assert_coverage_falsification(
+    *,
+    language: str,
+    test_adapter: str,
+    poison_path: str,
+    repository: Path,
+    base_sha: str,
+    head_sha: str,
+    evidence: quality_profile.QualityEvidence,
+    failed: quality_profile.QualityEvidence,
+) -> None:
+    test_result = next(command for command in evidence.commands if command.adapter == test_adapter)
+    assert test_result.executed and test_result.exit_code == 0
+    assert test_result.covered_paths == ("src",)
+    assert evidence.changed_paths == (poison_path,)
+    assert evidence.high_risk_paths == (poison_path,)
+    assert poison_path in evidence.production_files
+    assert evidence.untested_areas == ()
+
+    original_blocks = _coverage_blocks(evidence, repository, base_sha, head_sha, poison_path)
+    removed_claim = replace(
+        evidence,
+        commands=tuple(
+            replace(command, covered_paths=()) if command.adapter == test_adapter else command
+            for command in evidence.commands
+        ),
+    )
+    removed_claim_blocks = _coverage_blocks(
+        removed_claim, repository, base_sha, head_sha, poison_path
+    )
+    declared_untested_blocks = _coverage_blocks(
+        replace(evidence, untested_areas=(poison_path,)),
+        repository,
+        base_sha,
+        head_sha,
+        poison_path,
+    )
+    assert original_blocks == ()
+    assert f"QUALITY_CHANGED_FILE_COVERAGE:{test_adapter}:{poison_path}" in removed_claim_blocks
+    assert f"QUALITY_HIGH_RISK_FILE_COVERAGE:{test_adapter}:{poison_path}" in removed_claim_blocks
+    assert f"UNTESTED_AREA:{poison_path}" in declared_untested_blocks
+
+    failed_test = next(command for command in failed.commands if command.adapter == test_adapter)
+    assert failed_test.executed and failed_test.exit_code != 0
+    assert set(failed.untested_areas) == set(failed.production_files)
+    _write_coverage_receipt(
+        language,
+        poison_path,
+        evidence,
+        original_blocks,
+        removed_claim_blocks,
+        declared_untested_blocks,
+        failed,
+    )
+
+
 @pytest.mark.skipif(
     os.environ.get("RUNNER_ENVIRONMENT") != "github-hosted",
     reason="target quality commands are forbidden outside GitHub-hosted runners",
 )
-def test_typescript_profile_executes_every_fixed_gate_on_hosted_runner(tmp_path: Path) -> None:
-    repository = tmp_path / "typescript-target"
-    repository.mkdir()
+def test_python_profile_falsifies_declared_test_coverage() -> None:
+    repository = _hosted_root("python")
+    _run_git(repository, "init", "--initial-branch=main")
+    _run_git(repository, "config", "user.name", "Fixture")
+    _run_git(repository, "config", "user.email", "fixture@example.invalid")
+    _run_git(repository, "remote", "add", "origin", "https://github.com/example/python.git")
+    (repository / ".supportability.toml").write_text(
+        """schema_version = "1.0"
+language = "python"
+production_paths = ["src"]
+high_risk_paths = ["src/sample/unexecuted.py"]
+
+[[gates]]
+adapter = "python.c901-touched.v1"
+paths = ["src"]
+
+[[gates]]
+adapter = "python.import-linter.v1"
+paths = ["src"]
+
+[[gates]]
+adapter = "python.mypy-strict.v1"
+paths = ["src"]
+
+[[gates]]
+adapter = "python.pytest.v1"
+paths = ["src"]
+
+[[gates]]
+adapter = "python.ruff-lint.v1"
+paths = ["src"]
+
+[complexity]
+adapter = "python.c901-touched.v1"
+maximum = 10
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+    (repository / "pyproject.toml").write_text(
+        """[build-system]
+requires = ["setuptools==83.0.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "m9-python-coverage-fixture"
+version = "1.0.0"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+    source = repository / "src" / "sample"
+    source.mkdir(parents=True)
+    (source / "__init__.py").write_text("", encoding="utf-8")
+    (source / "covered.py").write_text(
+        "def score(value: int) -> int:\n    return value + 1\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    poison = source / "unexecuted.py"
+    poison.write_text('raise RuntimeError("M9_UNEXECUTED_BASE")\n', encoding="utf-8", newline="\n")
+    tests = repository / "tests"
+    tests.mkdir()
+    test_file = tests / "test_covered.py"
+    test_file.write_text(
+        "from sample.covered import score\n\n\ndef test_score() -> None:\n"
+        "    assert score(1) == 2\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    _run_git(repository, "add", "--all")
+    _run_git(repository, "commit", "-m", "base")
+    base_sha = _run_git(repository, "rev-parse", "HEAD")
+    poison.write_text('raise RuntimeError("M9_UNEXECUTED_HEAD")\n', encoding="utf-8", newline="\n")
+    _run_git(repository, "add", "--all")
+    _run_git(repository, "commit", "-m", "head")
+    head_sha = _run_git(repository, "rev-parse", "HEAD")
+
+    completed, evidence = _run_hosted_profile(
+        repository,
+        base_sha,
+        head_sha,
+        repository.parent / "m9-python-success" / "quality-gates.json",
+        "example/python",
+    )
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    assert all(command.executed and command.exit_code == 0 for command in evidence.commands)
+
+    test_file.write_text(
+        "from sample import unexecuted\n"
+        "from sample.covered import score\n\n\ndef test_score() -> None:\n"
+        "    assert score(1) == 2\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    _run_git(repository, "add", "--all")
+    _run_git(repository, "commit", "-m", "failure-control")
+    failure_sha = _run_git(repository, "rev-parse", "HEAD")
+    failed_completed, failed = _run_hosted_profile(
+        repository,
+        base_sha,
+        failure_sha,
+        repository.parent / "m9-python-failure" / "quality-gates.json",
+        "example/python",
+    )
+    assert failed_completed.returncode == 1
+    _assert_coverage_falsification(
+        language="python",
+        test_adapter="python.pytest.v1",
+        poison_path="src/sample/unexecuted.py",
+        repository=repository,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        evidence=evidence,
+        failed=failed,
+    )
+
+
+@pytest.mark.skipif(
+    os.environ.get("RUNNER_ENVIRONMENT") != "github-hosted",
+    reason="target quality commands are forbidden outside GitHub-hosted runners",
+)
+def test_typescript_profile_falsifies_declared_test_coverage() -> None:
+    repository = _hosted_root("typescript")
     _run_git(repository, "init", "--initial-branch=main")
     _run_git(repository, "config", "user.name", "Fixture")
     _run_git(repository, "config", "user.email", "fixture@example.invalid")
@@ -303,7 +598,7 @@ def test_typescript_profile_executes_every_fixed_gate_on_hosted_runner(tmp_path:
         """schema_version = "1.0"
 language = "typescript"
 production_paths = ["src"]
-high_risk_paths = ["src/domain/model.ts"]
+high_risk_paths = ["src/domain/unexecuted.ts"]
 
 [[gates]]
 adapter = "typescript.c901-equivalent-touched.v1"
@@ -320,67 +615,66 @@ maximum = 10
         encoding="utf-8",
         newline="\n",
     )
-    source = repository / "src" / "domain" / "model.ts"
-    source.parent.mkdir(parents=True)
-    source.write_text(
-        "export function score(value: number): number {\n  return value;\n}\n",
-        encoding="utf-8",
-        newline="\n",
-    )
-    tests = repository / "tests"
-    tests.mkdir()
-    (tests / "quality.test.mjs").write_text(
-        'import assert from "node:assert/strict";\n'
-        'import test from "node:test";\n\n'
-        'import { score } from "../src/domain/model.ts";\n\n'
-        'test("score", () => {\n  assert.equal(score(1), 2);\n});\n',
-        encoding="utf-8",
-        newline="\n",
-    )
-    _run_git(repository, "add", "--all")
-    _run_git(repository, "commit", "-m", "base")
-    base_sha = _run_git(repository, "rev-parse", "HEAD")
-    source.write_text(
+    source = repository / "src" / "domain"
+    source.mkdir(parents=True)
+    (source / "model.ts").write_text(
         "export function score(value: number): number {\n  return value + 1;\n}\n",
         encoding="utf-8",
         newline="\n",
     )
+    poison = source / "unexecuted.ts"
+    poison.write_text('throw new Error("M9_UNEXECUTED_BASE");\n', encoding="utf-8", newline="\n")
+    tests = repository / "tests"
+    tests.mkdir()
+    test_file = tests / "quality.test.mjs"
+    passing_test = (
+        'import assert from "node:assert/strict";\n'
+        'import test from "node:test";\n\n'
+        'import { score } from "../src/domain/model.ts";\n\n'
+        'test("score", () => {\n  assert.equal(score(1), 2);\n});\n'
+    )
+    test_file.write_text(passing_test, encoding="utf-8", newline="\n")
+    _run_git(repository, "add", "--all")
+    _run_git(repository, "commit", "-m", "base")
+    base_sha = _run_git(repository, "rev-parse", "HEAD")
+    poison.write_text('throw new Error("M9_UNEXECUTED_HEAD");\n', encoding="utf-8", newline="\n")
     _run_git(repository, "add", "--all")
     _run_git(repository, "commit", "-m", "head")
     head_sha = _run_git(repository, "rev-parse", "HEAD")
 
-    output = tmp_path / "evidence" / "quality-gates.json"
-    runner = Path(__file__).with_name("hosted_quality_profile.py")
-    completed = subprocess.run(
-        [
-            sys.executable,
-            "-P",
-            str(runner),
-            "--repository",
-            str(repository.resolve()),
-            "--repository-name",
-            "example/typescript",
-            "--repository-id",
-            "123",
-            "--base-ref",
-            base_sha,
-            "--head-ref",
-            head_sha,
-            "--workflow-sha",
-            WORKFLOW_SHA,
-            "--run-id",
-            "456",
-            "--run-attempt",
-            "1",
-            "--output",
-            str(output.resolve()),
-        ],
-        check=False,
-        capture_output=True,
-        timeout=quality_profile.TIMEOUT_SECONDS,
+    completed, evidence = _run_hosted_profile(
+        repository,
+        base_sha,
+        head_sha,
+        repository.parent / "m9-typescript-success" / "quality-gates.json",
+        "example/typescript",
     )
     assert completed.returncode == 0, completed.stderr.decode(errors="replace")
-    evidence = quality_profile.load_evidence(output)
-
-    assert evidence.untested_areas == ()
     assert all(command.executed and command.exit_code == 0 for command in evidence.commands)
+
+    test_file.write_text(
+        'import "../src/domain/unexecuted.ts";\n' + passing_test,
+        encoding="utf-8",
+        newline="\n",
+    )
+    _run_git(repository, "add", "--all")
+    _run_git(repository, "commit", "-m", "failure-control")
+    failure_sha = _run_git(repository, "rev-parse", "HEAD")
+    failed_completed, failed = _run_hosted_profile(
+        repository,
+        base_sha,
+        failure_sha,
+        repository.parent / "m9-typescript-failure" / "quality-gates.json",
+        "example/typescript",
+    )
+    assert failed_completed.returncode == 1
+    _assert_coverage_falsification(
+        language="typescript",
+        test_adapter="typescript.test.v1",
+        poison_path="src/domain/unexecuted.ts",
+        repository=repository,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        evidence=evidence,
+        failed=failed,
+    )

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -378,6 +378,19 @@ def test_transport_failures_block(error: Exception, code: str) -> None:
         request_response(_packet(), opener=fail)
 
 
+def test_transport_uses_fixed_480_second_default() -> None:
+    packet = _packet()
+    observed: list[float] = []
+
+    def open_request(_request: object, *, timeout: float) -> _Reply:
+        observed.append(timeout)
+        return _Reply(_response(packet))
+
+    request_response(packet, opener=open_request)
+
+    assert observed == [480.0]
+
+
 @pytest.mark.parametrize(
     "injection",
     [


### PR DESCRIPTION
## Purpose

Falsify or confirm whether M9 converts declared root scope plus zero command exit into per-file test-coverage proof.

## Controls

- Python and TypeScript changed/high-risk poison files raise at module load but are omitted from passing tests.
- Exact hosted profiles must still claim test coverage and no untested area for the theory to hold.
- Removing only the coverage declaration and declaring the file untested are causal controls.
- Importing the poison file is the execution-failure control.

## Boundaries

- Diagnostic only; never merge.
- Production source is byte-identical to PR #44 head \86c6f2b808c68094127c0f07cc9ad57fd5bef763\.
- No model verdict is used as the oracle.
- Closes #24