### PR TITLE
Allow exactly authorized production deletions

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,19 +2,25 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "5952be3b3b14d253ebfe3b7a43f362a06ea95b6e"
+base_sha = "1271a041452a28e005daadb6ce8a442eb607561d"
 overall_result = "PASS"
 responsibility_changes = [
-    "Semantic architecture citations are limited to imports in authenticated reviewed_sources evidence.",
+    "Refactor target discovery now owns deterministic base-blob identities for deleted source files.",
+    "Characterization verification now distinguishes deleted paths from retained paths that still require runnable coverage.",
 ]
 simplified_functions = [
-    "request_payload",
+    "_target_identities",
+    "verify_refactor",
+    "_definition_blocks",
+    "_coverage_blocks",
+    "verify_evidence",
 ]
 boundary_rationale = [
-    "The existing request builder remains the single owner of semantic-review instructions.",
+    "Existing refactor authorization remains the sole owner of exact repository, commit, sequence, scope, and target approval.",
+    "Existing characterization verification remains the sole owner of retained-behavior proof.",
 ]
 remaining_risks = [
-    "Model output can still violate bindings, but the deterministic parser continues to fail closed.",
+    "Deleted non-source, empty, or unparseable production files intentionally remain fail-closed as unbounded targets.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -34,6 +40,11 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-reviewed-import-binding"
-text = "Semantic instructions define trusted imports exclusively as imports listed under reviewed_sources."
-citations = ["src/supportability_gate/semantic_contract.py:289-293"]
+id = "claim-deleted-base-identities"
+text = "Deleted source responsibilities are parsed from the immutable base blob; empty or unparseable deletions remain unbounded."
+citations = ["src/supportability_gate/refactor_policy.py:278-308"]
+
+[[completion_report.claims]]
+id = "claim-retained-characterization"
+text = "A removed characterization scenario is accepted only when every covered path was deleted or remains covered by a surviving scenario."
+citations = ["src/supportability_gate/characterization.py:201-210"]

--- a/src/supportability_gate/characterization.py
+++ b/src/supportability_gate/characterization.py
@@ -189,6 +189,7 @@ def _definition_blocks(
     head_sha: str,
     language: str,
     head: Manifest,
+    deleted_paths: set[str],
     records: list[git_changes.CommandRecord],
 ) -> list[str]:
     try:
@@ -200,8 +201,13 @@ def _definition_blocks(
     blocks: list[str] = []
     base_by_id = {item.id: item for item in base.scenarios}
     head_by_id = {item.id: item for item in head.scenarios}
+    head_covered = {path for item in head.scenarios for path in item.covers}
     for identifier in sorted(set(base_by_id) - set(head_by_id)):
-        blocks.append(f"REMOVED_CHARACTERIZATION_SCENARIO:{identifier}")
+        if any(
+            path not in deleted_paths and path not in head_covered
+            for path in base_by_id[identifier].covers
+        ):
+            blocks.append(f"REMOVED_CHARACTERIZATION_SCENARIO:{identifier}")
     for identifier in sorted(set(base_by_id) & set(head_by_id)):
         if base_by_id[identifier] != head_by_id[identifier]:
             blocks.append(f"CHANGED_CHARACTERIZATION_DEFINITION:{identifier}")
@@ -287,21 +293,17 @@ def _artifact_identity_blocks(
 
 
 def _coverage_blocks(
-    repository: Path,
-    base_sha: str,
-    head_sha: str,
     policy: contract.Contract,
     manifest: Manifest,
-    records: list[git_changes.CommandRecord],
+    changes: tuple[git_changes.ChangedPath, ...],
+    deleted_paths: set[str],
 ) -> tuple[list[str], list[str], list[str]]:
-    changes = git_changes.changed_paths(repository, base_sha, head_sha, records)
     changed = {
-        path
+        item.new_path
         for item in changes
-        for path in (item.old_path, item.new_path)
-        if path and policy.is_production_path(path)
+        if item.new_path and policy.is_production_path(item.new_path)
     }
-    required = sorted(changed | set(policy.high_risk_paths))
+    required = sorted(changed | (set(policy.high_risk_paths) - deleted_paths))
     covered = sorted({path for item in manifest.scenarios for path in item.covers})
     blocks = [
         f"MISSING_CHARACTERIZATION_COVERAGE:{path}" for path in required if path not in covered
@@ -440,6 +442,12 @@ def verify_evidence(
         repository, base_sha, ".supportability.toml", records
     )
     policy = contract.parse_contract(policy_blob.content)
+    changes = git_changes.changed_paths(repository, base_sha, head_sha, records)
+    deleted_paths = {
+        item.old_path
+        for item in changes
+        if item.old_path and item.new_path is None and policy.is_production_path(item.old_path)
+    }
     manifest = _manifest(repository, head_sha, records)
     base, base_error = _load_capture(base_path, "MISSING_BASELINE")
     head, head_error = _load_capture(head_path, "HEAD_ONLY_CHARACTERIZATION_CLAIM")
@@ -464,11 +472,17 @@ def verify_evidence(
     )
     blocks.extend((*base_blocks, *head_blocks))
     blocks.extend(
-        _definition_blocks(repository, base_sha, head_sha, policy.language, manifest, records)
+        _definition_blocks(
+            repository,
+            base_sha,
+            head_sha,
+            policy.language,
+            manifest,
+            deleted_paths,
+            records,
+        )
     )
-    coverage_blocks, required, covered = _coverage_blocks(
-        repository, base_sha, head_sha, policy, manifest, records
-    )
+    coverage_blocks, required, covered = _coverage_blocks(policy, manifest, changes, deleted_paths)
     blocks.extend(coverage_blocks)
     if (
         not base_artifact_id.isdecimal()

--- a/src/supportability_gate/refactor_policy.py
+++ b/src/supportability_gate/refactor_policy.py
@@ -276,19 +276,32 @@ def _target_identities(
     targets: list[str] = []
     unbounded: list[str] = []
     for change in changes:
-        path = change.new_path
+        path = change.new_path or change.old_path
         if path is None or not policy.is_production_path(path):
-            if change.old_path and policy.is_production_path(change.old_path):
-                unbounded.append(change.old_path)
             continue
         if not _profile_source(path, policy.language):
             unbounded.append(path)
             continue
-        lines = git_changes.changed_head_lines(
-            repository, identity.base_sha, identity.head_sha, path, records
+        deleted = change.new_path is None
+        commit = identity.base_sha if deleted else identity.head_sha
+        blob = git_changes.read_regular_blob(repository, commit, path, records)
+        lines = (
+            tuple(range(1, len(blob.content.splitlines()) + 1))
+            if deleted
+            else git_changes.changed_head_lines(
+                repository, identity.base_sha, identity.head_sha, path, records
+            )
         )
-        blob = git_changes.read_regular_blob(repository, identity.head_sha, path, records)
-        spans = function_changes.responsibility_spans(path, blob.content, set(lines))
+        if not lines:
+            unbounded.append(path)
+            continue
+        try:
+            spans = function_changes.responsibility_spans(path, blob.content, set(lines))
+        except function_changes.PythonSourceError:
+            if not deleted:
+                raise
+            unbounded.append(path)
+            continue
         targets.extend(
             f"{path}::{item.kind}:{item.name}:{item.start_line}-{item.end_line}" for item in spans
         )
@@ -395,7 +408,15 @@ def verify_refactor(
             blocks.extend(_focus_blocks(authorization, actual_scope, targets, unbounded, policy))
         except RefactorPolicyError as error:
             blocks.append(error.code)
-    production_paths = tuple(sorted({item.split("::", 1)[0] for item in targets}))
+    production_paths = tuple(
+        sorted(
+            {
+                change.new_path
+                for change in changes
+                if change.new_path and policy.is_production_path(change.new_path)
+            }
+        )
+    )
     blocks.extend(
         _characterization_blocks(
             characterization, repository_name, base_sha, head_sha, production_paths

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -134,6 +134,7 @@ def _repository(
     add_scenario: bool = False,
     changed_source: bool = False,
     changed_golden: bool = False,
+    deleted_source: bool = False,
     uncovered_high_risk: bool = False,
 ) -> tuple[Path, Path, str, str]:
     repository = tmp_path / "repository"
@@ -156,10 +157,25 @@ def _repository(
     if uncovered_high_risk:
         _write(repository / "src/risk.py", "risk\n")
     scenarios = [_scenario("existing", source_path)]
+    if deleted_source:
+        _write(repository / "src/retained.py", "retained\n")
+        scenarios[0]["covers"] = [source_path, "src/retained.py"]
+        scenarios.append(_scenario("retained", "src/retained.py"))
     _write(repository / characterization.MANIFEST_PATH, _manifest(scenarios))
     _add_scenario_files(repository, "existing", source_path, language, "base\n")
+    if deleted_source:
+        _add_scenario_files(repository, "retained", "src/retained.py", language, "retained\n")
     base_sha = _commit(repository, "base")
     _write(repository / "docs/note.md", "head\n")
+    if deleted_source:
+        (repository / source_path).unlink()
+        extension = "py" if language == "python" else "mjs"
+        (repository / f"tests/characterization/existing.characterization.{extension}").unlink()
+        (repository / "tests/characterization/existing.golden.json").unlink()
+        _write(
+            repository / characterization.MANIFEST_PATH,
+            _manifest([_scenario("retained", "src/retained.py")]),
+        )
     if changed_source:
         _write(repository / source_path, "head\n")
     if changed_golden:
@@ -266,6 +282,18 @@ def test_existing_characterization_passes_with_exact_identity(
     assert result["coverage"]["required_paths"] == [
         "src/sample.py" if language == "python" else "src/sample.ts"
     ]
+
+
+def test_deleted_source_uses_retained_characterization_only(tmp_path: Path) -> None:
+    repository, base_checkout, base_sha, head_sha = _repository(tmp_path, deleted_source=True)
+    base, head = _captures(repository, base_checkout, base_sha, head_sha)
+    paths = _write_artifacts(tmp_path, base, head)
+
+    result = _verify(repository, base_sha, head_sha, *paths)
+
+    assert result["overall_result"] == "PASS"
+    assert result["coverage"]["required_paths"] == []
+    assert [item["id"] for item in result["scenarios"]] == ["retained"]
 
 
 def test_new_scenario_runs_against_same_base_and_head(tmp_path: Path) -> None:

--- a/tests/test_refactor_policy.py
+++ b/tests/test_refactor_policy.py
@@ -293,6 +293,111 @@ def test_missing_owner_authorization_blocks(tmp_path: Path) -> None:
     assert result["policy_blocks"] == ["MISSING_OWNER_AUTHORIZATION"]
 
 
+def test_exact_authorized_python_deletion_uses_base_responsibilities(tmp_path: Path) -> None:
+    repository, base_sha, _ = _repository(tmp_path)
+    _git(repository, "reset", "--hard", base_sha)
+    (repository / "src/sample.py").unlink()
+    head_sha = _commit(repository, "delete")
+    path = "src/sample.py"
+    target = f"{path}::function:calculate:1-2"
+    event = _event(
+        base_sha,
+        head_sha,
+        _authorization(base_sha, head_sha, [path], [target]),
+    )
+
+    first = _verify(repository, event, _characterization(base_sha, head_sha, []))
+    second = _verify(repository, event, _characterization(base_sha, head_sha, []))
+
+    assert first == second
+    assert first["overall_result"] == "PASS"
+    assert first["targets"] == [target]
+    assert first["unbounded_paths"] == []
+
+
+def test_existing_addition_enforcement_is_unchanged(tmp_path: Path) -> None:
+    repository, base_sha, _ = _repository(tmp_path)
+    _git(repository, "reset", "--hard", base_sha)
+    path = "src/added.py"
+    _write(repository / path, "def normalize(value: int) -> int:\n    return value + 1\n")
+    head_sha = _commit(repository, "add")
+    target = f"{path}::function:normalize:1-2"
+    event = _event(
+        base_sha,
+        head_sha,
+        _authorization(base_sha, head_sha, [path], [target]),
+    )
+
+    result = _verify(repository, event, _characterization(base_sha, head_sha, [path]))
+
+    assert result["overall_result"] == "PASS"
+    assert result["targets"] == [target]
+
+
+@pytest.mark.parametrize(
+    ("defect", "code"),
+    [
+        ("missing", "MISSING_OWNER_AUTHORIZATION"),
+        ("head", "STALE_OWNER_AUTHORIZATION"),
+        ("scope", "UNFOCUSED_DIFF_SCOPE"),
+        ("target", "UNVERIFIABLE_BOUNDED_TARGET"),
+        ("sequence", "INVALID_STRANGLER_SEQUENCE"),
+    ],
+)
+def test_python_deletion_authorization_remains_exact(
+    tmp_path: Path, defect: str, code: str
+) -> None:
+    repository, base_sha, _ = _repository(tmp_path)
+    _git(repository, "reset", "--hard", base_sha)
+    (repository / "src/sample.py").unlink()
+    head_sha = _commit(repository, "delete")
+    path = "src/sample.py"
+    target = f"{path}::function:calculate:1-2"
+    body = None
+    if defect != "missing":
+        body = _authorization(
+            base_sha,
+            "f" * 40 if defect == "head" else head_sha,
+            ["docs/outside.md"] if defect == "scope" else [path],
+            [f"{path}::function:wrong:1-2"] if defect == "target" else [target],
+            predecessor_sha="e" * 40 if defect == "sequence" else base_sha,
+        )
+
+    result = _verify(
+        repository,
+        _event(base_sha, head_sha, body),
+        _characterization(base_sha, head_sha, []),
+    )
+
+    assert code in result["policy_blocks"]
+
+
+@pytest.mark.parametrize(
+    ("path", "content"),
+    [("src/data.bin", "data\n"), ("src/broken.py", "def broken(:\n")],
+)
+def test_unbounded_deleted_production_files_fail_closed(
+    tmp_path: Path, path: str, content: str
+) -> None:
+    repository, base_sha, _ = _repository(tmp_path)
+    _git(repository, "reset", "--hard", base_sha)
+    _write(repository / path, content)
+    base_sha = _commit(repository, "unbounded base")
+    (repository / path).unlink()
+    head_sha = _commit(repository, "delete unbounded")
+    event = _event(
+        base_sha,
+        head_sha,
+        _authorization(base_sha, head_sha, [path], [f"{path}::module:{path}:1-1"]),
+    )
+
+    result = _verify(repository, event, _characterization(base_sha, head_sha, []))
+
+    assert result["overall_result"] == "BLOCK"
+    assert result["unbounded_paths"] == [path]
+    assert "UNVERIFIABLE_BOUNDED_TARGET" in result["policy_blocks"]
+
+
 def test_non_production_change_is_not_a_refactor(tmp_path: Path) -> None:
     repository, base_sha, _ = _repository(tmp_path)
     _git(repository, "reset", "--hard", base_sha)


### PR DESCRIPTION
Fixes deterministic handling of production-file deletions without adding a waiver.

Root cause:
- refactor target discovery inspected only head blobs, so deleted production files became unbounded
- characterization required deleted paths and removed scenarios even when retained paths remained covered

Change:
- derive deleted responsibility identities from the immutable base blob
- require exact existing repository/base/head/sequence/scope/target owner authorization
- require retained production behavior to stay covered by surviving characterization scenarios
- keep deleted non-source, empty, or unparseable production files fail-closed

Proof:
- exact TWMN PR #43 replay: characterization PASS; 258 deterministic targets; zero unbounded paths; missing authorization still BLOCKS
- focused deletion/characterization suite: 46 passed
- Python 3.12.13 exact lock
- Ruff lint/format/C901: PASS
- strict mypy: PASS
- Import Linter: 2 contracts kept
- pytest: 253 passed, 2 skipped
- compileall: PASS
- wheel build + fresh exact-lock install + installed CLI help: PASS
- immutable-standard tamper test: PASS
- exact-range whitespace: PASS
- immutable standard SHA-256 unchanged

No TWMN files, comments, PR state, or settings changed. No threshold, scope, contract, waiver, bypass, dependency, or unrelated policy change.