### PR TITLE
ci: add Droid Wiki refresh action

### DIFF
--- a/.github/workflows/droid-wiki-refresh.yml
+++ b/.github/workflows/droid-wiki-refresh.yml
@@ -1,0 +1,19 @@
+name: Droid Wiki Refresh
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  wiki-refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Factory Droid
+        run: curl -fsSL https://app.factory.ai/cli | sh
+
+      - name: Generate wiki
+        run: droid exec --auto high "/wiki"
+        env:
+          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that installs Factory Droid and refreshes the Factory Wiki on pushes to main. The workflow uses the FACTORY_API_KEY repository secret.