### PR TITLE
Use Node 24-native GitHub Actions

### DIFF
--- a/.github/workflows/organization-required.yml
+++ b/.github/workflows/organization-required.yml
@@ -49,9 +49,10 @@ jobs:
           python-version: "3.12"
 
       - name: Set up Node.js 24
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "24"
+          package-manager-cache: false
 
       - name: Install exact characterization dependencies
         run: python -m pip install --disable-pip-version-check --require-hashes -r gate/requirements-dev.lock
@@ -81,7 +82,7 @@ jobs:
 
       - name: Upload authenticated base behavior
         id: upload
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: characterization-base-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/base/characterization.json
@@ -126,9 +127,10 @@ jobs:
           python-version: "3.12"
 
       - name: Set up Node.js 24
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "24"
+          package-manager-cache: false
 
       - name: Install exact characterization dependencies
         run: python -m pip install --disable-pip-version-check --require-hashes -r gate/requirements-dev.lock
@@ -158,7 +160,7 @@ jobs:
 
       - name: Upload authenticated head behavior
         id: upload
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: characterization-head-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/head/characterization.json
@@ -195,9 +197,10 @@ jobs:
           python-version: "3.12"
 
       - name: Set up Node.js 24
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "24"
+          package-manager-cache: false
 
       - name: Install exact quality runner dependencies
         run: python -m pip install --disable-pip-version-check --require-hashes -r gate/requirements-dev.lock
@@ -227,7 +230,7 @@ jobs:
 
       - name: Upload authenticated quality evidence
         id: upload
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: quality-profile-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/quality/quality-gates.json
@@ -267,19 +270,19 @@ jobs:
           "$RUNNER_TEMP/gate-venv/bin/python" -m pip install --disable-pip-version-check --no-build-isolation --no-deps ./gate
 
       - name: Download authenticated base behavior
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: characterization-base-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/base
 
       - name: Download authenticated head behavior
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: characterization-head-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/head
 
       - name: Download authenticated quality evidence
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: quality-profile-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/quality
@@ -374,7 +377,7 @@ jobs:
 
       - name: Upload authoritative supportability evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: supportability-evidence-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/evidence


### PR DESCRIPTION
## Change
- replace Node 20 action pins with first Node 24-native releases
- keep `node-version: "24"`
- disable setup-node automatic package-manager caching to preserve prior behavior

## Proof
- all pinned first-party action metadata resolves to `runs.using: node24`
- Python 3.12.13 exact-lock source proof passed
- 259 tests passed, 2 skipped
- fresh wheel install and installed CLI smoke passed
- immutable standard hash unchanged

Closes #63