### PR TITLE
Allow private PR authorization evidence

### DIFF
--- a/.github/workflows/organization-required.yml
+++ b/.github/workflows/organization-required.yml
@@ -7,6 +7,7 @@ permissions:
   actions: read
   contents: read
   issues: read
+  pull-requests: read
 
 jobs:
   characterize-base:


### PR DESCRIPTION
Repairs private-repository deployment of the completed Supportability Gate.

The refactor verifier reads authenticated owner authorization from pull-request comments. GitHub's workflow token exposes permissions independently; the final workflow granted `issues: read` but omitted `pull-requests: read`, producing `GITHUB_AUTHORIZATION_EVIDENCE_FAILURE` on private TWMN PR #26.

This adds the single least-privilege read permission. No product logic, policy, threshold, scope, waiver, standard, or runtime interface changes.

Proof:
- Python 3.12.13
- Ruff lint/format/C901: PASS
- strict mypy: PASS
- import-linter: 2 contracts kept
- pytest: 243 passed, 2 skipped
- focused immutable-standard tamper test: PASS
- wheel build + fresh exact-lock install + installed CLI help: PASS
- immutable standard SHA-256 unchanged