### PR TITLE
Preserve protected documentation-only reviews

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,52 +2,19 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "468238fe456262c663125c7ec92af4b1e4ee2d98"
+base_sha = "7a2227b6c464cb602f6a8ca18b7d9a1e0f649142"
 overall_result = "PASS"
 responsibility_changes = [
-    "Completion-report truth is now separated from the existing M9 quality runner and M3 structured review parser.",
-    "The GitHub App binds exact-head report bytes to the existing authenticated M9 workflow artifact before semantic review.",
+    "Documentation-only changes retain the required semantic check without requiring a production completion report.",
 ]
 simplified_functions = [
-    "GitHubApp._artifact_bytes",
-    "GitHubApp._artifact_json",
-    "GitHubApp._completion_report",
-    "GitHubApp._handoff_artifact",
-    "GitHubApp._handoff_evidence",
-    "GitHubApp._handoff_run",
     "GitHubApp.m10_evidence_packet",
-    "_NoAuthRedirect.redirect_request",
-    "_architecture_result",
-    "_citation_resolves",
-    "_claim_reviews",
-    "_claims",
-    "_command_blocks",
-    "_commands",
-    "_function_names",
-    "_review",
-    "_review_blocks",
-    "_response_data",
-    "_result_blocks",
-    "_risk_blocks",
-    "_source_lines",
-    "_text_list",
-    "_trusted_verdict",
-    "_verdict_summary",
-    "deterministic_completion_blocks",
-    "evaluate_completion_report",
-    "parse_completion_report",
-    "parse_response",
-    "request_payload",
-    "result_schema",
 ]
 boundary_rationale = [
-    "handoff_policy owns report parsing and evidence cross-checking without GitHub transport or target execution.",
-    "GitHubApp owns authenticated GitHub run, artifact, and exact-head report retrieval without semantic judgment.",
-    "semantic_review owns strict model-response parsing and final bound verdict construction.",
+    "GitHubApp packet orchestration distinguishes production evidence from documentation-only evidence before handoff retrieval.",
 ]
 remaining_risks = [
-    "Model or localhost transport unavailability intentionally leaves the required semantic check absent, so merge remains blocked until a fresh full request succeeds.",
-    "A substantive report defect intentionally remains visible as a failing required semantic check and must be repaired on a fresh head.",
+    "Production changes still require a current completion report and authenticated attempt-one artifact before semantic review.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -67,20 +34,6 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-report-cross-check"
-text = "The handoff evaluator combines machine-resolvable report blocks with exact model claim reviews."
-citations = ["src/supportability_gate/handoff_policy.py:273-293"]
-
-[[completion_report.claims]]
-id = "claim-artifact-provenance"
-text = "The GitHub App verifies the attempt-one artifact digest and binds its run identity to the exact head."
-citations = ["src/supportability_gate/github_app.py:338-362"]
-
-[[completion_report.claims]]
-id = "claim-response-binding"
-text = "The semantic parser binds returned model, terminal status, response hash, and parser result into the verdict."
-citations = [
-    "src/supportability_gate/semantic_review.py:31-50",
-    "src/supportability_gate/semantic_review.py:318-332",
-    "src/supportability_gate/semantic_review.py:335-400",
-]
+id = "claim-doc-only-compatibility"
+text = "M10 packet construction skips handoff artifact retrieval when no production sources changed."
+citations = ["src/supportability_gate/github_app.py:231-251"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -36,4 +36,4 @@ gate_coverage = [
 [[completion_report.claims]]
 id = "claim-doc-only-compatibility"
 text = "M10 packet construction skips handoff artifact retrieval when no production sources changed."
-citations = ["src/supportability_gate/github_app.py:231-251"]
+citations = ["src/supportability_gate/github_app.py:231-249"]

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -234,6 +234,8 @@ class GitHubApp:
         """Add authenticated M10 report and workflow evidence to one exact-head packet."""
         packet = self.evidence_packet(repository, pull, token)
         evidence = packet.evidence
+        if not evidence.get("reviewed_sources"):
+            return packet
         evidence.update(self._handoff_evidence(repository, packet.head_sha, token))
         evidence.update(self._completion_report(repository, packet.head_sha, token))
         return EvidencePacket(

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -135,6 +135,27 @@ def test_m10_packet_binds_fresh_full_run_artifact_and_report() -> None:
     }
 
 
+def test_m10_packet_skips_completion_report_for_nonproduction_diff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packet = EvidencePacket(
+        "mbh-solutions/supportability-gate",
+        "a" * 40,
+        "b" * 40,
+        42,
+        {"pull_request": 3, "reviewed_sources": []},
+    )
+    app = GitHubApp(42, 7, b"unused")
+    monkeypatch.setattr(app, "evidence_packet", lambda *args: packet)
+    monkeypatch.setattr(
+        app,
+        "_handoff_evidence",
+        lambda *args: pytest.fail("nonproduction diff must not require a handoff artifact"),
+    )
+
+    assert app.m10_evidence_packet("mbh-solutions/supportability-gate", {}, "token") is packet
+
+
 def test_rerun_attempt_is_not_accepted_as_m10_evidence() -> None:
     run = {
         "conclusion": "failure",


### PR DESCRIPTION
M10 closure repair: documentation-only pull requests retain the required semantic check without requiring a production completion report. Production changes remain fail-closed.

References #25. Does not close it.

Closes #25