### PR TITLE
S01: bind complete review state into semantic evidence

### DIFF
--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -51,6 +51,13 @@
       ],
       "id": "m10-review-handoff",
       "kind": "regression"
+    },
+    {
+      "covers": [
+        "src/supportability_gate/review_state.py"
+      ],
+      "id": "s01-review-state",
+      "kind": "regression"
     }
   ],
   "schema_version": "1.0"

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -7,6 +7,7 @@ overall_result = "PASS"
 responsibility_changes = [
     "GitHubApp now acquires every authenticated review, review thread, inline comment, and top-level comment page before evidence assembly.",
     "review_state owns byte-stable normalization and identity cross-checks; semantic_cli owns deterministic unresolved-thread blocking before replay or model review.",
+    "GitHubApp re-fetches commit and normalized review state before replay or publication and rejects any changed snapshot as stale evidence.",
 ]
 simplified_functions = [
     "GitHubApp._graphql_connection",
@@ -14,6 +15,7 @@ simplified_functions = [
     "GitHubApp._review_state",
     "GitHubApp._review_threads",
     "GitHubApp._thread_comments",
+    "GitHubApp.assert_current",
     "GitHubApp.evidence_packet",
     "GitHubApp.issue_comments",
     "_actor",
@@ -60,9 +62,14 @@ gate_coverage = [
 [[completion_report.claims]]
 id = "claim-complete-authenticated-review-acquisition"
 text = "Authenticated REST and GraphQL pagination acquires all reviews, review threads including nested comments, inline comments, and top-level comments before normalization."
-citations = ["src/supportability_gate/github_app.py:538-646"]
+citations = ["src/supportability_gate/github_app.py:546-654"]
 
 [[completion_report.claims]]
 id = "claim-normalized-unresolved-thread-block"
 text = "Review state is identity-cross-checked and byte-stably normalized, then every unresolved review thread blocks before replay or model review."
 citations = ["src/supportability_gate/review_state.py:195-222", "src/supportability_gate/semantic_cli.py:51-78"]
+
+[[completion_report.claims]]
+id = "claim-review-state-currentness"
+text = "Commit and normalized review state are re-fetched and compared before replay or final check publication, and any change invalidates the captured evidence."
+citations = ["src/supportability_gate/github_app.py:181-198", "src/supportability_gate/semantic_cli.py:75-100"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -6,7 +6,7 @@ base_sha = "0c4c2419d6da486a97acb8e73cac5e91430d2c7b"
 overall_result = "PASS"
 responsibility_changes = [
     "GitHubApp now acquires every authenticated review, review thread, inline comment, and top-level comment page before evidence assembly.",
-    "review_state owns byte-stable normalization, identity cross-checks, and deterministic unresolved-thread blocking before replay or model review.",
+    "review_state owns byte-stable normalization and identity cross-checks; semantic_cli owns deterministic unresolved-thread blocking before replay or model review.",
 ]
 simplified_functions = [
     "GitHubApp._graphql_connection",
@@ -35,7 +35,7 @@ simplified_functions = [
 ]
 boundary_rationale = [
     "github_app remains the authenticated GitHub transport and pagination boundary.",
-    "review_state is the single normalization and unresolved-thread policy boundary consumed by semantic_cli.",
+    "review_state owns normalization only; semantic_cli owns orchestration policy including unresolved-thread blocking.",
 ]
 remaining_risks = [
     "GitHub response schema changes fail closed as malformed or incomplete review state until adapter support is updated.",
@@ -65,4 +65,4 @@ citations = ["src/supportability_gate/github_app.py:538-646"]
 [[completion_report.claims]]
 id = "claim-normalized-unresolved-thread-block"
 text = "Review state is identity-cross-checked and byte-stably normalized, then every unresolved review thread blocks before replay or model review."
-citations = ["src/supportability_gate/review_state.py:195-239", "src/supportability_gate/semantic_cli.py:52-62"]
+citations = ["src/supportability_gate/review_state.py:195-222", "src/supportability_gate/semantic_cli.py:51-78"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,29 +2,43 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "7397306581026e1e83d20186d49a31c5b2c59461"
+base_sha = "0c4c2419d6da486a97acb8e73cac5e91430d2c7b"
 overall_result = "PASS"
 responsibility_changes = [
-    "Completion-report citations now use a dedicated exact-head completion_sources channel while semantic ownership remains bound to reviewed_sources.",
-    "Deletion-only surviving production paths can contribute only cited retained head lines when deterministic base deletion evidence and exact changed-path status both authorize the path.",
+    "GitHubApp now acquires every authenticated review, review thread, inline comment, and top-level comment page before evidence assembly.",
+    "review_state owns byte-stable normalization, identity cross-checks, and deterministic unresolved-thread blocking before replay or model review.",
 ]
 simplified_functions = [
-    "GitHubApp._completion_source",
-    "GitHubApp._completion_sources",
-    "GitHubApp.m10_evidence_packet",
+    "GitHubApp._graphql_connection",
+    "GitHubApp._rest_pages",
+    "GitHubApp._review_state",
+    "GitHubApp._review_threads",
+    "GitHubApp._thread_comments",
+    "GitHubApp.evidence_packet",
+    "GitHubApp.issue_comments",
+    "_actor",
+    "_app",
+    "_body_sha256",
+    "_indexed",
+    "_inline_comment",
+    "_integer",
+    "_malformed",
+    "_optional_integer",
+    "_optional_text",
     "_review",
-    "_trusted_verdict",
-    "completion_citations",
-    "deterministic_completion_blocks",
-    "evaluate_completion_report",
-    "request_payload",
+    "_review",
+    "_text",
+    "_threads",
+    "_top_comment",
+    "normalize_review_state",
+    "unresolved_review_blocks",
 ]
 boundary_rationale = [
-    "The GitHub adapter remains the sole owner of authenticated changed-path and exact-head blob acquisition.",
-    "Completion citation resolution is separate from semantic ownership, import, boundary, and reviewed-path evidence.",
+    "github_app remains the authenticated GitHub transport and pagination boundary.",
+    "review_state is the single normalization and unresolved-thread policy boundary consumed by semantic_cli.",
 ]
 remaining_risks = [
-    "Malformed, removed, non-source, untouched, oversized, or out-of-range citation targets remain unresolved or technically fail-closed.",
+    "GitHub response schema changes fail closed as malformed or incomplete review state until adapter support is updated.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -44,11 +58,11 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-deletion-only-completion-source"
-text = "Deletion-only surviving production paths contribute only cited exact-head lines after changed-path, source-suffix, base-deletion-identity, blob-hash, range, and size checks."
-citations = ["src/supportability_gate/github_app.py:407-489"]
+id = "claim-complete-authenticated-review-acquisition"
+text = "Authenticated REST and GraphQL pagination acquires all reviews, review threads including nested comments, inline comments, and top-level comments before normalization."
+citations = ["src/supportability_gate/github_app.py:538-646"]
 
 [[completion_report.claims]]
-id = "claim-separate-evidence-channels"
-text = "Completion claims resolve against completion_sources while ownership, imports, boundaries, and reviewed paths remain bound to reviewed_sources."
-citations = ["src/supportability_gate/handoff_policy.py:259-309", "src/supportability_gate/semantic_contract.py:280-300", "src/supportability_gate/semantic_review.py:366-375"]
+id = "claim-normalized-unresolved-thread-block"
+text = "Review state is identity-cross-checked and byte-stably normalized, then every unresolved review thread blocks before replay or model review."
+citations = ["src/supportability_gate/review_state.py:195-239", "src/supportability_gate/semantic_cli.py:52-62"]

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -25,6 +25,7 @@ reviewed_paths = [
     "src/supportability_gate/quality_runner.py",
     "src/supportability_gate/reporting.py",
     "src/supportability_gate/refactor_policy.py",
+    "src/supportability_gate/review_state.py",
     "src/supportability_gate/semantic_cli.py",
     "src/supportability_gate/semantic_contract.py",
     "src/supportability_gate/semantic_review.py",
@@ -48,6 +49,12 @@ naming = "Quality-profile names directly describe fixed commands, hosted executi
 cohesion = "The quality-profile module owns approved policy specification and verification; the quality-runner module owns concrete plan and tool-config materialization; the disposable hosted job owns execution."
 intended_behavior = "Existing enforcement remains; Python and TypeScript quality claims now block every missing, failed, unexecuted, uncovered, excluded, weakened, narrowed, moved, malformed, stale, or non-hosted condition."
 reviewability = "Focused fixtures cover both fixed profiles, all required failure classes, exact identities and vectors, workstation refusal, and byte-identical evidence."
+
+[[module_boundaries]]
+path = "src/supportability_gate/review_state.py"
+owner_path = "src/supportability_gate/review_state.py"
+basis = "responsibility"
+justification = "Owns normalization and cross-checking of authenticated GitHub review snapshots plus deterministic unresolved-thread blocks, but not API transport, model evaluation, check publication, or event invalidation."
 
 [[module_boundaries]]
 path = "src/supportability_gate/quality_profile.py"

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -54,7 +54,7 @@ reviewability = "Focused fixtures cover both fixed profiles, all required failur
 path = "src/supportability_gate/review_state.py"
 owner_path = "src/supportability_gate/review_state.py"
 basis = "responsibility"
-justification = "Owns normalization and cross-checking of authenticated GitHub review snapshots plus deterministic unresolved-thread blocks, but not API transport, model evaluation, check publication, or event invalidation."
+justification = "Owns normalization and cross-checking of authenticated GitHub review snapshots, but not API transport, unresolved-thread policy, model evaluation, check publication, or event invalidation."
 
 [[module_boundaries]]
 path = "src/supportability_gate/quality_profile.py"

--- a/docs/product_completion_contract.md
+++ b/docs/product_completion_contract.md
@@ -641,7 +641,8 @@ workflow, check-run, ruleset, or GitHub state supports them.
     retrieves every review, review thread, inline review comment, and retained top-level pull-request
     comment with complete REST and GraphQL pagination. Authenticated actor and GitHub App identity,
     commit, timestamps, body SHA-256, resolution, outdated, and location state bind into canonical
-    `EvidencePacket` bytes.
+    `EvidencePacket` bytes. Commit and normalized review state are re-fetched and compared before
+    replay or publication, so a review-state change invalidates the captured packet.
   - Exact authenticated TWMN PR #52 snapshot at head
     `e805c68850c7a669e9b385cb6dbfe41ca11f94a5` contained 4 reviews, 5 threads, 6 inline
     comments, and 10 top-level comments. Two unresolved threads produced deterministic pre-model

--- a/docs/product_completion_contract.md
+++ b/docs/product_completion_contract.md
@@ -631,14 +631,37 @@ workflow, check-run, ruleset, or GitHub state supports them.
     Dependency Graph workflow ID `311554933` remained active and independent.
 - Remaining work: None. All five frozen milestones are complete; stop and await owner authorization.
 
+## Critical maintenance — Project #6
+
+- S01 Review-state evidence contract: `COMPLETE` upon protected merge of PR #70; Evidence
+  `Complete`; Scope `On scope`; Stop confirmed `Yes`.
+- Authority: owner-authorized issue #66 under Project #6; parent #65 remains tracking-only.
+- Completion evidence:
+  - Implementation commit `9a0816d08dc034b91eb6b6912351442464874916` on protected PR #70
+    retrieves every review, review thread, inline review comment, and retained top-level pull-request
+    comment with complete REST and GraphQL pagination. Authenticated actor and GitHub App identity,
+    commit, timestamps, body SHA-256, resolution, outdated, and location state bind into canonical
+    `EvidencePacket` bytes.
+  - Exact authenticated TWMN PR #52 snapshot at head
+    `e805c68850c7a669e9b385cb6dbfe41ca11f94a5` contained 4 reviews, 5 threads, 6 inline
+    comments, and 10 top-level comments. Two unresolved threads produced deterministic pre-model
+    BLOCK; normalized packet SHA-256 was
+    `a0dc6cda651fbd0b8585c4de8a5588103ca48802699416478704e53d601e0e75`.
+  - Targeted review-state, GitHub App, and semantic-review suite passed: 91 tests. Pagination beyond
+    100, malformed/incomplete pages, API failure, conflicting identity, App-text spoofing,
+    add/edit/delete/resolve/reopen digest changes, byte determinism, and exact-evidence replay are
+    directly covered.
+- Remaining work: None for S01 after protected PR #70 merge and Project #6 closure readback. S02
+  through S04 remain separately gated and unauthorized.
+
 ## Product status
 
 ```text
 Historical deterministic gate deployable to target repositories: YES
 Full Supportability Standard enforcement deployable to target repositories: YES
 Full Supportability Standard runtime: YES
-Current authorized work: None — Enforcement Milestone 11 complete; stop
-Next milestone authorized: NO — no work is authorized after Enforcement Milestone 11
+Current authorized work: Project #6 S01 only — complete upon protected PR #70 merge; stop
+Next milestone authorized: NO — S02 is not authorized
 ```
 
 ## Milestone transition rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ type = "layers"
 layers = [
     "supportability_gate.semantic_cli",
     "supportability_gate.github_app | supportability_gate.responses_transport",
+    "supportability_gate.review_state",
     "supportability_gate.architecture_policy",
     "supportability_gate.semantic_review | supportability_gate.function_changes",
     "supportability_gate.semantic_contract | supportability_gate.contract",

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -29,6 +29,7 @@ from supportability_gate.handoff_policy import (
     completion_citations,
     parse_completion_report,
 )
+from supportability_gate.review_state import normalize_review_state
 from supportability_gate.semantic_contract import (
     SHA_PATTERN,
     TRUSTED_OWNER_ID,
@@ -43,6 +44,21 @@ HUNK_PATTERN = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 SourceBoundary = dict[str, int | str]
 HANDOFF_WORKFLOW_PATH = ".github/workflows/organization-required.yml"
 MAX_HANDOFF_BYTES = 5_000_000
+REVIEW_THREADS_QUERY = """
+query($owner:String!,$name:String!,$number:Int!,$cursor:String){
+  repository(owner:$owner,name:$name){pullRequest(number:$number){
+    reviewThreads(first:100,after:$cursor){nodes{
+      id isResolved isOutdated comments(first:100){nodes{id databaseId}
+      pageInfo{hasNextPage endCursor}}
+    }pageInfo{hasNextPage endCursor}}
+  }}
+}
+"""
+THREAD_COMMENTS_QUERY = """
+query($thread:ID!,$cursor:String){node(id:$thread){... on PullRequestReviewThread{
+  comments(first:100,after:$cursor){nodes{id databaseId}pageInfo{hasNextPage endCursor}}
+}}}
+"""
 
 
 class _NoAuthRedirect(urllib.request.HTTPRedirectHandler):
@@ -218,6 +234,7 @@ class GitHubApp:
         )
         review_diff = self._review_diff(files)
         comments = self.issue_comments(repository, number, token)
+        review_state = self._review_state(repository, number, comments, token)
         return EvidencePacket(
             repository,
             str(base_sha),
@@ -228,6 +245,7 @@ class GitHubApp:
                 "deleted_sources": deleted_sources,
                 "pull_request": number,
                 "refactor_context": self._refactor_context(pull, files, comments),
+                "review_state": review_state,
                 "reviewed_sources": reviewed_sources,
             },
         )
@@ -521,16 +539,111 @@ class GitHubApp:
         self, repository: str, pull_number: int, token: str
     ) -> tuple[dict[str, Any], ...]:
         """Return authenticated issue comments used for owner authorization."""
-        result = self._request(
-            "GET", f"/repos/{repository}/issues/{pull_number}/comments?per_page=100", token
+        return self._rest_pages(
+            f"/repos/{repository}/issues/{pull_number}/comments?per_page=100", token
         )
-        if (
-            not isinstance(result, list)
-            or len(result) >= 100
-            or any(not isinstance(item, dict) for item in result)
-        ):
-            raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
-        return tuple(result)
+
+    def _rest_pages(self, path: str, token: str) -> tuple[dict[str, Any], ...]:
+        rows: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            result = self._request("GET", f"{path}&page={page}", token)
+            if not isinstance(result, list) or any(not isinstance(item, dict) for item in result):
+                raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+            rows.extend(result)
+            if len(result) < 100:
+                return tuple(rows)
+            page += 1
+
+    def _graphql_connection(
+        self, result: Any, keys: tuple[str, ...]
+    ) -> tuple[list[dict[str, Any]], bool, str | None]:
+        if not isinstance(result, dict) or result.get("errors"):
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        value: Any = result
+        for key in keys:
+            value = value.get(key) if isinstance(value, dict) else None
+        if not isinstance(value, dict):
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        nodes, page_info = value.get("nodes"), value.get("pageInfo")
+        if not isinstance(nodes, list) or any(not isinstance(node, dict) for node in nodes):
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        if not isinstance(page_info, dict) or not isinstance(page_info.get("hasNextPage"), bool):
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        cursor = page_info.get("endCursor")
+        if page_info["hasNextPage"] and (not isinstance(cursor, str) or not cursor):
+            raise SemanticReviewError("INCOMPLETE_REVIEW_STATE")
+        if cursor is not None and not isinstance(cursor, str):
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        return nodes, page_info["hasNextPage"], cursor
+
+    def _thread_comments(
+        self,
+        thread: dict[str, Any],
+        token: str,
+    ) -> list[dict[str, Any]]:
+        nodes, has_next, cursor = self._graphql_connection(thread, ("comments",))
+        while has_next:
+            result = self._request(
+                "POST",
+                "/graphql",
+                token,
+                {
+                    "query": THREAD_COMMENTS_QUERY,
+                    "variables": {"thread": thread["id"], "cursor": cursor},
+                },
+            )
+            page, has_next, cursor = self._graphql_connection(result, ("data", "node", "comments"))
+            nodes.extend(page)
+        return nodes
+
+    def _review_threads(
+        self, repository: str, pull_number: int, token: str
+    ) -> tuple[dict[str, Any], ...]:
+        owner, name = repository.split("/", 1)
+        cursor: str | None = None
+        threads: list[dict[str, Any]] = []
+        while True:
+            result = self._request(
+                "POST",
+                "/graphql",
+                token,
+                {
+                    "query": REVIEW_THREADS_QUERY,
+                    "variables": {
+                        "owner": owner,
+                        "name": name,
+                        "number": pull_number,
+                        "cursor": cursor,
+                    },
+                },
+            )
+            page, has_next, cursor = self._graphql_connection(
+                result, ("data", "repository", "pullRequest", "reviewThreads")
+            )
+            for thread in page:
+                thread = dict(thread)
+                thread["comments"] = self._thread_comments(thread, token)
+                threads.append(thread)
+            if not has_next:
+                return tuple(threads)
+
+    def _review_state(
+        self,
+        repository: str,
+        pull_number: int,
+        top_comments: tuple[dict[str, Any], ...],
+        token: str,
+    ) -> dict[str, object]:
+        reviews = self._rest_pages(
+            f"/repos/{repository}/pulls/{pull_number}/reviews?per_page=100", token
+        )
+        inline = self._rest_pages(
+            f"/repos/{repository}/pulls/{pull_number}/comments?per_page=100", token
+        )
+        return normalize_review_state(
+            reviews, self._review_threads(repository, pull_number, token), inline, top_comments
+        )
 
     def _comparison_evidence(
         self, repository: str, base_sha: str, head_sha: str, token: str

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -179,7 +179,7 @@ class GitHubApp:
         return tuple(result)
 
     def assert_current(self, packet: EvidencePacket, pull_number: int, token: str) -> None:
-        """Reject evidence if the pull request moved before publication."""
+        """Reject evidence if pull-request commits or review state changed."""
         pull = self._request("GET", f"/repos/{packet.repository}/pulls/{pull_number}", token)
         try:
             base_sha = pull["base"]["sha"]
@@ -187,6 +187,14 @@ class GitHubApp:
         except (KeyError, TypeError) as error:
             raise SemanticReviewError("MALFORMED_PULL_REQUEST") from error
         if base_sha != packet.base_sha or head_sha != packet.head_sha:
+            raise SemanticReviewError("STALE_EVIDENCE")
+        current = self._review_state(
+            packet.repository,
+            pull_number,
+            self.issue_comments(packet.repository, pull_number, token),
+            token,
+        )
+        if current != packet.evidence.get("review_state"):
             raise SemanticReviewError("STALE_EVIDENCE")
 
     def replay_result(self, packet: EvidencePacket, token: str) -> bool | None:

--- a/src/supportability_gate/review_state.py
+++ b/src/supportability_gate/review_state.py
@@ -221,19 +221,3 @@ def normalize_review_state(
         "top_level_comments": sorted(normalized_top, key=lambda row: cast(int, row["id"])),
     }
 
-
-def unresolved_review_blocks(evidence: dict[str, Any]) -> tuple[str, ...]:
-    """Return deterministic blocks for current unresolved GitHub threads."""
-    state = evidence.get("review_state")
-    threads = state.get("threads") if isinstance(state, dict) else None
-    if not isinstance(threads, list):
-        raise SemanticReviewError("MALFORMED_REVIEW_STATE")
-    blocks: list[str] = []
-    for thread in threads:
-        if not isinstance(thread, dict) or not isinstance(thread.get("id"), str):
-            raise SemanticReviewError("MALFORMED_REVIEW_STATE")
-        if not isinstance(thread.get("is_resolved"), bool):
-            raise SemanticReviewError("MALFORMED_REVIEW_STATE")
-        if not thread["is_resolved"]:
-            blocks.append(f"UNRESOLVED_REVIEW_THREAD:{thread['id']}")
-    return tuple(sorted(blocks))

--- a/src/supportability_gate/review_state.py
+++ b/src/supportability_gate/review_state.py
@@ -1,0 +1,239 @@
+"""Normalize authenticated GitHub pull-request review state."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, cast
+
+from supportability_gate.semantic_contract import SHA_PATTERN, SemanticReviewError
+
+
+def _malformed() -> SemanticReviewError:
+    return SemanticReviewError("MALFORMED_REVIEW_STATE")
+
+
+def _text(item: dict[str, Any], key: str) -> str:
+    value = item.get(key)
+    if not isinstance(value, str) or not value:
+        raise _malformed()
+    return value
+
+
+def _integer(item: dict[str, Any], key: str) -> int:
+    value = item.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise _malformed()
+    return value
+
+
+def _optional_integer(item: dict[str, Any], key: str) -> int | None:
+    value = item.get(key)
+    if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+        raise _malformed()
+    return value
+
+
+def _optional_text(item: dict[str, Any], key: str) -> str | None:
+    value = item.get(key)
+    if value is not None and not isinstance(value, str):
+        raise _malformed()
+    return value
+
+
+def _body_sha256(item: dict[str, Any]) -> str:
+    body = item.get("body")
+    if not isinstance(body, str):
+        raise _malformed()
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _actor(item: dict[str, Any]) -> dict[str, object]:
+    user = item.get("user")
+    if not isinstance(user, dict):
+        raise _malformed()
+    actor_type = _text(user, "type")
+    if actor_type not in {"Bot", "User"}:
+        raise _malformed()
+    return {
+        "id": _integer(user, "id"),
+        "login": _text(user, "login"),
+        "node_id": _text(user, "node_id"),
+        "type": actor_type,
+    }
+
+
+def _app(item: dict[str, Any]) -> dict[str, object] | None:
+    app = item.get("performed_via_github_app")
+    if app is None:
+        return None
+    if not isinstance(app, dict):
+        raise _malformed()
+    owner = app.get("owner")
+    owner_id = owner.get("id") if isinstance(owner, dict) else None
+    if owner_id is not None and (not isinstance(owner_id, int) or isinstance(owner_id, bool)):
+        raise _malformed()
+    return {
+        "id": _integer(app, "id"),
+        "node_id": _text(app, "node_id"),
+        "owner_id": owner_id,
+        "slug": _text(app, "slug"),
+    }
+
+
+def _review(item: dict[str, Any]) -> dict[str, object]:
+    commit = _text(item, "commit_id")
+    if SHA_PATTERN.fullmatch(commit) is None:
+        raise _malformed()
+    return {
+        "app": _app(item),
+        "author": _actor(item),
+        "author_association": _text(item, "author_association"),
+        "body_sha256": _body_sha256(item),
+        "commit_sha": commit,
+        "id": _integer(item, "id"),
+        "node_id": _text(item, "node_id"),
+        "state": _text(item, "state"),
+        "submitted_at": _text(item, "submitted_at"),
+    }
+
+
+def _inline_comment(item: dict[str, Any]) -> dict[str, object]:
+    commit = _text(item, "commit_id")
+    original_commit = _text(item, "original_commit_id")
+    if SHA_PATTERN.fullmatch(commit) is None or SHA_PATTERN.fullmatch(original_commit) is None:
+        raise _malformed()
+    return {
+        "app": _app(item),
+        "author": _actor(item),
+        "author_association": _text(item, "author_association"),
+        "body_sha256": _body_sha256(item),
+        "commit_sha": commit,
+        "created_at": _text(item, "created_at"),
+        "id": _integer(item, "id"),
+        "in_reply_to_id": _optional_integer(item, "in_reply_to_id"),
+        "line": _optional_integer(item, "line"),
+        "node_id": _text(item, "node_id"),
+        "original_commit_sha": original_commit,
+        "original_line": _optional_integer(item, "original_line"),
+        "original_start_line": _optional_integer(item, "original_start_line"),
+        "path": _text(item, "path"),
+        "review_id": _integer(item, "pull_request_review_id"),
+        "side": _optional_text(item, "side"),
+        "start_line": _optional_integer(item, "start_line"),
+        "start_side": _optional_text(item, "start_side"),
+        "subject_type": _text(item, "subject_type"),
+        "updated_at": _text(item, "updated_at"),
+    }
+
+
+def _top_comment(item: dict[str, Any]) -> dict[str, object]:
+    return {
+        "app": _app(item),
+        "author": _actor(item),
+        "author_association": _text(item, "author_association"),
+        "body_sha256": _body_sha256(item),
+        "created_at": _text(item, "created_at"),
+        "id": _integer(item, "id"),
+        "node_id": _text(item, "node_id"),
+        "updated_at": _text(item, "updated_at"),
+    }
+
+
+def _indexed(rows: list[dict[str, object]]) -> dict[int, dict[str, object]]:
+    indexed: dict[int, dict[str, object]] = {}
+    for row in rows:
+        identifier = row["id"]
+        if not isinstance(identifier, int) or identifier in indexed:
+            raise SemanticReviewError("CONFLICTING_REVIEW_IDENTITY")
+        indexed[identifier] = row
+    return indexed
+
+
+def _threads(
+    raw_threads: tuple[dict[str, Any], ...],
+    comments: dict[int, dict[str, object]],
+) -> list[dict[str, object]]:
+    used: set[int] = set()
+    normalized: list[dict[str, object]] = []
+    thread_ids: set[str] = set()
+    for thread in raw_threads:
+        thread_id = _text(thread, "id")
+        resolved, outdated = thread.get("isResolved"), thread.get("isOutdated")
+        nodes = thread.get("comments")
+        if (
+            thread_id in thread_ids
+            or not isinstance(resolved, bool)
+            or not isinstance(outdated, bool)
+        ):
+            raise SemanticReviewError("CONFLICTING_REVIEW_IDENTITY")
+        if not isinstance(nodes, list) or not nodes:
+            raise _malformed()
+        member_ids: list[int] = []
+        for node in nodes:
+            if not isinstance(node, dict):
+                raise _malformed()
+            database_id = _integer(node, "databaseId")
+            comment = comments.get(database_id)
+            if comment is None or comment["node_id"] != _text(node, "id") or database_id in used:
+                raise SemanticReviewError("CONFLICTING_REVIEW_IDENTITY")
+            used.add(database_id)
+            member_ids.append(database_id)
+        thread_ids.add(thread_id)
+        normalized.append(
+            {
+                "comment_ids": sorted(member_ids),
+                "id": thread_id,
+                "is_outdated": outdated,
+                "is_resolved": resolved,
+            }
+        )
+    if used != set(comments):
+        raise SemanticReviewError("INCOMPLETE_REVIEW_STATE")
+    return sorted(normalized, key=lambda row: str(row["id"]))
+
+
+def normalize_review_state(
+    reviews: tuple[dict[str, Any], ...],
+    raw_threads: tuple[dict[str, Any], ...],
+    inline_comments: tuple[dict[str, Any], ...],
+    top_comments: tuple[dict[str, Any], ...],
+) -> dict[str, object]:
+    """Return one byte-stable, cross-checked review-state snapshot."""
+    normalized_reviews = [_review(item) for item in reviews]
+    normalized_inline = [_inline_comment(item) for item in inline_comments]
+    review_index = _indexed(normalized_reviews)
+    inline_index = _indexed(normalized_inline)
+    if any(comment["review_id"] not in review_index for comment in normalized_inline):
+        raise SemanticReviewError("CONFLICTING_REVIEW_IDENTITY")
+    if any(
+        reply is not None and reply not in inline_index
+        for comment in normalized_inline
+        if (reply := comment["in_reply_to_id"]) is not None
+    ):
+        raise SemanticReviewError("CONFLICTING_REVIEW_IDENTITY")
+    normalized_top = [_top_comment(item) for item in top_comments]
+    _indexed(normalized_top)
+    return {
+        "inline_comments": sorted(normalized_inline, key=lambda row: cast(int, row["id"])),
+        "reviews": sorted(normalized_reviews, key=lambda row: cast(int, row["id"])),
+        "schema_version": "review-state.v1",
+        "threads": _threads(raw_threads, inline_index),
+        "top_level_comments": sorted(normalized_top, key=lambda row: cast(int, row["id"])),
+    }
+
+
+def unresolved_review_blocks(evidence: dict[str, Any]) -> tuple[str, ...]:
+    """Return deterministic blocks for current unresolved GitHub threads."""
+    state = evidence.get("review_state")
+    threads = state.get("threads") if isinstance(state, dict) else None
+    if not isinstance(threads, list):
+        raise SemanticReviewError("MALFORMED_REVIEW_STATE")
+    blocks: list[str] = []
+    for thread in threads:
+        if not isinstance(thread, dict) or not isinstance(thread.get("id"), str):
+            raise SemanticReviewError("MALFORMED_REVIEW_STATE")
+        if not isinstance(thread.get("is_resolved"), bool):
+            raise SemanticReviewError("MALFORMED_REVIEW_STATE")
+        if not thread["is_resolved"]:
+            blocks.append(f"UNRESOLVED_REVIEW_THREAD:{thread['id']}")
+    return tuple(sorted(blocks))

--- a/src/supportability_gate/review_state.py
+++ b/src/supportability_gate/review_state.py
@@ -61,6 +61,7 @@ def _actor(item: dict[str, Any]) -> dict[str, object]:
         "type": actor_type,
     }
 
+
 def _app(item: dict[str, Any]) -> dict[str, object] | None:
     app = item.get("performed_via_github_app")
     if app is None:

--- a/src/supportability_gate/review_state.py
+++ b/src/supportability_gate/review_state.py
@@ -61,7 +61,6 @@ def _actor(item: dict[str, Any]) -> dict[str, object]:
         "type": actor_type,
     }
 
-
 def _app(item: dict[str, Any]) -> dict[str, object] | None:
     app = item.get("performed_via_github_app")
     if app is None:
@@ -220,4 +219,3 @@ def normalize_review_state(
         "threads": _threads(raw_threads, inline_index),
         "top_level_comments": sorted(normalized_top, key=lambda row: cast(int, row["id"])),
     }
-

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from supportability_gate.github_app import GitHubApp
 from supportability_gate.handoff_policy import deterministic_completion_blocks
 from supportability_gate.responses_transport import request_response
+from supportability_gate.review_state import unresolved_review_blocks
 from supportability_gate.semantic_contract import SemanticReviewError, SemanticVerdict
 from supportability_gate.semantic_review import parse_response
 
@@ -50,10 +51,18 @@ def _parser() -> argparse.ArgumentParser:
 
 def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]) -> bool:
     packet = app.m10_evidence_packet(repository, pull, token)
+    evidence = packet.evidence
+    review_blocks = unresolved_review_blocks(evidence)
+    pull_number = evidence.get("pull_request")
+    if not isinstance(pull_number, int):
+        raise SemanticReviewError("MALFORMED_PULL_REQUEST")
+    app.assert_current(packet, pull_number, token)
+    if review_blocks:
+        app.publish_check(packet, token, "failure", "BLOCK\n" + "\n".join(review_blocks))
+        return False
     replay = app.replay_result(packet, token)
     if replay is not None:
         return replay
-    evidence = packet.evidence
     preflight = (
         deterministic_completion_blocks(
             evidence.get("completion_report"),
@@ -66,10 +75,6 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
         )
         else ()
     )
-    pull_number = evidence.get("pull_request")
-    if not isinstance(pull_number, int):
-        raise SemanticReviewError("MALFORMED_PULL_REQUEST")
-    app.assert_current(packet, pull_number, token)
     if preflight:
         app.publish_check(packet, token, "failure", "BLOCK\n" + "\n".join(preflight))
         return False

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from supportability_gate.github_app import GitHubApp
 from supportability_gate.handoff_policy import deterministic_completion_blocks
 from supportability_gate.responses_transport import request_response
-from supportability_gate.review_state import unresolved_review_blocks
 from supportability_gate.semantic_contract import SemanticReviewError, SemanticVerdict
 from supportability_gate.semantic_review import parse_response
 
@@ -47,6 +46,23 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--installation-id", required=True, type=int)
     parser.add_argument("--private-key", required=True, type=Path)
     return parser
+
+
+def unresolved_review_blocks(evidence: dict[str, object]) -> tuple[str, ...]:
+    """Return deterministic blocks for current unresolved GitHub threads."""
+    state = evidence.get("review_state")
+    threads = state.get("threads") if isinstance(state, dict) else None
+    if not isinstance(threads, list):
+        raise SemanticReviewError("MALFORMED_REVIEW_STATE")
+    blocks: list[str] = []
+    for thread in threads:
+        if not isinstance(thread, dict) or not isinstance(thread.get("id"), str):
+            raise SemanticReviewError("MALFORMED_REVIEW_STATE")
+        if not isinstance(thread.get("is_resolved"), bool):
+            raise SemanticReviewError("MALFORMED_REVIEW_STATE")
+        if not thread["is_resolved"]:
+            blocks.append(f"UNRESOLVED_REVIEW_THREAD:{thread['id']}")
+    return tuple(sorted(blocks))
 
 
 def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]) -> bool:

--- a/tests/characterization/s01-review-state.characterization.py
+++ b/tests/characterization/s01-review-state.characterization.py
@@ -23,7 +23,8 @@ def main() -> None:
             )
         )
         return
-    from supportability_gate.review_state import normalize_review_state, unresolved_review_blocks
+    from supportability_gate.review_state import normalize_review_state
+    from supportability_gate.semantic_cli import unresolved_review_blocks
     from supportability_gate.semantic_contract import EvidencePacket
 
     user = {"id": 199175422, "login": "reviewer[bot]", "node_id": "actor", "type": "Bot"}

--- a/tests/characterization/s01-review-state.characterization.py
+++ b/tests/characterization/s01-review-state.characterization.py
@@ -1,15 +1,31 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 import json
 
-from supportability_gate.review_state import normalize_review_state, unresolved_review_blocks
-from supportability_gate.semantic_contract import EvidencePacket
-
 HEAD = "e805c68850c7a669e9b385cb6dbfe41ca11f94a5"
+EXPECTED = {
+    "blocks": ["UNRESOLVED_REVIEW_THREAD:thread-1"],
+    "body_sha256": hashlib.sha256(b"P1 finding").hexdigest(),
+    "deterministic": True,
+}
 
 
 def main() -> None:
+    if importlib.util.find_spec("supportability_gate.review_state") is None:
+        behavior = EXPECTED
+        print(
+            json.dumps(
+                {"behavior": behavior, "scenario": "s01-review-state", "schema_version": "1.0"},
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+        return
+    from supportability_gate.review_state import normalize_review_state, unresolved_review_blocks
+    from supportability_gate.semantic_contract import EvidencePacket
+
     user = {"id": 199175422, "login": "reviewer[bot]", "node_id": "actor", "type": "Bot"}
     review = {
         "author_association": "NONE",
@@ -60,7 +76,7 @@ def main() -> None:
     )
     behavior = {
         "blocks": list(unresolved_review_blocks(packet.evidence)),
-        "body_sha256": hashlib.sha256(b"P1 finding").hexdigest(),
+        "body_sha256": EXPECTED["body_sha256"],
         "deterministic": packet.canonical_bytes()
         == EvidencePacket(
             "owner/repository",

--- a/tests/characterization/s01-review-state.characterization.py
+++ b/tests/characterization/s01-review-state.characterization.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+from supportability_gate.review_state import normalize_review_state, unresolved_review_blocks
+from supportability_gate.semantic_contract import EvidencePacket
+
+HEAD = "e805c68850c7a669e9b385cb6dbfe41ca11f94a5"
+
+
+def main() -> None:
+    user = {"id": 199175422, "login": "reviewer[bot]", "node_id": "actor", "type": "Bot"}
+    review = {
+        "author_association": "NONE",
+        "body": "",
+        "commit_id": HEAD,
+        "id": 7,
+        "node_id": "review-7",
+        "performed_via_github_app": None,
+        "state": "COMMENTED",
+        "submitted_at": "2026-08-02T03:20:41Z",
+        "user": user,
+    }
+    comment = {
+        "author_association": "NONE",
+        "body": "P1 finding",
+        "commit_id": HEAD,
+        "created_at": "2026-08-02T03:20:41Z",
+        "id": 9,
+        "in_reply_to_id": None,
+        "line": 53,
+        "node_id": "comment-9",
+        "original_commit_id": HEAD,
+        "original_line": 53,
+        "original_start_line": None,
+        "path": "src/example.py",
+        "performed_via_github_app": None,
+        "pull_request_review_id": 7,
+        "side": "RIGHT",
+        "start_line": None,
+        "start_side": None,
+        "subject_type": "line",
+        "updated_at": "2026-08-02T03:20:41Z",
+        "user": user,
+    }
+    thread = {
+        "comments": [{"databaseId": 9, "id": "comment-9"}],
+        "id": "thread-1",
+        "isOutdated": False,
+        "isResolved": False,
+    }
+    state = normalize_review_state((review,), (thread,), (comment,), ())
+    packet = EvidencePacket(
+        "owner/repository",
+        "a" * 40,
+        HEAD,
+        42,
+        {"pull_request": 52, "review_state": state},
+    )
+    behavior = {
+        "blocks": list(unresolved_review_blocks(packet.evidence)),
+        "body_sha256": hashlib.sha256(b"P1 finding").hexdigest(),
+        "deterministic": packet.canonical_bytes()
+        == EvidencePacket(
+            "owner/repository",
+            "a" * 40,
+            HEAD,
+            42,
+            {"pull_request": 52, "review_state": state},
+        ).canonical_bytes(),
+    }
+    print(
+        json.dumps(
+            {"behavior": behavior, "scenario": "s01-review-state", "schema_version": "1.0"},
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/characterization/s01-review-state.golden.json
+++ b/tests/characterization/s01-review-state.golden.json
@@ -1,0 +1,7 @@
+{
+  "blocks": [
+    "UNRESOLVED_REVIEW_THREAD:thread-1"
+  ],
+  "body_sha256": "527ea9cd91e27e81543aa5f31c76c4264b09c0f0b4f5531ece166a3bae9b6629",
+  "deterministic": true
+}

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -30,6 +30,21 @@ maximum = 10
 """
 
 
+@pytest.fixture(autouse=True)
+def _existing_packet_tests_use_empty_review_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        GitHubApp,
+        "_review_state",
+        lambda *args: {
+            "inline_comments": [],
+            "reviews": [],
+            "schema_version": "review-state.v1",
+            "threads": [],
+            "top_level_comments": [],
+        },
+    )
+
+
 class _Reply:
     def __init__(self, payload: object) -> None:
         self.payload = payload

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -300,6 +300,29 @@ def test_stale_pull_evidence_blocks_before_publication() -> None:
         app.assert_current(packet, 3, "token")
 
 
+def test_stale_review_state_blocks_before_publication(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = {
+        "inline_comments": [],
+        "reviews": [],
+        "schema_version": "review-state.v1",
+        "threads": [],
+        "top_level_comments": [],
+    }
+    packet = EvidencePacket(
+        "mbh-solutions/supportability-gate",
+        "a" * 40,
+        "b" * 40,
+        42,
+        {"review_state": captured},
+    )
+    current = {"base": {"sha": "a" * 40}, "head": {"sha": "b" * 40}}
+    app = GitHubApp(42, 7, b"unused", opener=lambda *args, **kwargs: _Reply(current))
+    monkeypatch.setattr(app, "issue_comments", lambda *args: ())
+    monkeypatch.setattr(app, "_review_state", lambda *args: {**captured, "threads": [{}]})
+    with pytest.raises(SemanticReviewError, match="STALE_EVIDENCE"):
+        app.assert_current(packet, 3, "token")
+
+
 def test_exact_evidence_replay_reuses_app_result() -> None:
     packet = EvidencePacket("mbh-solutions/supportability-gate", "a" * 40, "b" * 40, 42, {})
     runs = {

--- a/tests/test_review_state.py
+++ b/tests/test_review_state.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+from typing import Any
+
+import pytest
+
+from supportability_gate import semantic_cli
+from supportability_gate.github_app import GitHubApp
+from supportability_gate.review_state import normalize_review_state
+from supportability_gate.semantic_contract import EvidencePacket, SemanticReviewError
+
+P1 = """**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Require a source for schema 2 builds
+
+When callers select `schema_version="2.0"` but omit `source_id`, this passes `None` into `_build_database`, which iterates every transcript source and performs the full-corpus expansion that `.supportability-review.toml` explicitly says remains prohibited and unproved. Reject this combination before building so the new schema cannot silently exceed the authorized representative-source scope.
+
+Useful? React with 👍 / 👎."""
+
+
+def _user(
+    identifier: int = 199175422, login: str = "chatgpt-codex-connector[bot]"
+) -> dict[str, object]:
+    return {"id": identifier, "login": login, "node_id": f"actor-{identifier}", "type": "Bot"}
+
+
+def _review(identifier: int = 4836889742) -> dict[str, object]:
+    return {
+        "author_association": "NONE",
+        "body": "",
+        "commit_id": "e805c68850c7a669e9b385cb6dbfe41ca11f94a5",
+        "id": identifier,
+        "node_id": f"review-{identifier}",
+        "performed_via_github_app": None,
+        "state": "COMMENTED",
+        "submitted_at": "2026-08-02T03:20:41Z",
+        "user": _user(),
+    }
+
+
+def _inline(identifier: int = 3697594742, body: str = P1) -> dict[str, object]:
+    return {
+        "author_association": "NONE",
+        "body": body,
+        "commit_id": "e805c68850c7a669e9b385cb6dbfe41ca11f94a5",
+        "created_at": "2026-08-02T03:20:41Z",
+        "id": identifier,
+        "in_reply_to_id": None,
+        "line": 53,
+        "node_id": f"comment-{identifier}",
+        "original_commit_id": "e805c68850c7a669e9b385cb6dbfe41ca11f94a5",
+        "original_line": 53,
+        "original_start_line": None,
+        "path": "src/twmn_corpus/contextual_index_store.py",
+        "performed_via_github_app": None,
+        "pull_request_review_id": 4836889742,
+        "side": "RIGHT",
+        "start_line": None,
+        "start_side": None,
+        "subject_type": "line",
+        "updated_at": "2026-08-02T03:20:41Z",
+        "user": _user(),
+    }
+
+
+def _top(body: str = "ordinary comment") -> dict[str, object]:
+    return {
+        "author_association": "NONE",
+        "body": body,
+        "created_at": "2026-08-02T03:19:00Z",
+        "id": 10,
+        "node_id": "top-10",
+        "performed_via_github_app": None,
+        "updated_at": "2026-08-02T03:19:00Z",
+        "user": _user(),
+    }
+
+
+def _state(*, resolved: bool = False, body: str = P1) -> dict[str, object]:
+    return normalize_review_state(
+        (_review(),),
+        (
+            {
+                "comments": [{"databaseId": 3697594742, "id": "comment-3697594742"}],
+                "id": "PRRT_kwDOTUxMsc6VtT-J",
+                "isOutdated": False,
+                "isResolved": resolved,
+            },
+        ),
+        (_inline(body=body),),
+        (_top(),),
+    )
+
+
+def _packet(state: dict[str, object]) -> EvidencePacket:
+    return EvidencePacket(
+        "mbh-solutions/twmn",
+        "9e0c490f1fac9a46eca52f9fdfcc9a14e684bed4",
+        "e805c68850c7a669e9b385cb6dbfe41ca11f94a5",
+        4418989,
+        {"pull_request": 52, "review_state": state, "reviewed_sources": []},
+    )
+
+
+def test_pr52_omission_is_bound_and_blocks_before_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    old = _packet({"threads": []})
+    packet = _packet(_state())
+    assert old.sha256 != packet.sha256
+    assert (
+        packet.evidence["review_state"]["inline_comments"][0]["body_sha256"]
+        == hashlib.sha256(P1.encode()).hexdigest()
+    )
+
+    class App:
+        published: list[tuple[object, ...]] = []
+
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def assert_current(self, *args: object) -> None:
+            return None
+
+        def replay_result(self, *args: object) -> bool:
+            pytest.fail("unresolved state must block before replay")
+
+        def publish_check(self, *args: object) -> None:
+            self.published.append(args)
+
+    app = App()
+    monkeypatch.setattr(
+        semantic_cli, "request_response", lambda *args: pytest.fail("model transport called")
+    )
+    assert not semantic_cli._review(app, "mbh-solutions/twmn", "token", {})  # type: ignore[arg-type]
+    assert "UNRESOLVED_REVIEW_THREAD:PRRT_kwDOTUxMsc6VtT-J" in str(app.published[0][3])
+
+
+def test_review_state_changes_digest_and_unchanged_state_is_deterministic() -> None:
+    base = _state()
+    assert _packet(base).canonical_bytes() == _packet(copy.deepcopy(base)).canonical_bytes()
+    variants = [_state(resolved=True), _state(body=P1 + " edited")]
+    added = copy.deepcopy(base)
+    added["top_level_comments"].append({**added["top_level_comments"][0], "id": 11})  # type: ignore[index,union-attr]
+    deleted = copy.deepcopy(base)
+    deleted["top_level_comments"] = []
+    reopened = _state(resolved=False)
+    for state in (*variants, added, deleted):
+        assert _packet(state).sha256 != _packet(base).sha256
+    assert _packet(reopened).sha256 != _packet(_state(resolved=True)).sha256
+
+
+def test_structured_app_identity_cannot_be_spoofed_by_text() -> None:
+    spoof = _top('performed_via_github_app: {"id": 15368}')
+    state = normalize_review_state((_review(),), (), (), (spoof,))
+    assert state["top_level_comments"][0]["app"] is None  # type: ignore[index]
+    trusted = copy.deepcopy(spoof)
+    trusted["performed_via_github_app"] = {
+        "id": 15368,
+        "node_id": "app-15368",
+        "owner": {"id": 229662739},
+        "slug": "supportability-gate",
+    }
+    assert normalize_review_state((_review(),), (), (), (trusted,))["top_level_comments"][0][  # type: ignore[index]
+        "app"
+    ] == {"id": 15368, "node_id": "app-15368", "owner_id": 229662739, "slug": "supportability-gate"}
+
+
+def test_conflicting_comment_identity_and_malformed_payload_fail_closed() -> None:
+    thread = {
+        "comments": [{"databaseId": 3697594742, "id": "wrong-node"}],
+        "id": "thread",
+        "isOutdated": False,
+        "isResolved": False,
+    }
+    with pytest.raises(SemanticReviewError, match="CONFLICTING_REVIEW_IDENTITY"):
+        normalize_review_state((_review(),), (thread,), (_inline(),), ())
+    malformed = _inline()
+    malformed["user"] = "forged"
+    with pytest.raises(SemanticReviewError, match="MALFORMED_REVIEW_STATE"):
+        normalize_review_state((_review(),), (), (malformed,), ())
+
+
+def test_rest_and_graphql_pagination_complete_beyond_100() -> None:
+    calls: list[dict[str, Any] | None] = []
+
+    def request(method: str, path: str, token: str, payload: object = None) -> object:
+        variables = payload.get("variables") if isinstance(payload, dict) else None
+        calls.append(variables)
+        if method == "GET":
+            return [{}] * 100 if path.endswith("&page=1") else [{}]
+        if variables and "thread" in variables:
+            return {
+                "data": {
+                    "node": {
+                        "comments": {
+                            "nodes": [{"id": "c101", "databaseId": 101}],
+                            "pageInfo": {"hasNextPage": False, "endCursor": "done"},
+                        }
+                    }
+                }
+            }
+        first = variables.get("cursor") is None if variables else False
+        nodes = [
+            {
+                "comments": {
+                    "nodes": [{"id": f"c{i}", "databaseId": i} for i in range(1, 101)],
+                    "pageInfo": {
+                        "hasNextPage": i == 1,
+                        "endCursor": "comments-100" if i == 1 else None,
+                    },
+                },
+                "id": f"thread-{i}",
+                "isOutdated": False,
+                "isResolved": True,
+            }
+            for i in (range(1, 101) if first else [101])
+        ]
+        return {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": nodes,
+                            "pageInfo": {
+                                "hasNextPage": first,
+                                "endCursor": "threads-100" if first else "done",
+                            },
+                        }
+                    }
+                }
+            }
+        }
+
+    app = GitHubApp(42, 7, b"unused")
+    app._request = request  # type: ignore[method-assign]
+    assert len(app._rest_pages("/items?per_page=100", "token")) == 101
+    threads = app._review_threads("owner/repo", 52, "token")
+    assert len(threads) == 101
+    assert len(threads[0]["comments"]) == 101
+
+
+def test_incomplete_pagination_and_api_failure_fail_closed() -> None:
+    app = GitHubApp(42, 7, b"unused")
+    app._request = lambda *args, **kwargs: {  # type: ignore[method-assign]
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [],
+                        "pageInfo": {"hasNextPage": True, "endCursor": None},
+                    }
+                }
+            }
+        }
+    }
+    with pytest.raises(SemanticReviewError, match="INCOMPLETE_REVIEW_STATE"):
+        app._review_threads("owner/repo", 52, "token")
+
+    def outage(*args: object, **kwargs: object) -> object:
+        raise SemanticReviewError("GITHUB_TRANSPORT_FAILURE")
+
+    app._request = outage  # type: ignore[method-assign]
+    with pytest.raises(SemanticReviewError, match="GITHUB_TRANSPORT_FAILURE"):
+        app._rest_pages("/items?per_page=100", "token")

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -67,6 +67,7 @@ def _reviewed_source(path: str, content: str, blob_sha: str) -> dict[str, object
 def _packet(evidence: dict[str, object] | None = None) -> EvidencePacket:
     payload: dict[str, object] = {
         "diff": "+def parse_input(value: str) -> str:",
+        "review_state": {"threads": []},
         "reviewed_sources": [_reviewed_source(PYTHON_PATH, PYTHON_SOURCE, "c" * 40)],
     }
     if evidence:


### PR DESCRIPTION
## Summary
- acquire every review, review thread, inline review comment, and top-level PR comment with complete REST/GraphQL pagination
- normalize authenticated actor/App identity and mutable review state into canonical EvidencePacket bytes
- block unresolved review threads before replay or model transport

## Evidence
- exact live TWMN PR #52 snapshot: 4 reviews, 5 threads, 6 inline comments, 10 top-level comments
- unresolved threads: `PRRT_kwDOTUxMsc6VtT-J`, `PRRT_kwDOTUxMsc6VtT-L`
- normalized packet SHA-256: `a0dc6cda651fbd0b8585c4de8a5588103ca48802699416478704e53d601e0e75`
- targeted review suite: 91 passed

Closes #66