### PR TITLE
M11: support anonymous TypeScript callbacks

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -36,4 +36,4 @@ gate_coverage = [
 [[completion_report.claims]]
 id = "claim-anonymous-callback-identity"
 text = "Anonymous TypeScript-family callbacks use stable source-coordinate identities instead of failing extraction."
-citations = ["src/supportability_gate/function_changes.py:187-206", "tests/test_evaluate_complexity.py:518-525"]
+citations = ["src/supportability_gate/function_changes.py:187-206"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,19 +2,19 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "18f84a8cd4cce880d1f467825623161350edcb0e"
+base_sha = "07152e27db44811165a816589d622fe04030ab32"
 overall_result = "PASS"
 responsibility_changes = [
-    "Documentation-only reviews bypass completion-report preflight while retaining the required semantic check.",
+    "Anonymous TypeScript and TSX callbacks receive deterministic source-coordinate identities.",
 ]
 simplified_functions = [
-    "_review",
+    "_TypeScriptFunctionCollector._name",
 ]
 boundary_rationale = [
-    "Semantic review runs completion preflight whenever reviewed production sources are present.",
+    "All TypeScript-family function identities remain owned by the shared source collector.",
 ]
 remaining_risks = [
-    "Production changes still run completion preflight and require a current report plus authenticated attempt-one artifact.",
+    "Moving an anonymous callback changes its coordinate identity and is reported as a remove/add pair.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -34,6 +34,6 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-nonproduction-preflight"
-text = "Semantic review skips completion preflight only when no reviewed production source is present."
-citations = ["src/supportability_gate/semantic_cli.py:51-79"]
+id = "claim-anonymous-callback-identity"
+text = "Anonymous TypeScript-family callbacks use stable source-coordinate identities instead of failing extraction."
+citations = ["src/supportability_gate/function_changes.py:187-206", "tests/test_evaluate_complexity.py:518-525"]

--- a/src/supportability_gate/function_changes.py
+++ b/src/supportability_gate/function_changes.py
@@ -199,10 +199,7 @@ class _TypeScriptFunctionCollector:
         ):
             name = parent.child_by_field_name("name") or parent.child_by_field_name("key")
         if name is None:
-            raise PythonSourceError(
-                "AMBIGUOUS_FUNCTION_IDENTITY",
-                f"unnamed TypeScript function: {self.path}:{node.start_point.row + 1}",
-            )
+            return f"anonymous@{node.start_point.row + 1}:{node.start_point.column + 1}"
         value = _typescript_text(name, self.content)
         if not value:
             raise PythonSourceError("AMBIGUOUS_FUNCTION_IDENTITY", self.path)

--- a/tests/test_evaluate_complexity.py
+++ b/tests/test_evaluate_complexity.py
@@ -515,14 +515,14 @@ def test_typescript_tsx_arrow_function_is_bound(tmp_path: Path) -> None:
     assert result["functions"][0]["ending_complexity"] == 2
 
 
-def test_typescript_ambiguous_callback_fails_closed(tmp_path: Path) -> None:
+def test_typescript_anonymous_callback_gets_stable_identity(tmp_path: Path) -> None:
     source = "export const values = [1].map((value) => value + 1);\n"
     repository, base_sha, head_sha = _typescript_repository(tmp_path, None, source)
 
     exit_code, result = _evaluate(repository, base_sha, head_sha, tmp_path / "result")
 
-    assert exit_code == 2
-    assert result["technical_errors"][0]["code"] == "AMBIGUOUS_FUNCTION_IDENTITY"
+    assert exit_code == 0
+    assert result["touched_qualified_functions"] == ["anonymous@1:31"]
 
 
 def test_typescript_profile_mismatch_blocks_instead_of_skipping(tmp_path: Path) -> None:


### PR DESCRIPTION
Implements the M11-qualified parser repair after the protected characterization baseline in #53.  - assigns deterministic source-coordinate identities to anonymous TypeScript-family callbacks - updates the single regression check - refreshes the required completion report against the merged baseline  Local required source proof: PASS (Python 3.12; 243 passed, 2 skipped; wheel fresh-install CLI PASS).  Refs #26 

Closes #26