### PR TITLE
Fix deletion-only semantic boundaries

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -11,7 +11,6 @@ responsibility_changes = [
 simplified_functions = [
     "responsibility_spans",
     "GitHubApp._changed_lines",
-    "GitHubApp._deleted_source",
     "GitHubApp._reviewed_source",
     "GitHubApp._source_boundaries",
     "GitHubApp._source_evidence",
@@ -45,9 +44,9 @@ gate_coverage = [
 [[completion_report.claims]]
 id = "claim-deletion-only-boundaries"
 text = "Deletion-only surviving source files emit no fabricated exact-head boundary and retain parser-derived base-blob identities."
-citations = ["src/supportability_gate/github_app.py:493-623", "src/supportability_gate/function_changes.py:263-290"]
+citations = ["src/supportability_gate/github_app.py:493-542", "src/supportability_gate/function_changes.py:263-290"]
 
 [[completion_report.claims]]
 id = "claim-mixed-change-review"
 text = "Mixed changes retain exact-head review boundaries while separately identifying removed base responsibilities."
-citations = ["src/supportability_gate/github_app.py:503-516", "src/supportability_gate/github_app.py:568-601"]
+citations = ["src/supportability_gate/github_app.py:503-542"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,25 +2,25 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "1271a041452a28e005daadb6ce8a442eb607561d"
+base_sha = "841086357261752f815bd6da8cc340ac7307c0e7"
 overall_result = "PASS"
 responsibility_changes = [
-    "Refactor target discovery now owns deterministic base-blob identities for deleted source files.",
-    "Characterization verification now distinguishes deleted paths from retained paths that still require runnable coverage.",
+    "Semantic evidence now separates exact-head review boundaries from deleted responsibilities identified on the immutable base blob.",
+    "Deletion-only surviving files no longer fabricate a whole-module head boundary; mixed changes retain both head review and base deletion evidence.",
 ]
 simplified_functions = [
-    "_target_identities",
-    "verify_refactor",
-    "_definition_blocks",
-    "_coverage_blocks",
-    "verify_evidence",
+    "responsibility_spans",
+    "_source_evidence",
+    "_reviewed_source",
+    "_deleted_source",
+    "_changed_lines",
 ]
 boundary_rationale = [
-    "Existing refactor authorization remains the sole owner of exact repository, commit, sequence, scope, and target approval.",
-    "Existing characterization verification remains the sole owner of retained-behavior proof.",
+    "The GitHub adapter remains the sole owner of authenticated base and head blob evidence.",
+    "The semantic verifier still accepts findings and citations only from exact-head reviewed_sources.",
 ]
 remaining_risks = [
-    "Deleted non-source, empty, or unparseable production files intentionally remain fail-closed as unbounded targets.",
+    "Malformed patches, blob identities, and unparseable source remain fail-closed.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -40,11 +40,11 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-deleted-base-identities"
-text = "Deleted source responsibilities are parsed from the immutable base blob; empty or unparseable deletions remain unbounded."
-citations = ["src/supportability_gate/refactor_policy.py:278-308"]
+id = "claim-deletion-only-boundaries"
+text = "Deletion-only surviving source files emit no fabricated exact-head boundary and retain parser-derived base-blob identities."
+citations = ["src/supportability_gate/github_app.py:493-623", "src/supportability_gate/function_changes.py:263-290"]
 
 [[completion_report.claims]]
-id = "claim-retained-characterization"
-text = "A removed characterization scenario is accepted only when every covered path was deleted or remains covered by a surviving scenario."
-citations = ["src/supportability_gate/characterization.py:201-210"]
+id = "claim-mixed-change-review"
+text = "Mixed changes retain exact-head review boundaries while separately identifying removed base responsibilities."
+citations = ["src/supportability_gate/github_app.py:503-516", "tests/test_github_app.py:433-479"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -10,10 +10,13 @@ responsibility_changes = [
 ]
 simplified_functions = [
     "responsibility_spans",
-    "_source_evidence",
-    "_reviewed_source",
-    "_deleted_source",
-    "_changed_lines",
+    "GitHubApp._changed_lines",
+    "GitHubApp._deleted_source",
+    "GitHubApp._reviewed_source",
+    "GitHubApp._source_boundaries",
+    "GitHubApp._source_evidence",
+    "GitHubApp.evidence_packet",
+    "request_payload",
 ]
 boundary_rationale = [
     "The GitHub adapter remains the sole owner of authenticated base and head blob evidence.",
@@ -47,4 +50,4 @@ citations = ["src/supportability_gate/github_app.py:493-623", "src/supportabilit
 [[completion_report.claims]]
 id = "claim-mixed-change-review"
 text = "Mixed changes retain exact-head review boundaries while separately identifying removed base responsibilities."
-citations = ["src/supportability_gate/github_app.py:503-516", "tests/test_github_app.py:433-479"]
+citations = ["src/supportability_gate/github_app.py:503-516", "src/supportability_gate/github_app.py:568-601"]

--- a/src/supportability_gate/function_changes.py
+++ b/src/supportability_gate/function_changes.py
@@ -286,9 +286,7 @@ def responsibility_spans(
         for span in touched
     ]
     covered = {line for span in touched for line in range(span.start_line, span.end_line + 1)}
-    module_spans = (
-        _line_spans(changed_lines - covered) if changed_lines else [(1, len(content.splitlines()))]
-    )
+    module_spans = _line_spans(changed_lines - covered)
     boundaries.extend(ResponsibilitySpan(start, end, "module", path) for start, end in module_spans)
     return tuple(boundaries)
 

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -507,11 +507,37 @@ class GitHubApp:
             for item in production
             if (source := self._reviewed_source(repository, item, token)) is not None
         ]
-        deleted = [
-            source
-            for item in production
-            if (source := self._deleted_source(repository, base_sha, item, token)) is not None
-        ]
+        deleted = []
+        for item in production:
+            patch = item.get("patch")
+            if not isinstance(patch, str) or not patch:
+                raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
+            if not self._changed_lines(patch, "-"):
+                continue
+            path = item.get("previous_filename", item["filename"])
+            if not isinstance(path, str):
+                raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+            result = self._request(
+                "GET",
+                f"/repos/{repository}/contents/{urllib.parse.quote(path)}"
+                f"?ref={urllib.parse.quote(base_sha)}",
+                token,
+            )
+            blob_sha = result.get("sha") if isinstance(result, dict) else None
+            if not isinstance(blob_sha, str) or not SHA_PATTERN.fullmatch(blob_sha):
+                raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+            content = self._blob_content(repository, blob_sha, token)
+            boundaries = self._source_boundaries(path, content, patch, "-")
+            if not boundaries:
+                raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
+            deleted.append(
+                {
+                    "blob_sha": blob_sha,
+                    "boundaries": boundaries,
+                    "line_count": len(content.splitlines()),
+                    "path": path,
+                }
+            )
         self._validate_review_size(sources)
         return sources, deleted
 
@@ -562,41 +588,6 @@ class GitHubApp:
             ],
             "line_count": len(content.splitlines()),
             "lines": self._source_excerpt(content, boundaries),
-            "path": path,
-        }
-
-    def _deleted_source(
-        self,
-        repository: str,
-        base_sha: str,
-        item: dict[str, Any],
-        token: str,
-    ) -> dict[str, Any] | None:
-        patch = item.get("patch")
-        if not isinstance(patch, str) or not patch:
-            raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
-        if not self._changed_lines(patch, "-"):
-            return None
-        path = item.get("previous_filename", item["filename"])
-        if not isinstance(path, str):
-            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
-        result = self._request(
-            "GET",
-            f"/repos/{repository}/contents/{urllib.parse.quote(path)}"
-            f"?ref={urllib.parse.quote(base_sha)}",
-            token,
-        )
-        blob_sha = result.get("sha") if isinstance(result, dict) else None
-        if not isinstance(blob_sha, str) or not SHA_PATTERN.fullmatch(blob_sha):
-            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
-        content = self._blob_content(repository, blob_sha, token)
-        boundaries = self._source_boundaries(path, content, patch, "-")
-        if not boundaries:
-            raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
-        return {
-            "blob_sha": blob_sha,
-            "boundaries": boundaries,
-            "line_count": len(content.splitlines()),
             "path": path,
         }
 

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -38,7 +38,7 @@ from supportability_gate.semantic_contract import (
 API = "https://api.github.com"
 CHECK_NAME = "Supportability Semantic Review"
 REVIEWED_SUFFIXES = frozenset({".py", ".ts", ".tsx"})
-HUNK_PATTERN = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+HUNK_PATTERN = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 SourceBoundary = dict[str, int | str]
 HANDOFF_WORKFLOW_PATH = ".github/workflows/organization-required.yml"
 MAX_HANDOFF_BYTES = 5_000_000
@@ -212,7 +212,9 @@ class GitHubApp:
         if not isinstance(number, int):
             raise SemanticReviewError("MALFORMED_PULL_REQUEST")
         _, files = self._comparison_evidence(repository, str(base_sha), str(head_sha), token)
-        reviewed_sources = self._reviewed_sources(repository, str(base_sha), files, token)
+        reviewed_sources, deleted_sources = self._source_evidence(
+            repository, str(base_sha), files, token
+        )
         review_diff = self._review_diff(files)
         comments = self.issue_comments(repository, number, token)
         return EvidencePacket(
@@ -222,6 +224,7 @@ class GitHubApp:
             self.app_id,
             {
                 "diff": review_diff,
+                "deleted_sources": deleted_sources,
                 "pull_request": number,
                 "refactor_context": self._refactor_context(pull, files, comments),
                 "reviewed_sources": reviewed_sources,
@@ -487,23 +490,30 @@ class GitHubApp:
         ):
             raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
 
-    def _reviewed_sources(
+    def _source_evidence(
         self,
         repository: str,
         base_sha: str,
         files: tuple[dict[str, Any], ...],
         token: str,
-    ) -> list[dict[str, Any]]:
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         candidates = self._source_candidates(files)
         if not candidates:
-            return []
+            return [], []
         production_paths = self._production_paths(repository, base_sha, token)
+        production = self._production_candidates(candidates, production_paths)
         sources = [
-            self._reviewed_source(repository, item, token)
-            for item in self._production_candidates(candidates, production_paths)
+            source
+            for item in production
+            if (source := self._reviewed_source(repository, item, token)) is not None
+        ]
+        deleted = [
+            source
+            for item in production
+            if (source := self._deleted_source(repository, base_sha, item, token)) is not None
         ]
         self._validate_review_size(sources)
-        return sources
+        return sources, deleted
 
     def _production_candidates(
         self, candidates: tuple[dict[str, Any], ...], production_paths: tuple[str, ...]
@@ -531,7 +541,9 @@ class GitHubApp:
                 candidates.append(item)
         return tuple(sorted(candidates, key=lambda item: str(item["filename"])))
 
-    def _reviewed_source(self, repository: str, item: dict[str, Any], token: str) -> dict[str, Any]:
+    def _reviewed_source(
+        self, repository: str, item: dict[str, Any], token: str
+    ) -> dict[str, Any] | None:
         path, blob_sha, patch = item["filename"], item.get("sha"), item.get("patch")
         if not isinstance(blob_sha, str) or not SHA_PATTERN.fullmatch(blob_sha):
             raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
@@ -539,6 +551,8 @@ class GitHubApp:
             raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
         content = self._blob_content(repository, blob_sha, token)
         boundaries = self._source_boundaries(path, content, patch)
+        if not boundaries:
+            return None
         return {
             "boundaries": boundaries,
             "blob_sha": blob_sha,
@@ -551,9 +565,47 @@ class GitHubApp:
             "path": path,
         }
 
-    def _source_boundaries(self, path: str, content: str, patch: str) -> list[SourceBoundary]:
+    def _deleted_source(
+        self,
+        repository: str,
+        base_sha: str,
+        item: dict[str, Any],
+        token: str,
+    ) -> dict[str, Any] | None:
+        patch = item.get("patch")
+        if not isinstance(patch, str) or not patch:
+            raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
+        if not self._changed_lines(patch, "-"):
+            return None
+        path = item.get("previous_filename", item["filename"])
+        if not isinstance(path, str):
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        result = self._request(
+            "GET",
+            f"/repos/{repository}/contents/{urllib.parse.quote(path)}"
+            f"?ref={urllib.parse.quote(base_sha)}",
+            token,
+        )
+        blob_sha = result.get("sha") if isinstance(result, dict) else None
+        if not isinstance(blob_sha, str) or not SHA_PATTERN.fullmatch(blob_sha):
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        content = self._blob_content(repository, blob_sha, token)
+        boundaries = self._source_boundaries(path, content, patch, "-")
+        if not boundaries:
+            raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
+        return {
+            "blob_sha": blob_sha,
+            "boundaries": boundaries,
+            "line_count": len(content.splitlines()),
+            "path": path,
+        }
+
+    def _source_boundaries(
+        self, path: str, content: str, patch: str, side: str = "+"
+    ) -> list[SourceBoundary]:
+        changed_lines = self._changed_lines(patch, side)
         try:
-            spans = responsibility_spans(path, content.encode(), self._changed_lines(patch))
+            spans = responsibility_spans(path, content.encode(), changed_lines)
         except PythonSourceError as error:
             raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE") from error
         boundaries: list[SourceBoundary] = [
@@ -565,22 +617,22 @@ class GitHubApp:
             }
             for span in spans
         ]
-        if not boundaries:
-            raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
         return boundaries
 
-    def _changed_lines(self, patch: str) -> set[int]:
+    def _changed_lines(self, patch: str, side: str = "+") -> set[int]:
         changed: set[int] = set()
-        head_line: int | None = None
+        line_number: int | None = None
+        group = 3 if side == "+" else 1
+        opposite = "-" if side == "+" else "+"
         for line in patch.splitlines():
             match = HUNK_PATTERN.match(line)
             if match:
-                head_line = int(match.group(1))
-            elif head_line is not None and line.startswith("+"):
-                changed.add(head_line)
-                head_line += 1
-            elif head_line is not None and not line.startswith("-"):
-                head_line += 1
+                line_number = int(match.group(group))
+            elif line_number is not None:
+                if line.startswith(side):
+                    changed.add(line_number)
+                if not line.startswith(opposite) and not line.startswith("\\"):
+                    line_number += 1
         return changed
 
     def _source_excerpt(

--- a/src/supportability_gate/semantic_contract.py
+++ b/src/supportability_gate/semantic_contract.py
@@ -289,10 +289,12 @@ def request_payload(packet: EvidencePacket) -> dict[str, Any]:
         "and certainty; otherwise BLOCK or UNCERTAIN. Copy "
         "every binding exactly. Trusted imports are only imports listed under reviewed_sources; "
         "copy each into architecture_citations and return an empty list when none are listed. "
-        "reviewed_paths binds every changed production path. Explain the "
+        "reviewed_paths binds every changed production path with added or modified head "
+        "responsibilities. deleted_sources binds removed responsibilities to exact base blobs; "
+        "never fabricate head boundaries or findings from those base-only identities. Explain the "
         "resulting dependency direction."
-        " Removed files have no exact-head boundary and are intentionally absent from reviewed_sources; "
-        "do not block solely because a removed path is absent."
+        " Removed files and deletion-only surviving files have no exact-head boundary and are "
+        "intentionally absent from reviewed_sources; do not block solely because such a path is absent."
     )
     bindings = {
         "app_id": packet.app_id,

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -381,6 +381,102 @@ def test_frontend_component_boundary_uses_complete_parser_span() -> None:
     assert [item["line"] for item in app._source_excerpt(source, boundaries)] == [1, 2, 3, 4]
 
 
+def test_deletion_only_surviving_source_uses_base_identity_without_head_boundary() -> None:
+    base = b"def keep():\n    return 1\n\ndef obsolete():\n    return 2\n"
+    head = b"def keep():\n    return 1\n"
+    base_blob, head_blob, contract_blob = map(_blob_sha, (base, head, CONTRACT))
+    patch = "@@ -1,5 +1,2 @@\n def keep():\n     return 1\n-\n-def obsolete():\n-    return 2"
+
+    def open_request(request: Any, **kwargs: object) -> _Reply:
+        if "/issues/3/comments" in request.full_url:
+            return _Reply([])
+        if "/contents/.supportability.toml" in request.full_url:
+            return _Reply({"sha": contract_blob})
+        if "/contents/src/a.py?ref=" in request.full_url:
+            return _Reply({"sha": base_blob})
+        for content in (CONTRACT, base, head):
+            if request.full_url.endswith(f"/git/blobs/{_blob_sha(content)}"):
+                return _Reply(_blob_payload(content))
+        if request.get_header("Accept") == "application/vnd.github.v3.diff":
+            return _RawReply(f"diff --git a/src/a.py b/src/a.py\n{patch}")
+        return _Reply(
+            {
+                "files": [
+                    {
+                        "filename": "src/a.py",
+                        "patch": patch,
+                        "sha": head_blob,
+                        "status": "modified",
+                    }
+                ]
+            }
+        )
+
+    app = GitHubApp(42, 7, b"unused", opener=open_request)
+    pull = {"number": 3, "base": {"sha": "a" * 40}, "head": {"sha": "b" * 40}}
+    packet = app.evidence_packet("mbh-solutions/supportability-gate", pull, "token")
+
+    assert packet.evidence["reviewed_sources"] == []
+    assert packet.evidence["deleted_sources"] == [
+        {
+            "blob_sha": base_blob,
+            "boundaries": [
+                {"end_line": 5, "kind": "function", "name": "obsolete", "start_line": 4},
+                {"end_line": 3, "kind": "module", "name": "src/a.py", "start_line": 3},
+            ],
+            "line_count": 5,
+            "path": "src/a.py",
+        }
+    ]
+
+
+def test_mixed_source_change_reviews_head_and_identifies_deleted_base_responsibilities() -> None:
+    base = b"def keep():\n    return 1\n\ndef obsolete():\n    return 2\n"
+    head = b"def keep():\n    return 3\n"
+    base_blob, head_blob, contract_blob = map(_blob_sha, (base, head, CONTRACT))
+    patch = "@@ -1,5 +1,2 @@\n def keep():\n-    return 1\n-\n-def obsolete():\n-    return 2\n+    return 3"
+
+    def open_request(request: Any, **kwargs: object) -> _Reply:
+        if "/issues/3/comments" in request.full_url:
+            return _Reply([])
+        if "/contents/.supportability.toml" in request.full_url:
+            return _Reply({"sha": contract_blob})
+        if "/contents/src/a.py?ref=" in request.full_url:
+            return _Reply({"sha": base_blob})
+        for content in (CONTRACT, base, head):
+            if request.full_url.endswith(f"/git/blobs/{_blob_sha(content)}"):
+                return _Reply(_blob_payload(content))
+        if request.get_header("Accept") == "application/vnd.github.v3.diff":
+            return _RawReply(f"diff --git a/src/a.py b/src/a.py\n{patch}")
+        return _Reply(
+            {
+                "files": [
+                    {
+                        "filename": "src/a.py",
+                        "patch": patch,
+                        "sha": head_blob,
+                        "status": "modified",
+                    }
+                ]
+            }
+        )
+
+    app = GitHubApp(42, 7, b"unused", opener=open_request)
+    pull = {"number": 3, "base": {"sha": "a" * 40}, "head": {"sha": "b" * 40}}
+    packet = app.evidence_packet("mbh-solutions/supportability-gate", pull, "token")
+
+    assert packet.evidence["reviewed_sources"][0]["boundaries"] == [
+        {"end_line": 2, "kind": "function", "name": "keep", "start_line": 1}
+    ]
+    deleted = packet.evidence["deleted_sources"][0]
+    assert deleted["blob_sha"] == base_blob
+    assert deleted["boundaries"] == [
+        {"end_line": 2, "kind": "function", "name": "keep", "start_line": 1},
+        {"end_line": 5, "kind": "function", "name": "obsolete", "start_line": 4},
+        {"end_line": 3, "kind": "module", "name": "src/a.py", "start_line": 3},
+    ]
+
+
 @pytest.mark.parametrize(
     "diff",
     [


### PR DESCRIPTION
## Change
- keep deletion-only surviving files out of exact-head semantic boundaries
- bind removed responsibilities to the immutable base blob
- preserve exact-head review for mixed additions/modifications
- leave completion-claim citation validation unchanged

## Proof
- .venv Python 3.12.13
- 81 focused GitHub evidence and semantic-review tests passed
- Ruff, C901, mypy strict, import contracts, compileall, and diff whitespace passed
- immutable Standard SHA-256 unchanged

## Boundary
Supportability Gate only. No TWMN mutation.