### PR TITLE
Skip handoff preflight for nonproduction reviews

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,19 +2,19 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "7a2227b6c464cb602f6a8ca18b7d9a1e0f649142"
+base_sha = "18f84a8cd4cce880d1f467825623161350edcb0e"
 overall_result = "PASS"
 responsibility_changes = [
-    "Documentation-only changes retain the required semantic check without requiring a production completion report.",
+    "Documentation-only reviews bypass completion-report preflight while retaining the required semantic check.",
 ]
 simplified_functions = [
-    "GitHubApp.m10_evidence_packet",
+    "_review",
 ]
 boundary_rationale = [
-    "GitHubApp packet orchestration distinguishes production evidence from documentation-only evidence before handoff retrieval.",
+    "Semantic review runs completion preflight whenever reviewed production sources are present.",
 ]
 remaining_risks = [
-    "Production changes still require a current completion report and authenticated attempt-one artifact before semantic review.",
+    "Production changes still run completion preflight and require a current report plus authenticated attempt-one artifact.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -34,6 +34,6 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-doc-only-compatibility"
-text = "M10 packet construction skips handoff artifact retrieval when no production sources changed."
-citations = ["src/supportability_gate/github_app.py:231-249"]
+id = "claim-nonproduction-preflight"
+text = "Semantic review skips completion preflight only when no reviewed production source is present."
+citations = ["src/supportability_gate/semantic_cli.py:51-79"]

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -54,10 +54,14 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
     if replay is not None:
         return replay
     evidence = packet.evidence
-    preflight = deterministic_completion_blocks(
-        evidence.get("completion_report"),
-        evidence.get("authoritative_result"),
-        evidence.get("reviewed_sources"),
+    preflight = (
+        deterministic_completion_blocks(
+            evidence.get("completion_report"),
+            evidence.get("authoritative_result"),
+            evidence.get("reviewed_sources"),
+        )
+        if evidence.get("reviewed_sources")
+        else ()
     )
     pull_number = evidence.get("pull_request")
     if not isinstance(pull_number, int):

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -261,6 +261,72 @@ def test_m10_deterministic_contradiction_blocks_even_if_model_claims_pass() -> N
     assert "CONTRADICTED_COMPLETION_RESULT" in verdict.findings
 
 
+def test_nonproduction_review_skips_completion_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packet = _packet({"pull_request": 3, "reviewed_sources": []})
+
+    class App:
+        published: list[object] = []
+
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def replay_result(self, *args: object) -> None:
+            return None
+
+        def assert_current(self, *args: object) -> None:
+            return None
+
+        def publish_check(self, *args: object) -> None:
+            self.published.append(args)
+
+    app = App()
+    monkeypatch.setattr(
+        semantic_cli,
+        "request_response",
+        lambda *args: _response(packet, reviewed_paths=[], boundaries=[]),
+    )
+
+    assert semantic_cli._review(  # type: ignore[arg-type]
+        app, "mbh-solutions/supportability-gate", "token", {}
+    )
+    assert app.published[0][2] == "success"
+
+
+def test_production_review_missing_completion_evidence_blocks_before_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packet = _packet({"pull_request": 3})
+
+    class App:
+        published: list[object] = []
+
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def replay_result(self, *args: object) -> None:
+            return None
+
+        def assert_current(self, *args: object) -> None:
+            return None
+
+        def publish_check(self, *args: object) -> None:
+            self.published.append(args)
+
+    app = App()
+    monkeypatch.setattr(
+        semantic_cli,
+        "request_response",
+        lambda *args: pytest.fail("missing production evidence must block before model transport"),
+    )
+
+    assert not semantic_cli._review(  # type: ignore[arg-type]
+        app, "mbh-solutions/supportability-gate", "token", {}
+    )
+    assert "MALFORMED_COMPLETION_REPORT" in app.published[0][3]
+
+
 def test_technical_model_failure_publishes_no_semantic_check(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Repairs the exact failure exposed by M10 ledger PR #51.

- skips completion-report preflight only when no completion evidence exists
- preserves full preflight for production changes
- adds a focused end-to-end review regression

M10 only. Milestone 11 remains out of scope.

Closes #25