### PR TITLE
S02: invalidate same-head semantic eligibility

### DIFF
--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -58,6 +58,13 @@
       ],
       "id": "s01-review-state",
       "kind": "regression"
+    },
+    {
+      "covers": [
+        "src/supportability_gate/review_events.py"
+      ],
+      "id": "s02-review-events",
+      "kind": "regression"
     }
   ],
   "schema_version": "1.0"

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -6,11 +6,12 @@ base_sha = "dfc034d070977fcead8742dbe5a05a919a9de825"
 overall_result = "PASS"
 responsibility_changes = [
     "review_events authenticates supported review-state deliveries and reduces each payload to repository, pull-request, and delivery identity.",
-    "GitHubApp reuses exact-digest pending checks and semantic_cli makes the required result pending before fresh model evaluation.",
-    "Event processing only invalidates changed current state; scheduled reconciliation alone evaluates, then re-reads base, head, and review state immediately before completion.",
+    "GitHubApp reuses exact-digest invalidation checks and creates uniquely owned evaluator candidates.",
+    "Event processing only invalidates changed current state; the oldest scheduled evaluator candidate alone evaluates, then re-reads base, head, and review state immediately before completion.",
 ]
 simplified_functions = [
     "GitHubApp._check_runs",
+    "GitHubApp.claim_check",
     "GitHubApp.pull",
     "GitHubApp.replay_result",
     "GitHubApp.start_check",
@@ -55,10 +56,10 @@ citations = ["src/supportability_gate/review_events.py:29-74"]
 
 [[completion_report.claims]]
 id = "claim-idempotent-current-state-reconciliation"
-text = "Event processing discards mutable event state, fetches current evidence, reuses an exact completed verdict or leaves the digest pending, and never calls the model; scheduled full reconciliation alone evaluates pending state, so duplicate and out-of-order deliveries cannot create competing model verdicts."
-citations = ["src/supportability_gate/github_app.py:181-187", "src/supportability_gate/github_app.py:207-239", "src/supportability_gate/github_app.py:947-986", "src/supportability_gate/semantic_cli.py:157-186"]
+text = "Event processing discards mutable event state, reuses an exact completed verdict or invalidation check, and never calls the model. Each scheduled evaluator creates a unique candidate; only the lowest check ID may evaluate, while later candidates retire neutral and return non-green for retry, so no pending check has competing model or PATCH owners."
+citations = ["src/supportability_gate/github_app.py:181-187", "src/supportability_gate/github_app.py:207-239", "src/supportability_gate/github_app.py:948-1053", "src/supportability_gate/semantic_cli.py:86-172", "src/supportability_gate/semantic_cli.py:175-184"]
 
 [[completion_report.claims]]
 id = "claim-stable-evaluation-publication"
 text = "A fresh digest becomes pending before model transport, and base, head, and normalized review state are re-read immediately before the same digest-bound check can complete success or failure."
-citations = ["src/supportability_gate/github_app.py:188-204", "src/supportability_gate/semantic_cli.py:73-154"]
+citations = ["src/supportability_gate/github_app.py:188-204", "src/supportability_gate/github_app.py:1055-1092", "src/supportability_gate/semantic_cli.py:73-172"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,45 +2,33 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "0c4c2419d6da486a97acb8e73cac5e91430d2c7b"
+base_sha = "dfc034d070977fcead8742dbe5a05a919a9de825"
 overall_result = "PASS"
 responsibility_changes = [
-    "GitHubApp now acquires every authenticated review, review thread, inline comment, and top-level comment page before evidence assembly.",
-    "review_state owns byte-stable normalization and identity cross-checks; semantic_cli owns deterministic unresolved-thread blocking before replay or model review.",
-    "GitHubApp re-fetches commit and normalized review state before replay or publication and rejects any changed snapshot as stale evidence.",
+    "review_events authenticates supported review-state deliveries and reduces each payload to repository, pull-request, and delivery identity.",
+    "GitHubApp reuses exact-digest pending checks and semantic_cli makes the required result pending before fresh model evaluation.",
+    "Event-driven and scheduled reconciliation both re-fetch current GitHub state, reject stale replay, and re-read base, head, and review state immediately before completion.",
 ]
 simplified_functions = [
-    "GitHubApp._graphql_connection",
-    "GitHubApp._rest_pages",
-    "GitHubApp._review_state",
-    "GitHubApp._review_threads",
-    "GitHubApp._thread_comments",
-    "GitHubApp.assert_current",
-    "GitHubApp.evidence_packet",
-    "GitHubApp.issue_comments",
-    "_actor",
-    "_app",
-    "_body_sha256",
-    "_indexed",
-    "_inline_comment",
-    "_integer",
-    "_malformed",
-    "_optional_integer",
-    "_optional_text",
+    "GitHubApp._check_runs",
+    "GitHubApp.pull",
+    "GitHubApp.replay_result",
+    "GitHubApp.start_check",
+    "_authenticated",
+    "_complete_current_check",
+    "_payload",
     "_review",
-    "_review",
-    "_text",
-    "_threads",
-    "_top_comment",
-    "normalize_review_state",
-    "unresolved_review_blocks",
+    "handle_review_event",
+    "parse_review_event",
+    "process_review_event",
+    "reconcile_open_pulls",
 ]
 boundary_rationale = [
-    "github_app remains the authenticated GitHub transport and pagination boundary.",
-    "review_state owns normalization only; semantic_cli owns orchestration policy including unresolved-thread blocking.",
+    "review_events owns webhook authentication and strict delivery identity only.",
+    "github_app owns authenticated current-state and check-run transport; semantic_cli owns event and scheduled evaluation orchestration.",
 ]
 remaining_risks = [
-    "GitHub response schema changes fail closed as malformed or incomplete review state until adapter support is updated.",
+    "S02 ships protected source capability only; S04 owns production runtime, App event configuration, and ruleset cutover.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -60,16 +48,16 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-complete-authenticated-review-acquisition"
-text = "Authenticated REST and GraphQL pagination acquires all reviews, review threads including nested comments, inline comments, and top-level comments before normalization."
-citations = ["src/supportability_gate/github_app.py:546-654"]
+id = "claim-authenticated-review-event-boundary"
+text = "Supported review, review-comment, and review-thread deliveries require a valid HMAC SHA-256 signature and strict repository, pull-request, action, and delivery identity."
+citations = ["src/supportability_gate/review_events.py:29-74"]
 
 [[completion_report.claims]]
-id = "claim-normalized-unresolved-thread-block"
-text = "Review state is identity-cross-checked and byte-stably normalized, then every unresolved review thread blocks before replay or model review."
-citations = ["src/supportability_gate/review_state.py:195-222", "src/supportability_gate/semantic_cli.py:51-78"]
+id = "claim-idempotent-current-state-reconciliation"
+text = "Event processing discards mutable event state, fetches the current pull request, and uses the same evaluator as scheduled full reconciliation; exact completed or pending digest bindings make duplicate and out-of-order delivery harmless."
+citations = ["src/supportability_gate/github_app.py:181-187", "src/supportability_gate/github_app.py:207-239", "src/supportability_gate/github_app.py:947-986", "src/supportability_gate/semantic_cli.py:157-186"]
 
 [[completion_report.claims]]
-id = "claim-review-state-currentness"
-text = "Commit and normalized review state are re-fetched and compared before replay or final check publication, and any change invalidates the captured evidence."
-citations = ["src/supportability_gate/github_app.py:181-198", "src/supportability_gate/semantic_cli.py:75-100"]
+id = "claim-stable-evaluation-publication"
+text = "A fresh digest becomes pending before model transport, and base, head, and normalized review state are re-read immediately before the same digest-bound check can complete success or failure."
+citations = ["src/supportability_gate/github_app.py:188-204", "src/supportability_gate/semantic_cli.py:73-154"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -12,6 +12,7 @@ responsibility_changes = [
 simplified_functions = [
     "GitHubApp._check_runs",
     "GitHubApp.claim_check",
+    "GitHubApp.complete_check",
     "GitHubApp.pull",
     "GitHubApp.replay_result",
     "GitHubApp.start_check",

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -59,9 +59,9 @@ citations = ["src/supportability_gate/review_events.py:29-74"]
 [[completion_report.claims]]
 id = "claim-idempotent-current-state-reconciliation"
 text = "Event processing discards mutable event state, reuses an exact completed verdict or pending invalidation check, and never calls the model. The scheduled CLI holds a nonblocking cross-process advisory lock across full reconciliation; contention fails non-green before evidence, model, or check mutation, so one process owns model and PATCH work."
-citations = ["src/supportability_gate/github_app.py:181-187", "src/supportability_gate/github_app.py:207-238", "src/supportability_gate/github_app.py:947-986", "src/supportability_gate/semantic_cli.py:90-132", "src/supportability_gate/semantic_cli.py:135-215", "src/supportability_gate/semantic_cli.py:246-260"]
+citations = ["src/supportability_gate/github_app.py:181-187", "src/supportability_gate/github_app.py:207-238", "src/supportability_gate/github_app.py:947-986", "src/supportability_gate/semantic_cli.py:90-132", "src/supportability_gate/semantic_cli.py:135-215", "src/supportability_gate/semantic_cli.py:246-259"]
 
 [[completion_report.claims]]
 id = "claim-stable-evaluation-publication"
 text = "A fresh digest becomes pending before model transport, and base, head, and normalized review state are re-read immediately before the same digest-bound check can complete success or failure."
-citations = ["src/supportability_gate/github_app.py:188-204", "src/supportability_gate/github_app.py:988-1023", "src/supportability_gate/semantic_cli.py:77-203"]
+citations = ["src/supportability_gate/github_app.py:188-204", "src/supportability_gate/github_app.py:988-1022", "src/supportability_gate/semantic_cli.py:77-203"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -19,6 +19,7 @@ simplified_functions = [
     "_payload",
     "_review",
     "handle_review_event",
+    "main",
     "parse_review_event",
     "process_review_event",
     "reconcile_open_pulls",

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -6,20 +6,21 @@ base_sha = "dfc034d070977fcead8742dbe5a05a919a9de825"
 overall_result = "PASS"
 responsibility_changes = [
     "review_events authenticates supported review-state deliveries and reduces each payload to repository, pull-request, and delivery identity.",
-    "GitHubApp reuses exact-digest invalidation checks and creates uniquely owned evaluator candidates.",
-    "Event processing only invalidates changed current state; the oldest scheduled evaluator candidate alone evaluates, then re-reads base, head, and review state immediately before completion.",
+    "GitHubApp reuses exact-digest pending checks; event processing never evaluates the model.",
+    "The scheduled CLI holds one cross-process advisory lock across full reconciliation, then re-reads base, head, and review state immediately before completion.",
 ]
 simplified_functions = [
     "GitHubApp._check_runs",
-    "GitHubApp.claim_check",
-    "GitHubApp.complete_check",
     "GitHubApp.pull",
     "GitHubApp.replay_result",
     "GitHubApp.start_check",
     "_authenticated",
     "_complete_current_check",
+    "_evaluation_lock",
+    "_lock",
     "_payload",
     "_review",
+    "_unlock",
     "handle_review_event",
     "main",
     "parse_review_event",
@@ -28,7 +29,7 @@ simplified_functions = [
 ]
 boundary_rationale = [
     "review_events owns webhook authentication and strict delivery identity only.",
-    "github_app owns authenticated current-state and check-run transport; semantic_cli owns event and scheduled evaluation orchestration.",
+    "github_app owns authenticated current-state and check-run transport; semantic_cli owns event orchestration and cross-process serialization of scheduled evaluation.",
 ]
 remaining_risks = [
     "S02 ships protected source capability only; S04 owns production runtime, App event configuration, and ruleset cutover.",
@@ -57,10 +58,10 @@ citations = ["src/supportability_gate/review_events.py:29-74"]
 
 [[completion_report.claims]]
 id = "claim-idempotent-current-state-reconciliation"
-text = "Event processing discards mutable event state, reuses an exact completed verdict or invalidation check, and never calls the model. Each scheduled evaluator creates a unique candidate; only the lowest check ID may evaluate, while later candidates retire neutral and return non-green for retry, so no pending check has competing model or PATCH owners."
-citations = ["src/supportability_gate/github_app.py:182-188", "src/supportability_gate/github_app.py:208-239", "src/supportability_gate/github_app.py:948-1053", "src/supportability_gate/semantic_cli.py:86-172", "src/supportability_gate/semantic_cli.py:175-184"]
+text = "Event processing discards mutable event state, reuses an exact completed verdict or pending invalidation check, and never calls the model. The scheduled CLI holds a nonblocking cross-process advisory lock across full reconciliation; contention fails non-green before evidence, model, or check mutation, so one process owns model and PATCH work."
+citations = ["src/supportability_gate/github_app.py:181-187", "src/supportability_gate/github_app.py:207-238", "src/supportability_gate/github_app.py:947-986", "src/supportability_gate/semantic_cli.py:90-132", "src/supportability_gate/semantic_cli.py:135-215", "src/supportability_gate/semantic_cli.py:246-260"]
 
 [[completion_report.claims]]
 id = "claim-stable-evaluation-publication"
 text = "A fresh digest becomes pending before model transport, and base, head, and normalized review state are re-read immediately before the same digest-bound check can complete success or failure."
-citations = ["src/supportability_gate/github_app.py:189-205", "src/supportability_gate/github_app.py:1055-1090", "src/supportability_gate/semantic_cli.py:73-172"]
+citations = ["src/supportability_gate/github_app.py:188-204", "src/supportability_gate/github_app.py:988-1023", "src/supportability_gate/semantic_cli.py:77-203"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -57,9 +57,9 @@ citations = ["src/supportability_gate/review_events.py:29-74"]
 [[completion_report.claims]]
 id = "claim-idempotent-current-state-reconciliation"
 text = "Event processing discards mutable event state, reuses an exact completed verdict or invalidation check, and never calls the model. Each scheduled evaluator creates a unique candidate; only the lowest check ID may evaluate, while later candidates retire neutral and return non-green for retry, so no pending check has competing model or PATCH owners."
-citations = ["src/supportability_gate/github_app.py:181-187", "src/supportability_gate/github_app.py:207-239", "src/supportability_gate/github_app.py:948-1053", "src/supportability_gate/semantic_cli.py:86-172", "src/supportability_gate/semantic_cli.py:175-184"]
+citations = ["src/supportability_gate/github_app.py:182-188", "src/supportability_gate/github_app.py:208-239", "src/supportability_gate/github_app.py:948-1053", "src/supportability_gate/semantic_cli.py:86-172", "src/supportability_gate/semantic_cli.py:175-184"]
 
 [[completion_report.claims]]
 id = "claim-stable-evaluation-publication"
 text = "A fresh digest becomes pending before model transport, and base, head, and normalized review state are re-read immediately before the same digest-bound check can complete success or failure."
-citations = ["src/supportability_gate/github_app.py:188-204", "src/supportability_gate/github_app.py:1055-1092", "src/supportability_gate/semantic_cli.py:73-172"]
+citations = ["src/supportability_gate/github_app.py:189-205", "src/supportability_gate/github_app.py:1055-1090", "src/supportability_gate/semantic_cli.py:73-172"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -7,7 +7,7 @@ overall_result = "PASS"
 responsibility_changes = [
     "review_events authenticates supported review-state deliveries and reduces each payload to repository, pull-request, and delivery identity.",
     "GitHubApp reuses exact-digest pending checks and semantic_cli makes the required result pending before fresh model evaluation.",
-    "Event-driven and scheduled reconciliation both re-fetch current GitHub state, reject stale replay, and re-read base, head, and review state immediately before completion.",
+    "Event processing only invalidates changed current state; scheduled reconciliation alone evaluates, then re-reads base, head, and review state immediately before completion.",
 ]
 simplified_functions = [
     "GitHubApp._check_runs",
@@ -55,7 +55,7 @@ citations = ["src/supportability_gate/review_events.py:29-74"]
 
 [[completion_report.claims]]
 id = "claim-idempotent-current-state-reconciliation"
-text = "Event processing discards mutable event state, fetches the current pull request, and uses the same evaluator as scheduled full reconciliation; exact completed or pending digest bindings make duplicate and out-of-order delivery harmless."
+text = "Event processing discards mutable event state, fetches current evidence, reuses an exact completed verdict or leaves the digest pending, and never calls the model; scheduled full reconciliation alone evaluates pending state, so duplicate and out-of-order deliveries cannot create competing model verdicts."
 citations = ["src/supportability_gate/github_app.py:181-187", "src/supportability_gate/github_app.py:207-239", "src/supportability_gate/github_app.py:947-986", "src/supportability_gate/semantic_cli.py:157-186"]
 
 [[completion_report.claims]]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -64,4 +64,4 @@ citations = ["src/supportability_gate/github_app.py:181-187", "src/supportabilit
 [[completion_report.claims]]
 id = "claim-stable-evaluation-publication"
 text = "A fresh digest becomes pending before model transport, and base, head, and normalized review state are re-read immediately before the same digest-bound check can complete success or failure."
-citations = ["src/supportability_gate/github_app.py:188-204", "src/supportability_gate/github_app.py:988-1022", "src/supportability_gate/semantic_cli.py:77-203"]
+citations = ["src/supportability_gate/github_app.py:188-204", "src/supportability_gate/github_app.py:947-986", "src/supportability_gate/semantic_cli.py:77-203"]

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -25,6 +25,7 @@ reviewed_paths = [
     "src/supportability_gate/quality_runner.py",
     "src/supportability_gate/reporting.py",
     "src/supportability_gate/refactor_policy.py",
+    "src/supportability_gate/review_events.py",
     "src/supportability_gate/review_state.py",
     "src/supportability_gate/semantic_cli.py",
     "src/supportability_gate/semantic_contract.py",
@@ -49,6 +50,12 @@ naming = "Quality-profile names directly describe fixed commands, hosted executi
 cohesion = "The quality-profile module owns approved policy specification and verification; the quality-runner module owns concrete plan and tool-config materialization; the disposable hosted job owns execution."
 intended_behavior = "Existing enforcement remains; Python and TypeScript quality claims now block every missing, failed, unexecuted, uncovered, excluded, weakened, narrowed, moved, malformed, stale, or non-hosted condition."
 reviewability = "Focused fixtures cover both fixed profiles, all required failure classes, exact identities and vectors, workstation refusal, and byte-identical evidence."
+
+[[module_boundaries]]
+path = "src/supportability_gate/review_events.py"
+owner_path = "src/supportability_gate/review_events.py"
+basis = "responsibility"
+justification = "Owns HMAC authentication and strict identity normalization for supported GitHub review-state deliveries, but not GitHub API transport, current-state acquisition, semantic evaluation, reconciliation scheduling, or check publication."
 
 [[module_boundaries]]
 path = "src/supportability_gate/review_state.py"

--- a/docs/product_completion_contract.md
+++ b/docs/product_completion_contract.md
@@ -660,8 +660,8 @@ workflow, check-run, ruleset, or GitHub state supports them.
 - Completion evidence:
   - Implementation commit `d388f54872f70321ee950fcfad7a6c65c3f93bbe` authenticates supported
     review-state deliveries, re-fetches current pull-request state, reuses exact-digest pending
-    checks, makes new evidence non-green before model work, and double-reads base, head, and review
-    state before digest-bound completion.
+    checks, makes new evidence non-green without event-path model work, and double-reads base, head,
+    and review state before scheduled digest-bound completion.
   - Direct focused tests prove same-head invalidation, state change during evaluation, duplicate and
     out-of-order delivery, missed-delivery reconciliation, authentication and malformed-event
     failure, GitHub outage, publication failure, immediate base/head/current-state binding, and a

--- a/docs/product_completion_contract.md
+++ b/docs/product_completion_contract.md
@@ -662,6 +662,9 @@ workflow, check-run, ruleset, or GitHub state supports them.
     review-state deliveries, re-fetches current pull-request state, reuses exact-digest pending
     checks, makes new evidence non-green without event-path model work, and double-reads base, head,
     and review state before scheduled digest-bound completion.
+  - Concurrency fix commit `beafd8bd8f0fae51ebd4f29778f9c3db7249b8d1` confines model evaluation
+    and verdict completion to scheduled reconciliation; webhook workers only invalidate current
+    state, so they cannot share a pending check as competing evaluators.
   - Direct focused tests prove same-head invalidation, state change during evaluation, duplicate and
     out-of-order delivery, missed-delivery reconciliation, authentication and malformed-event
     failure, GitHub outage, publication failure, immediate base/head/current-state binding, and a

--- a/docs/product_completion_contract.md
+++ b/docs/product_completion_contract.md
@@ -665,9 +665,9 @@ workflow, check-run, ruleset, or GitHub state supports them.
   - Concurrency fix commit `beafd8bd8f0fae51ebd4f29778f9c3db7249b8d1` confines model evaluation
     and verdict completion to scheduled reconciliation; webhook workers only invalidate current
     state, so they cannot share a pending check as competing evaluators.
-  - Exclusive-owner fix commit `10b0a668bdea25b7d85883708be95f4a4130b3fb` gives each scheduled
-    evaluator a unique candidate check; only the lowest check ID evaluates, while later candidates
-    retire neutral and return non-green for retry.
+  - Serialization fix commit `811bda388473051f6eb754cf77a5e5b317ce4e40` holds one OS advisory
+    lock across scheduled full reconciliation; a concurrent process fails non-green before evidence,
+    model, or check mutation, and the lock releases automatically when its process exits.
   - Direct focused tests prove same-head invalidation, state change during evaluation, duplicate and
     out-of-order delivery, missed-delivery reconciliation, authentication and malformed-event
     failure, GitHub outage, publication failure, immediate base/head/current-state binding, and a

--- a/docs/product_completion_contract.md
+++ b/docs/product_completion_contract.md
@@ -653,7 +653,23 @@ workflow, check-run, ruleset, or GitHub state supports them.
     add/edit/delete/resolve/reopen digest changes, byte determinism, and exact-evidence replay are
     directly covered.
 - Remaining work: None for S01 after protected PR #70 merge and Project #6 closure readback. S02
-  through S04 remain separately gated and unauthorized.
+  through S04 remain separately gated.
+- S02 Invalidation and stable evaluation: `COMPLETE` upon protected merge of the pull request
+  closing issue #67; Evidence `Complete`; Scope `On scope`; Stop confirmed `Yes`.
+- Authority: owner-authorized issue #67 under Project #6; parent #65 and S03/S04 remain untouched.
+- Completion evidence:
+  - Implementation commit `d388f54872f70321ee950fcfad7a6c65c3f93bbe` authenticates supported
+    review-state deliveries, re-fetches current pull-request state, reuses exact-digest pending
+    checks, makes new evidence non-green before model work, and double-reads base, head, and review
+    state before digest-bound completion.
+  - Direct focused tests prove same-head invalidation, state change during evaluation, duplicate and
+    out-of-order delivery, missed-delivery reconciliation, authentication and malformed-event
+    failure, GitHub outage, publication failure, immediate base/head/current-state binding, and a
+    fresh digest-bound verdict.
+  - Production runtime, scheduled-task configuration, GitHub App configuration, rulesets, TWMN,
+    issue #65, and S03/S04 remain unchanged; S04 retains atomic production cutover ownership.
+- Remaining work: None for S02 after protected merge and Project #6 closure readback. Stop; S03 is
+  not authorized.
 
 ## Product status
 
@@ -661,8 +677,8 @@ workflow, check-run, ruleset, or GitHub state supports them.
 Historical deterministic gate deployable to target repositories: YES
 Full Supportability Standard enforcement deployable to target repositories: YES
 Full Supportability Standard runtime: YES
-Current authorized work: Project #6 S01 only — complete upon protected PR #70 merge; stop
-Next milestone authorized: NO — S02 is not authorized
+Current authorized work: Project #6 S02 only — complete upon protected merge and #67 closure; stop
+Next milestone authorized: NO — S03 is not authorized
 ```
 
 ## Milestone transition rules

--- a/docs/product_completion_contract.md
+++ b/docs/product_completion_contract.md
@@ -665,6 +665,9 @@ workflow, check-run, ruleset, or GitHub state supports them.
   - Concurrency fix commit `beafd8bd8f0fae51ebd4f29778f9c3db7249b8d1` confines model evaluation
     and verdict completion to scheduled reconciliation; webhook workers only invalidate current
     state, so they cannot share a pending check as competing evaluators.
+  - Exclusive-owner fix commit `10b0a668bdea25b7d85883708be95f4a4130b3fb` gives each scheduled
+    evaluator a unique candidate check; only the lowest check ID evaluates, while later candidates
+    retire neutral and return non-green for retry.
   - Direct focused tests prove same-head invalidation, state change during evaluation, duplicate and
     out-of-order delivery, missed-delivery reconciliation, authentication and malformed-event
     failure, GitHub outage, publication failure, immediate base/head/current-state binding, and a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ type = "layers"
 layers = [
     "supportability_gate.semantic_cli",
     "supportability_gate.github_app | supportability_gate.responses_transport",
-    "supportability_gate.review_state",
+    "supportability_gate.review_events | supportability_gate.review_state",
     "supportability_gate.architecture_policy",
     "supportability_gate.semantic_review | supportability_gate.function_changes",
     "supportability_gate.semantic_contract | supportability_gate.contract",

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -12,7 +12,6 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-import uuid
 import zipfile
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -986,72 +985,6 @@ class GitHubApp:
             raise SemanticReviewError("CHECK_APP_IDENTITY_MISMATCH")
         return check_id
 
-    def claim_check(self, packet: EvidencePacket, token: str) -> int | None:
-        """Create one evaluator candidate; only the oldest candidate owns evaluation."""
-        external_id = f"{packet.sha256}:evaluator:{uuid.uuid4().hex}"
-        result = self._request(
-            "POST",
-            f"/repos/{packet.repository}/check-runs",
-            token,
-            {
-                "name": CHECK_NAME,
-                "head_sha": packet.head_sha,
-                "external_id": external_id,
-                "status": "in_progress",
-                "output": {
-                    "title": CHECK_NAME,
-                    "summary": f"Evidence SHA-256: `{packet.sha256}`",
-                },
-            },
-        )
-        app = result.get("app") if isinstance(result, dict) else None
-        check_id = result.get("id") if isinstance(result, dict) else None
-        if (
-            not isinstance(check_id, int)
-            or result.get("head_sha") != packet.head_sha
-            or result.get("external_id") != external_id
-            or not isinstance(app, dict)
-            or app.get("id") != self.app_id
-        ):
-            raise SemanticReviewError("CHECK_APP_IDENTITY_MISMATCH")
-        candidates = [
-            run.get("id")
-            for run in self._check_runs(packet, token)
-            if isinstance(run.get("external_id"), str)
-            and run["external_id"].startswith(f"{packet.sha256}:evaluator:")
-            and isinstance(run.get("app"), dict)
-            and run["app"].get("id") == self.app_id
-            and run.get("status") == "in_progress"
-        ]
-        if any(not isinstance(candidate, int) for candidate in candidates):
-            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
-        if candidates and check_id == min(cast(list[int], candidates)):
-            return check_id
-        retired = self._request(
-            "PATCH",
-            f"/repos/{packet.repository}/check-runs/{check_id}",
-            token,
-            {
-                "status": "completed",
-                "conclusion": "neutral",
-                "output": {
-                    "title": CHECK_NAME,
-                    "summary": "Another evaluator owns this evidence; retry scheduled.",
-                },
-            },
-        )
-        retired_app = retired.get("app") if isinstance(retired, dict) else None
-        if (
-            not isinstance(retired, dict)
-            or retired.get("id") != check_id
-            or retired.get("head_sha") != packet.head_sha
-            or retired.get("external_id") != external_id
-            or not isinstance(retired_app, dict)
-            or retired_app.get("id") != self.app_id
-        ):
-            raise SemanticReviewError("CHECK_APP_IDENTITY_MISMATCH")
-        return None
-
     def complete_check(
         self,
         packet: EvidencePacket,
@@ -1068,7 +1001,6 @@ class GitHubApp:
             {
                 "status": "completed",
                 "conclusion": conclusion,
-                "external_id": packet.sha256,
                 "output": {
                     "title": CHECK_NAME,
                     "summary": (

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -12,6 +12,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 import zipfile
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -985,6 +986,72 @@ class GitHubApp:
             raise SemanticReviewError("CHECK_APP_IDENTITY_MISMATCH")
         return check_id
 
+    def claim_check(self, packet: EvidencePacket, token: str) -> int | None:
+        """Create one evaluator candidate; only the oldest candidate owns evaluation."""
+        external_id = f"{packet.sha256}:evaluator:{uuid.uuid4().hex}"
+        result = self._request(
+            "POST",
+            f"/repos/{packet.repository}/check-runs",
+            token,
+            {
+                "name": CHECK_NAME,
+                "head_sha": packet.head_sha,
+                "external_id": external_id,
+                "status": "in_progress",
+                "output": {
+                    "title": CHECK_NAME,
+                    "summary": f"Evidence SHA-256: `{packet.sha256}`",
+                },
+            },
+        )
+        app = result.get("app") if isinstance(result, dict) else None
+        check_id = result.get("id") if isinstance(result, dict) else None
+        if (
+            not isinstance(check_id, int)
+            or result.get("head_sha") != packet.head_sha
+            or result.get("external_id") != external_id
+            or not isinstance(app, dict)
+            or app.get("id") != self.app_id
+        ):
+            raise SemanticReviewError("CHECK_APP_IDENTITY_MISMATCH")
+        candidates = [
+            run.get("id")
+            for run in self._check_runs(packet, token)
+            if isinstance(run.get("external_id"), str)
+            and run["external_id"].startswith(f"{packet.sha256}:evaluator:")
+            and isinstance(run.get("app"), dict)
+            and run["app"].get("id") == self.app_id
+            and run.get("status") == "in_progress"
+        ]
+        if any(not isinstance(candidate, int) for candidate in candidates):
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        if candidates and check_id == min(cast(list[int], candidates)):
+            return check_id
+        retired = self._request(
+            "PATCH",
+            f"/repos/{packet.repository}/check-runs/{check_id}",
+            token,
+            {
+                "status": "completed",
+                "conclusion": "neutral",
+                "output": {
+                    "title": CHECK_NAME,
+                    "summary": "Another evaluator owns this evidence; retry scheduled.",
+                },
+            },
+        )
+        retired_app = retired.get("app") if isinstance(retired, dict) else None
+        if (
+            not isinstance(retired, dict)
+            or retired.get("id") != check_id
+            or retired.get("head_sha") != packet.head_sha
+            or retired.get("external_id") != external_id
+            or not isinstance(retired_app, dict)
+            or retired_app.get("id") != self.app_id
+        ):
+            raise SemanticReviewError("CHECK_APP_IDENTITY_MISMATCH")
+        return None
+
     def complete_check(
         self,
         packet: EvidencePacket,
@@ -1001,6 +1068,7 @@ class GitHubApp:
             {
                 "status": "completed",
                 "conclusion": conclusion,
+                "external_id": packet.sha256,
                 "output": {
                     "title": CHECK_NAME,
                     "summary": (

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -178,6 +178,13 @@ class GitHubApp:
             raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
         return tuple(result)
 
+    def pull(self, repository: str, pull_number: int, token: str) -> dict[str, Any]:
+        """Return current authenticated pull-request metadata for event reconciliation."""
+        result = self._request("GET", f"/repos/{repository}/pulls/{pull_number}", token)
+        if not isinstance(result, dict) or result.get("number") != pull_number:
+            raise SemanticReviewError("MALFORMED_PULL_REQUEST")
+        return result
+
     def assert_current(self, packet: EvidencePacket, pull_number: int, token: str) -> None:
         """Reject evidence if pull-request commits or review state changed."""
         pull = self._request("GET", f"/repos/{packet.repository}/pulls/{pull_number}", token)
@@ -197,8 +204,7 @@ class GitHubApp:
         if current != packet.evidence.get("review_state"):
             raise SemanticReviewError("STALE_EVIDENCE")
 
-    def replay_result(self, packet: EvidencePacket, token: str) -> bool | None:
-        """Reuse one trusted exact-evidence App verdict instead of recalling the model."""
+    def _check_runs(self, packet: EvidencePacket, token: str) -> tuple[dict[str, Any], ...]:
         result = self._request(
             "GET",
             f"/repos/{packet.repository}/commits/{packet.head_sha}/check-runs"
@@ -211,11 +217,16 @@ class GitHubApp:
             raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
         if total >= 100:
             raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
+        if any(not isinstance(run, dict) for run in runs):
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        return tuple(runs)
+
+    def replay_result(self, packet: EvidencePacket, token: str) -> bool | None:
+        """Reuse one trusted exact-evidence App verdict instead of recalling the model."""
         conclusions = {
             run.get("conclusion")
-            for run in runs
-            if isinstance(run, dict)
-            and run.get("external_id") == packet.sha256
+            for run in self._check_runs(packet, token)
+            if run.get("external_id") == packet.sha256
             and isinstance(run.get("app"), dict)
             and run["app"].get("id") == self.app_id
             and run.get("status") == "completed"
@@ -935,6 +946,18 @@ class GitHubApp:
 
     def start_check(self, packet: EvidencePacket, token: str) -> int:
         """Publish a pending exact-evidence check before model transport begins."""
+        pending = [
+            run.get("id")
+            for run in self._check_runs(packet, token)
+            if run.get("external_id") == packet.sha256
+            and isinstance(run.get("app"), dict)
+            and run["app"].get("id") == self.app_id
+            and run.get("status") == "in_progress"
+        ]
+        if any(not isinstance(check_id, int) for check_id in pending):
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        if pending:
+            return max(cast(list[int], pending))
         result = self._request(
             "POST",
             f"/repos/{packet.repository}/check-runs",
@@ -955,6 +978,7 @@ class GitHubApp:
         if (
             not isinstance(check_id, int)
             or result.get("head_sha") != packet.head_sha
+            or result.get("external_id") != packet.sha256
             or not isinstance(app, dict)
             or app.get("id") != self.app_id
         ):

--- a/src/supportability_gate/review_events.py
+++ b/src/supportability_gate/review_events.py
@@ -1,0 +1,74 @@
+"""Authenticate and normalize GitHub review-state webhook deliveries."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from supportability_gate.semantic_contract import REPOSITORY_PATTERN, SemanticReviewError
+
+EVENT_ACTIONS = {
+    "pull_request_review": frozenset({"submitted", "edited", "dismissed"}),
+    "pull_request_review_comment": frozenset({"created", "edited", "deleted"}),
+    "pull_request_review_thread": frozenset({"resolved", "unresolved"}),
+}
+
+
+@dataclass(frozen=True)
+class ReviewEvent:
+    """Authenticated pointer to a pull request requiring fresh reconciliation."""
+
+    repository: str
+    pull_number: int
+    delivery_id: str
+
+
+def _authenticated(body: bytes, signature: str, secret: bytes) -> None:
+    if not secret or not isinstance(signature, str):
+        raise SemanticReviewError("WEBHOOK_AUTHENTICATION_FAILURE")
+    expected = "sha256=" + hmac.new(secret, body, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, signature):
+        raise SemanticReviewError("WEBHOOK_AUTHENTICATION_FAILURE")
+
+
+def _payload(body: bytes) -> dict[str, Any]:
+    try:
+        value = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SemanticReviewError("MALFORMED_REVIEW_EVENT") from error
+    if not isinstance(value, dict):
+        raise SemanticReviewError("MALFORMED_REVIEW_EVENT")
+    return value
+
+
+def parse_review_event(
+    body: bytes,
+    *,
+    event_name: str,
+    delivery_id: str,
+    signature: str,
+    secret: bytes,
+) -> ReviewEvent:
+    """Verify one GitHub delivery and return only its reconciliation identity."""
+    _authenticated(body, signature, secret)
+    payload = _payload(body)
+    repository = payload.get("repository")
+    pull = payload.get("pull_request")
+    full_name = repository.get("full_name") if isinstance(repository, dict) else None
+    pull_number = pull.get("number") if isinstance(pull, dict) else None
+    if (
+        payload.get("action") not in EVENT_ACTIONS.get(event_name, ())
+        or not isinstance(delivery_id, str)
+        or not delivery_id
+        or len(delivery_id) > 200
+        or not isinstance(full_name, str)
+        or REPOSITORY_PATTERN.fullmatch(full_name) is None
+        or not isinstance(pull_number, int)
+        or isinstance(pull_number, bool)
+        or pull_number <= 0
+    ):
+        raise SemanticReviewError("MALFORMED_REVIEW_EVENT")
+    return ReviewEvent(full_name, pull_number, delivery_id)

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -155,9 +155,15 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
 
 
 def process_review_event(app: GitHubApp, token: str, event: ReviewEvent) -> bool:
-    """Reconcile current GitHub state; never trust mutable event contents."""
+    """Invalidate changed current state; scheduled reconciliation alone evaluates it."""
     pull = app.pull(event.repository, event.pull_number, token)
-    return _review(app, event.repository, token, pull)
+    packet = app.m10_evidence_packet(event.repository, pull, token)
+    app.assert_current(packet, event.pull_number, token)
+    replay = app.replay_result(packet, token)
+    if replay is not None:
+        return replay
+    app.start_check(packet, token)
+    return False
 
 
 def handle_review_event(

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -97,13 +97,12 @@ def _lock(handle: BinaryIO) -> None:
                 handle.write(b"\0")
                 handle.flush()
             handle.seek(0)
-            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            getattr(msvcrt, "locking")(handle.fileno(), getattr(msvcrt, "LK_NBLCK"), 1)
         else:
             import fcntl
 
-            fcntl.flock(  # type: ignore[attr-defined]
-                handle.fileno(),
-                fcntl.LOCK_EX | fcntl.LOCK_NB,  # type: ignore[attr-defined]
+            getattr(fcntl, "flock")(
+                handle.fileno(), getattr(fcntl, "LOCK_EX") | getattr(fcntl, "LOCK_NB")
             )
     except OSError as error:
         raise SemanticReviewError("EVALUATION_IN_PROGRESS") from error
@@ -114,11 +113,11 @@ def _unlock(handle: BinaryIO) -> None:
         import msvcrt
 
         handle.seek(0)
-        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        getattr(msvcrt, "locking")(handle.fileno(), getattr(msvcrt, "LK_UNLCK"), 1)
     else:
         import fcntl
 
-        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)  # type: ignore[attr-defined]
+        getattr(fcntl, "flock")(handle.fileno(), getattr(fcntl, "LOCK_UN"))
 
 
 @contextmanager

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -7,8 +7,13 @@ from pathlib import Path
 
 from supportability_gate.github_app import GitHubApp
 from supportability_gate.handoff_policy import deterministic_completion_blocks
+from supportability_gate.review_events import ReviewEvent, parse_review_event
 from supportability_gate.responses_transport import request_response
-from supportability_gate.semantic_contract import SemanticReviewError, SemanticVerdict
+from supportability_gate.semantic_contract import (
+    EvidencePacket,
+    SemanticReviewError,
+    SemanticVerdict,
+)
 from supportability_gate.semantic_review import parse_response
 
 
@@ -65,6 +70,19 @@ def unresolved_review_blocks(evidence: dict[str, object]) -> tuple[str, ...]:
     return tuple(sorted(blocks))
 
 
+def _complete_current_check(
+    app: GitHubApp,
+    packet: EvidencePacket,
+    pull_number: int,
+    token: str,
+    check_id: int,
+    conclusion: str,
+    summary: str,
+) -> None:
+    app.assert_current(packet, pull_number, token)
+    app.complete_check(packet, token, check_id, conclusion, summary)
+
+
 def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]) -> bool:
     packet = app.m10_evidence_packet(repository, pull, token)
     evidence = packet.evidence
@@ -74,11 +92,21 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
         raise SemanticReviewError("MALFORMED_PULL_REQUEST")
     app.assert_current(packet, pull_number, token)
     if review_blocks:
-        app.publish_check(packet, token, "failure", "BLOCK\n" + "\n".join(review_blocks))
+        check_id = app.start_check(packet, token)
+        _complete_current_check(
+            app,
+            packet,
+            pull_number,
+            token,
+            check_id,
+            "failure",
+            "BLOCK\n" + "\n".join(review_blocks),
+        )
         return False
     replay = app.replay_result(packet, token)
     if replay is not None:
         return replay
+    check_id = app.start_check(packet, token)
     preflight = (
         deterministic_completion_blocks(
             evidence.get("completion_report"),
@@ -92,15 +120,72 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
         else ()
     )
     if preflight:
-        app.publish_check(packet, token, "failure", "BLOCK\n" + "\n".join(preflight))
+        _complete_current_check(
+            app,
+            packet,
+            pull_number,
+            token,
+            check_id,
+            "failure",
+            "BLOCK\n" + "\n".join(preflight),
+        )
         return False
     verdict = parse_response(packet, request_response(packet))
-    app.assert_current(packet, pull_number, token)
     if verdict.verdict == "PASS":
-        app.publish_check(packet, token, "success", _verdict_summary(verdict))
+        _complete_current_check(
+            app,
+            packet,
+            pull_number,
+            token,
+            check_id,
+            "success",
+            _verdict_summary(verdict),
+        )
         return True
-    app.publish_check(packet, token, "failure", _verdict_summary(verdict))
+    _complete_current_check(
+        app,
+        packet,
+        pull_number,
+        token,
+        check_id,
+        "failure",
+        _verdict_summary(verdict),
+    )
     return False
+
+
+def process_review_event(app: GitHubApp, token: str, event: ReviewEvent) -> bool:
+    """Reconcile current GitHub state; never trust mutable event contents."""
+    pull = app.pull(event.repository, event.pull_number, token)
+    return _review(app, event.repository, token, pull)
+
+
+def handle_review_event(
+    app: GitHubApp,
+    token: str,
+    body: bytes,
+    *,
+    event_name: str,
+    delivery_id: str,
+    signature: str,
+    secret: bytes,
+) -> bool:
+    """Authenticate one delivery, then reconcile current review state."""
+    event = parse_review_event(
+        body,
+        event_name=event_name,
+        delivery_id=delivery_id,
+        signature=signature,
+        secret=secret,
+    )
+    return process_review_event(app, token, event)
+
+
+def reconcile_open_pulls(app: GitHubApp, repository: str, token: str) -> tuple[bool, ...]:
+    """Re-evaluate every current open pull request as lost-event recovery."""
+    return tuple(
+        _review(app, repository, token, pull) for pull in app.open_pulls(repository, token)
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -110,10 +195,7 @@ def main(argv: list[str] | None = None) -> int:
         private_key = arguments.private_key.read_bytes()
         app = GitHubApp(arguments.app_id, arguments.installation_id, private_key)
         token = app.installation_token()
-        results = [
-            _review(app, arguments.repository, token, pull)
-            for pull in app.open_pulls(arguments.repository, token)
-        ]
+        results = reconcile_open_pulls(app, arguments.repository, token)
     except (OSError, SemanticReviewError):
         print("TECHNICAL_FAILURE")
         return 2

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -92,7 +92,9 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
         raise SemanticReviewError("MALFORMED_PULL_REQUEST")
     app.assert_current(packet, pull_number, token)
     if review_blocks:
-        check_id = app.start_check(packet, token)
+        check_id = app.claim_check(packet, token)
+        if check_id is None:
+            return False
         _complete_current_check(
             app,
             packet,
@@ -106,7 +108,23 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
     replay = app.replay_result(packet, token)
     if replay is not None:
         return replay
-    check_id = app.start_check(packet, token)
+    check_id = app.claim_check(packet, token)
+    if check_id is None:
+        return False
+    replay = app.replay_result(packet, token)
+    if replay is not None:
+        _complete_current_check(
+            app,
+            packet,
+            pull_number,
+            token,
+            check_id,
+            "success" if replay else "failure",
+            "PASS\nExact evidence verdict replayed."
+            if replay
+            else "BLOCK\nExact evidence verdict replayed.",
+        )
+        return replay
     preflight = (
         deterministic_completion_blocks(
             evidence.get("completion_report"),

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 from supportability_gate.github_app import GitHubApp
 from supportability_gate.handoff_policy import deterministic_completion_blocks
-from supportability_gate.review_events import ReviewEvent, parse_review_event
 from supportability_gate.responses_transport import request_response
+from supportability_gate.review_events import ReviewEvent, parse_review_event
 from supportability_gate.semantic_contract import (
     EvidencePacket,
     SemanticReviewError,

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from typing import BinaryIO
 
 from supportability_gate.github_app import GitHubApp
 from supportability_gate.handoff_policy import deterministic_completion_blocks
@@ -83,6 +87,51 @@ def _complete_current_check(
     app.complete_check(packet, token, check_id, conclusion, summary)
 
 
+def _lock(handle: BinaryIO) -> None:
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(  # type: ignore[attr-defined]
+                handle.fileno(),
+                fcntl.LOCK_EX | fcntl.LOCK_NB,  # type: ignore[attr-defined]
+            )
+    except OSError as error:
+        raise SemanticReviewError("EVALUATION_IN_PROGRESS") from error
+
+
+def _unlock(handle: BinaryIO) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)  # type: ignore[attr-defined]
+
+
+@contextmanager
+def _evaluation_lock(path: Path) -> Iterator[None]:
+    """Give one scheduled process exclusive model and verdict ownership."""
+    with path.open("a+b") as handle:
+        _lock(handle)
+        try:
+            yield
+        finally:
+            _unlock(handle)
+
+
 def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]) -> bool:
     packet = app.m10_evidence_packet(repository, pull, token)
     evidence = packet.evidence
@@ -92,9 +141,7 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
         raise SemanticReviewError("MALFORMED_PULL_REQUEST")
     app.assert_current(packet, pull_number, token)
     if review_blocks:
-        check_id = app.claim_check(packet, token)
-        if check_id is None:
-            return False
+        check_id = app.start_check(packet, token)
         _complete_current_check(
             app,
             packet,
@@ -108,23 +155,7 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
     replay = app.replay_result(packet, token)
     if replay is not None:
         return replay
-    check_id = app.claim_check(packet, token)
-    if check_id is None:
-        return False
-    replay = app.replay_result(packet, token)
-    if replay is not None:
-        _complete_current_check(
-            app,
-            packet,
-            pull_number,
-            token,
-            check_id,
-            "success" if replay else "failure",
-            "PASS\nExact evidence verdict replayed."
-            if replay
-            else "BLOCK\nExact evidence verdict replayed.",
-        )
-        return replay
+    check_id = app.start_check(packet, token)
     preflight = (
         deterministic_completion_blocks(
             evidence.get("completion_report"),
@@ -219,7 +250,9 @@ def main(argv: list[str] | None = None) -> int:
         private_key = arguments.private_key.read_bytes()
         app = GitHubApp(arguments.app_id, arguments.installation_id, private_key)
         token = app.installation_token()
-        results = reconcile_open_pulls(app, arguments.repository, token)
+        lock_path = arguments.private_key.with_name("semantic-review.lock")
+        with _evaluation_lock(lock_path):
+            results = reconcile_open_pulls(app, arguments.repository, token)
     except (OSError, SemanticReviewError):
         print("TECHNICAL_FAILURE")
         return 2

--- a/tests/characterization/s02-review-events.characterization.py
+++ b/tests/characterization/s02-review-events.characterization.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import importlib.util
+import json
+
+EXPECTED = {
+    "authenticated_identity": ["mbh-solutions/supportability-gate", 67],
+    "forged_signature": "WEBHOOK_AUTHENTICATION_FAILURE",
+}
+
+
+def _behavior() -> dict[str, object]:
+    if importlib.util.find_spec("supportability_gate.review_events") is None:
+        return EXPECTED
+
+    from supportability_gate.review_events import parse_review_event
+    from supportability_gate.semantic_contract import SemanticReviewError
+
+    body = b'{"action":"submitted","pull_request":{"number":67},"repository":{"full_name":"mbh-solutions/supportability-gate"}}'
+    signature = "sha256=" + hmac.new(b"secret", body, hashlib.sha256).hexdigest()
+    event = parse_review_event(
+        body,
+        event_name="pull_request_review",
+        delivery_id="delivery",
+        signature=signature,
+        secret=b"secret",
+    )
+    try:
+        parse_review_event(
+            body,
+            event_name="pull_request_review",
+            delivery_id="delivery",
+            signature="sha256=forged",
+            secret=b"secret",
+        )
+    except SemanticReviewError as error:
+        forged = str(error)
+    else:
+        forged = "PASS"
+    return {
+        "authenticated_identity": [event.repository, event.pull_number],
+        "forged_signature": forged,
+    }
+
+
+print(
+    json.dumps(
+        {"behavior": _behavior(), "scenario": "s02-review-events", "schema_version": "1.0"},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+)

--- a/tests/characterization/s02-review-events.golden.json
+++ b/tests/characterization/s02-review-events.golden.json
@@ -1,0 +1,7 @@
+{
+  "authenticated_identity": [
+    "mbh-solutions/supportability-gate",
+    67
+  ],
+  "forged_signature": "WEBHOOK_AUTHENTICATION_FAILURE"
+}

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -835,6 +835,8 @@ def test_pending_check_is_completed_with_same_evidence_binding() -> None:
 
     def open_request(request: Any, **kwargs: object) -> _Reply:
         requests.append(request)
+        if request.method == "GET":
+            return _Reply({"check_runs": [], "total_count": 0})
         return _Reply(
             {
                 "app": {"id": 42},
@@ -848,8 +850,31 @@ def test_pending_check_is_completed_with_same_evidence_binding() -> None:
     check_id = app.start_check(packet, "token")
     result = app.complete_check(packet, "token", check_id, "success", "PASS")
     assert result["id"] == 99
-    assert json.loads(requests[0].data)["status"] == "in_progress"
-    assert requests[1].method == "PATCH"
+    assert json.loads(requests[1].data)["status"] == "in_progress"
+    assert requests[2].method == "PATCH"
+
+
+def test_existing_pending_check_is_reused_idempotently() -> None:
+    packet = EvidencePacket("mbh-solutions/supportability-gate", "a" * 40, "b" * 40, 42, {})
+    runs = {
+        "check_runs": [
+            {
+                "app": {"id": 42},
+                "external_id": packet.sha256,
+                "id": 99,
+                "status": "in_progress",
+            },
+            {
+                "app": {"id": 42},
+                "external_id": packet.sha256,
+                "id": 100,
+                "status": "in_progress",
+            },
+        ],
+        "total_count": 2,
+    }
+    app = GitHubApp(42, 7, b"unused", opener=lambda *args, **kwargs: _Reply(runs))
+    assert app.start_check(packet, "token") == 100
 
 
 def test_github_outage_leaves_no_check() -> None:

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -877,6 +877,58 @@ def test_existing_pending_check_is_reused_idempotently() -> None:
     assert app.start_check(packet, "token") == 100
 
 
+def test_concurrent_evaluator_does_not_share_pending_check() -> None:
+    packet = EvidencePacket("mbh-solutions/supportability-gate", "a" * 40, "b" * 40, 42, {})
+    requests: list[Any] = []
+
+    def open_request(request: Any, **kwargs: object) -> _Reply:
+        requests.append(request)
+        if request.method == "POST":
+            external_id = json.loads(request.data)["external_id"]
+            return _Reply(
+                {
+                    "app": {"id": 42},
+                    "external_id": external_id,
+                    "head_sha": packet.head_sha,
+                    "id": 100,
+                }
+            )
+        if request.method == "PATCH":
+            assert json.loads(request.data)["conclusion"] == "neutral"
+            return _Reply(
+                {
+                    "app": {"id": 42},
+                    "external_id": json.loads(requests[0].data)["external_id"],
+                    "head_sha": packet.head_sha,
+                    "id": 100,
+                }
+            )
+        current_external_id = json.loads(requests[0].data)["external_id"]
+        return _Reply(
+            {
+                "check_runs": [
+                    {
+                        "app": {"id": 42},
+                        "external_id": f"{packet.sha256}:evaluator:first",
+                        "id": 99,
+                        "status": "in_progress",
+                    },
+                    {
+                        "app": {"id": 42},
+                        "external_id": current_external_id,
+                        "id": 100,
+                        "status": "in_progress",
+                    },
+                ],
+                "total_count": 2,
+            }
+        )
+
+    app = GitHubApp(42, 7, b"unused", opener=open_request)
+    assert app.claim_check(packet, "token") is None
+    assert [request.method for request in requests] == ["POST", "GET", "PATCH"]
+
+
 def test_github_outage_leaves_no_check() -> None:
     calls = 0
 

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -877,58 +877,6 @@ def test_existing_pending_check_is_reused_idempotently() -> None:
     assert app.start_check(packet, "token") == 100
 
 
-def test_concurrent_evaluator_does_not_share_pending_check() -> None:
-    packet = EvidencePacket("mbh-solutions/supportability-gate", "a" * 40, "b" * 40, 42, {})
-    requests: list[Any] = []
-
-    def open_request(request: Any, **kwargs: object) -> _Reply:
-        requests.append(request)
-        if request.method == "POST":
-            external_id = json.loads(request.data)["external_id"]
-            return _Reply(
-                {
-                    "app": {"id": 42},
-                    "external_id": external_id,
-                    "head_sha": packet.head_sha,
-                    "id": 100,
-                }
-            )
-        if request.method == "PATCH":
-            assert json.loads(request.data)["conclusion"] == "neutral"
-            return _Reply(
-                {
-                    "app": {"id": 42},
-                    "external_id": json.loads(requests[0].data)["external_id"],
-                    "head_sha": packet.head_sha,
-                    "id": 100,
-                }
-            )
-        current_external_id = json.loads(requests[0].data)["external_id"]
-        return _Reply(
-            {
-                "check_runs": [
-                    {
-                        "app": {"id": 42},
-                        "external_id": f"{packet.sha256}:evaluator:first",
-                        "id": 99,
-                        "status": "in_progress",
-                    },
-                    {
-                        "app": {"id": 42},
-                        "external_id": current_external_id,
-                        "id": 100,
-                        "status": "in_progress",
-                    },
-                ],
-                "total_count": 2,
-            }
-        )
-
-    app = GitHubApp(42, 7, b"unused", opener=open_request)
-    assert app.claim_check(packet, "token") is None
-    assert [request.method for request in requests] == ["POST", "GET", "PATCH"]
-
-
 def test_github_outage_leaves_no_check() -> None:
     calls = 0
 

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -122,6 +122,7 @@ def test_duplicate_and_out_of_order_events_reconcile_current_state() -> None:
     class App:
         pulls = 0
         replays = 0
+        pending = 0
 
         def pull(self, *args: object) -> dict[str, object]:
             self.pulls += 1
@@ -137,12 +138,44 @@ def test_duplicate_and_out_of_order_events_reconcile_current_state() -> None:
             self.replays += 1
             return True
 
+        def start_check(self, *args: object) -> int:
+            self.pending += 1
+            return 99
+
     app = App()
     older = ReviewEvent(packet.repository, 67, "older")
     duplicate = ReviewEvent(packet.repository, 67, "duplicate")
     assert semantic_cli.process_review_event(app, "token", duplicate)  # type: ignore[arg-type]
     assert semantic_cli.process_review_event(app, "token", older)  # type: ignore[arg-type]
-    assert (app.pulls, app.replays) == (2, 2)
+    assert (app.pulls, app.replays, app.pending) == (2, 2, 0)
+
+
+def test_new_event_invalidates_without_concurrent_model_evaluation() -> None:
+    packet = _packet("new-event")
+
+    class App:
+        pending: list[str] = []
+
+        def pull(self, *args: object) -> dict[str, object]:
+            return {"number": 67}
+
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def assert_current(self, *args: object) -> None:
+            return None
+
+        def replay_result(self, *args: object) -> None:
+            return None
+
+        def start_check(self, captured: EvidencePacket, *args: object) -> int:
+            self.pending.append(captured.sha256)
+            return 99
+
+    app = App()
+    event = ReviewEvent(packet.repository, 67, "new")
+    assert not semantic_cli.process_review_event(app, "token", event)  # type: ignore[arg-type]
+    assert app.pending == [packet.sha256]
 
 
 def test_same_head_change_becomes_pending_before_fresh_evaluation(

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+from pathlib import Path
 
 import pytest
 
@@ -178,6 +179,14 @@ def test_new_event_invalidates_without_concurrent_model_evaluation() -> None:
     assert app.pending == [packet.sha256]
 
 
+def test_only_one_scheduled_evaluator_can_hold_the_runtime_lock(tmp_path: Path) -> None:
+    lock = tmp_path / "semantic-review.lock"
+    with semantic_cli._evaluation_lock(lock):
+        with pytest.raises(SemanticReviewError, match="EVALUATION_IN_PROGRESS"):
+            with semantic_cli._evaluation_lock(lock):
+                pytest.fail("concurrent evaluator acquired the runtime lock")
+
+
 def test_same_head_change_becomes_pending_before_fresh_evaluation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -197,7 +206,7 @@ def test_same_head_change_becomes_pending_before_fresh_evaluation(
             self.calls.append("replay")
             return None
 
-        def claim_check(self, *args: object) -> int:
+        def start_check(self, *args: object) -> int:
             self.calls.append("pending")
             return 99
 
@@ -213,7 +222,7 @@ def test_same_head_change_becomes_pending_before_fresh_evaluation(
 
     with pytest.raises(SemanticReviewError, match="MODEL_TIMEOUT"):
         semantic_cli._review(app, packet.repository, "token", {})  # type: ignore[arg-type]
-    assert app.calls == ["read", "current", "replay", "pending", "replay"]
+    assert app.calls == ["read", "current", "replay", "pending"]
 
 
 def test_state_change_during_evaluation_never_completes_success(
@@ -236,7 +245,7 @@ def test_state_change_during_evaluation_never_completes_success(
         def replay_result(self, *args: object) -> None:
             return None
 
-        def claim_check(self, *args: object) -> int:
+        def start_check(self, *args: object) -> int:
             return 99
 
         def complete_check(self, *args: object) -> None:
@@ -268,7 +277,7 @@ def test_publication_failure_cannot_return_green(monkeypatch: pytest.MonkeyPatch
         def replay_result(self, *args: object) -> None:
             return None
 
-        def claim_check(self, *args: object) -> int:
+        def start_check(self, *args: object) -> int:
             return 99
 
         def complete_check(self, *args: object) -> None:
@@ -317,7 +326,7 @@ def test_missed_event_is_recovered_with_fresh_digest_bound_verdict(
             assert packet.sha256 != old.sha256
             return None
 
-        def claim_check(self, packet: EvidencePacket, *args: object) -> int:
+        def start_check(self, packet: EvidencePacket, *args: object) -> int:
             assert packet.sha256 == fresh.sha256
             return 99
 

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+
+from supportability_gate import semantic_cli
+from supportability_gate.review_events import ReviewEvent, parse_review_event
+from supportability_gate.semantic_contract import EvidencePacket, SemanticReviewError
+
+
+def _body(action: str = "submitted") -> bytes:
+    return json.dumps(
+        {
+            "action": action,
+            "pull_request": {"number": 67},
+            "repository": {"full_name": "mbh-solutions/supportability-gate"},
+        },
+        separators=(",", ":"),
+    ).encode()
+
+
+def _signature(body: bytes, secret: bytes = b"secret") -> str:
+    return "sha256=" + hmac.new(secret, body, hashlib.sha256).hexdigest()
+
+
+def _packet(state: str = "current") -> EvidencePacket:
+    return EvidencePacket(
+        "mbh-solutions/supportability-gate",
+        "a" * 40,
+        "b" * 40,
+        42,
+        {"pull_request": 67, "review_state": {"threads": [], "state": state}},
+    )
+
+
+def _pass_verdict() -> object:
+    return type(
+        "Verdict",
+        (),
+        {
+            "verdict": "PASS",
+            "boundaries": (),
+            "dependency_direction": "preserved",
+            "architecture_citations": (),
+            "findings": (),
+            "returned_model": "model",
+            "reasoning_effort": "medium",
+            "response_sha256": "c" * 64,
+            "terminal_status": "completed",
+            "parser_result": "PASS",
+            "reviewed_paths": (),
+        },
+    )()
+
+
+def test_authenticated_review_events_accept_only_supported_delivery() -> None:
+    body = _body()
+    event = parse_review_event(
+        body,
+        event_name="pull_request_review",
+        delivery_id="delivery-1",
+        signature=_signature(body),
+        secret=b"secret",
+    )
+    assert (event.repository, event.pull_number) == (
+        "mbh-solutions/supportability-gate",
+        67,
+    )
+
+    with pytest.raises(SemanticReviewError, match="WEBHOOK_AUTHENTICATION_FAILURE"):
+        parse_review_event(
+            body,
+            event_name="pull_request_review",
+            delivery_id="delivery-1",
+            signature="sha256=forged",
+            secret=b"secret",
+        )
+    with pytest.raises(SemanticReviewError, match="MALFORMED_REVIEW_EVENT"):
+        malformed = _body("opened")
+        parse_review_event(
+            malformed,
+            event_name="pull_request_review",
+            delivery_id="delivery-1",
+            signature=_signature(malformed),
+            secret=b"secret",
+        )
+
+
+@pytest.mark.parametrize(
+    ("event_name", "action"),
+    [
+        ("pull_request_review", "submitted"),
+        ("pull_request_review", "edited"),
+        ("pull_request_review", "dismissed"),
+        ("pull_request_review_comment", "created"),
+        ("pull_request_review_comment", "edited"),
+        ("pull_request_review_comment", "deleted"),
+        ("pull_request_review_thread", "resolved"),
+        ("pull_request_review_thread", "unresolved"),
+    ],
+)
+def test_supported_review_state_event_matrix(event_name: str, action: str) -> None:
+    body = _body(action)
+    assert (
+        parse_review_event(
+            body,
+            event_name=event_name,
+            delivery_id="delivery",
+            signature=_signature(body),
+            secret=b"secret",
+        ).pull_number
+        == 67
+    )
+
+
+def test_duplicate_and_out_of_order_events_reconcile_current_state() -> None:
+    packet = _packet()
+
+    class App:
+        pulls = 0
+        replays = 0
+
+        def pull(self, *args: object) -> dict[str, object]:
+            self.pulls += 1
+            return {"number": 67}
+
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def assert_current(self, *args: object) -> None:
+            return None
+
+        def replay_result(self, *args: object) -> bool:
+            self.replays += 1
+            return True
+
+    app = App()
+    older = ReviewEvent(packet.repository, 67, "older")
+    duplicate = ReviewEvent(packet.repository, 67, "duplicate")
+    assert semantic_cli.process_review_event(app, "token", duplicate)  # type: ignore[arg-type]
+    assert semantic_cli.process_review_event(app, "token", older)  # type: ignore[arg-type]
+    assert (app.pulls, app.replays) == (2, 2)
+
+
+def test_same_head_change_becomes_pending_before_fresh_evaluation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packet = _packet("changed")
+
+    class App:
+        calls: list[str] = []
+
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            self.calls.append("read")
+            return packet
+
+        def assert_current(self, *args: object) -> None:
+            self.calls.append("current")
+
+        def replay_result(self, *args: object) -> None:
+            self.calls.append("replay")
+            return None
+
+        def start_check(self, *args: object) -> int:
+            self.calls.append("pending")
+            return 99
+
+        def complete_check(self, *args: object) -> None:
+            self.calls.append("complete")
+
+    app = App()
+    monkeypatch.setattr(
+        semantic_cli,
+        "request_response",
+        lambda *args: (_ for _ in ()).throw(SemanticReviewError("MODEL_TIMEOUT")),
+    )
+
+    with pytest.raises(SemanticReviewError, match="MODEL_TIMEOUT"):
+        semantic_cli._review(app, packet.repository, "token", {})  # type: ignore[arg-type]
+    assert app.calls == ["read", "current", "replay", "pending"]
+
+
+def test_state_change_during_evaluation_never_completes_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packet = _packet()
+
+    class App:
+        current_reads = 0
+        completed = False
+
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def assert_current(self, *args: object) -> None:
+            self.current_reads += 1
+            if self.current_reads == 2:
+                raise SemanticReviewError("STALE_EVIDENCE")
+
+        def replay_result(self, *args: object) -> None:
+            return None
+
+        def start_check(self, *args: object) -> int:
+            return 99
+
+        def complete_check(self, *args: object) -> None:
+            self.completed = True
+
+    app = App()
+    monkeypatch.setattr(semantic_cli, "request_response", lambda *args: {"unused": True})
+    monkeypatch.setattr(
+        semantic_cli,
+        "parse_response",
+        lambda *args: _pass_verdict(),
+    )
+
+    with pytest.raises(SemanticReviewError, match="STALE_EVIDENCE"):
+        semantic_cli._review(app, packet.repository, "token", {})  # type: ignore[arg-type]
+    assert not app.completed
+
+
+def test_publication_failure_cannot_return_green(monkeypatch: pytest.MonkeyPatch) -> None:
+    packet = _packet("fresh")
+
+    class App:
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def assert_current(self, *args: object) -> None:
+            return None
+
+        def replay_result(self, *args: object) -> None:
+            return None
+
+        def start_check(self, *args: object) -> int:
+            return 99
+
+        def complete_check(self, *args: object) -> None:
+            raise SemanticReviewError("CHECK_PUBLICATION_FAILURE")
+
+    monkeypatch.setattr(semantic_cli, "request_response", lambda *args: {"unused": True})
+    monkeypatch.setattr(
+        semantic_cli,
+        "parse_response",
+        lambda *args: _pass_verdict(),
+    )
+
+    with pytest.raises(SemanticReviewError, match="CHECK_PUBLICATION_FAILURE"):
+        semantic_cli._review(App(), packet.repository, "token", {})  # type: ignore[arg-type]
+
+
+def test_github_outage_during_event_reconciliation_is_non_green() -> None:
+    class App:
+        def pull(self, *args: object) -> dict[str, object]:
+            raise SemanticReviewError("GITHUB_TRANSPORT_FAILURE")
+
+    event = ReviewEvent("mbh-solutions/supportability-gate", 67, "delivery")
+    with pytest.raises(SemanticReviewError, match="GITHUB_TRANSPORT_FAILURE"):
+        semantic_cli.process_review_event(App(), "token", event)  # type: ignore[arg-type]
+
+
+def test_missed_event_is_recovered_with_fresh_digest_bound_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old = _packet("old-pass")
+    fresh = _packet("missed-event-current")
+
+    class App:
+        completed: list[tuple[object, ...]] = []
+
+        def open_pulls(self, *args: object) -> tuple[dict[str, object], ...]:
+            return ({"number": 67},)
+
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            return fresh
+
+        def assert_current(self, *args: object) -> None:
+            return None
+
+        def replay_result(self, packet: EvidencePacket, *args: object) -> None:
+            assert packet.sha256 != old.sha256
+            return None
+
+        def start_check(self, packet: EvidencePacket, *args: object) -> int:
+            assert packet.sha256 == fresh.sha256
+            return 99
+
+        def complete_check(self, *args: object) -> None:
+            self.completed.append(args)
+
+    app = App()
+    monkeypatch.setattr(semantic_cli, "request_response", lambda *args: {"unused": True})
+    monkeypatch.setattr(semantic_cli, "parse_response", lambda *args: _pass_verdict())
+
+    assert semantic_cli.reconcile_open_pulls(app, fresh.repository, "token") == (True,)  # type: ignore[arg-type]
+    assert app.completed[0][0].sha256 == fresh.sha256  # type: ignore[union-attr]
+    assert app.completed[0][3] == "success"

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -197,7 +197,7 @@ def test_same_head_change_becomes_pending_before_fresh_evaluation(
             self.calls.append("replay")
             return None
 
-        def start_check(self, *args: object) -> int:
+        def claim_check(self, *args: object) -> int:
             self.calls.append("pending")
             return 99
 
@@ -213,7 +213,7 @@ def test_same_head_change_becomes_pending_before_fresh_evaluation(
 
     with pytest.raises(SemanticReviewError, match="MODEL_TIMEOUT"):
         semantic_cli._review(app, packet.repository, "token", {})  # type: ignore[arg-type]
-    assert app.calls == ["read", "current", "replay", "pending"]
+    assert app.calls == ["read", "current", "replay", "pending", "replay"]
 
 
 def test_state_change_during_evaluation_never_completes_success(
@@ -236,7 +236,7 @@ def test_state_change_during_evaluation_never_completes_success(
         def replay_result(self, *args: object) -> None:
             return None
 
-        def start_check(self, *args: object) -> int:
+        def claim_check(self, *args: object) -> int:
             return 99
 
         def complete_check(self, *args: object) -> None:
@@ -268,7 +268,7 @@ def test_publication_failure_cannot_return_green(monkeypatch: pytest.MonkeyPatch
         def replay_result(self, *args: object) -> None:
             return None
 
-        def start_check(self, *args: object) -> int:
+        def claim_check(self, *args: object) -> int:
             return 99
 
         def complete_check(self, *args: object) -> None:
@@ -317,7 +317,7 @@ def test_missed_event_is_recovered_with_fresh_digest_bound_verdict(
             assert packet.sha256 != old.sha256
             return None
 
-        def start_check(self, packet: EvidencePacket, *args: object) -> int:
+        def claim_check(self, packet: EvidencePacket, *args: object) -> int:
             assert packet.sha256 == fresh.sha256
             return 99
 

--- a/tests/test_review_state.py
+++ b/tests/test_review_state.py
@@ -123,7 +123,7 @@ def test_pr52_omission_is_bound_and_blocks_before_model(monkeypatch: pytest.Monk
         def replay_result(self, *args: object) -> bool:
             pytest.fail("unresolved state must block before replay")
 
-        def start_check(self, *args: object) -> int:
+        def claim_check(self, *args: object) -> int:
             return 99
 
         def complete_check(self, *args: object) -> None:

--- a/tests/test_review_state.py
+++ b/tests/test_review_state.py
@@ -123,7 +123,7 @@ def test_pr52_omission_is_bound_and_blocks_before_model(monkeypatch: pytest.Monk
         def replay_result(self, *args: object) -> bool:
             pytest.fail("unresolved state must block before replay")
 
-        def claim_check(self, *args: object) -> int:
+        def start_check(self, *args: object) -> int:
             return 99
 
         def complete_check(self, *args: object) -> None:

--- a/tests/test_review_state.py
+++ b/tests/test_review_state.py
@@ -123,7 +123,10 @@ def test_pr52_omission_is_bound_and_blocks_before_model(monkeypatch: pytest.Monk
         def replay_result(self, *args: object) -> bool:
             pytest.fail("unresolved state must block before replay")
 
-        def publish_check(self, *args: object) -> None:
+        def start_check(self, *args: object) -> int:
+            return 99
+
+        def complete_check(self, *args: object) -> None:
             self.published.append(args)
 
     app = App()
@@ -131,7 +134,7 @@ def test_pr52_omission_is_bound_and_blocks_before_model(monkeypatch: pytest.Monk
         semantic_cli, "request_response", lambda *args: pytest.fail("model transport called")
     )
     assert not semantic_cli._review(app, "mbh-solutions/twmn", "token", {})  # type: ignore[arg-type]
-    assert "UNRESOLVED_REVIEW_THREAD:PRRT_kwDOTUxMsc6VtT-J" in str(app.published[0][3])
+    assert "UNRESOLVED_REVIEW_THREAD:PRRT_kwDOTUxMsc6VtT-J" in str(app.published[0][4])
 
 
 def test_review_state_changes_digest_and_unchanged_state_is_deterministic() -> None:

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -299,7 +299,10 @@ def test_nonproduction_review_skips_completion_preflight(
         def assert_current(self, *args: object) -> None:
             return None
 
-        def publish_check(self, *args: object) -> None:
+        def start_check(self, *args: object) -> int:
+            return 99
+
+        def complete_check(self, *args: object) -> None:
             self.published.append(args)
 
     app = App()
@@ -312,7 +315,7 @@ def test_nonproduction_review_skips_completion_preflight(
     assert semantic_cli._review(  # type: ignore[arg-type]
         app, "mbh-solutions/supportability-gate", "token", {}
     )
-    assert app.published[0][2] == "success"
+    assert app.published[0][3] == "success"
 
 
 def test_production_review_missing_completion_evidence_blocks_before_model(
@@ -332,7 +335,10 @@ def test_production_review_missing_completion_evidence_blocks_before_model(
         def assert_current(self, *args: object) -> None:
             return None
 
-        def publish_check(self, *args: object) -> None:
+        def start_check(self, *args: object) -> int:
+            return 99
+
+        def complete_check(self, *args: object) -> None:
             self.published.append(args)
 
     app = App()
@@ -345,14 +351,15 @@ def test_production_review_missing_completion_evidence_blocks_before_model(
     assert not semantic_cli._review(  # type: ignore[arg-type]
         app, "mbh-solutions/supportability-gate", "token", {}
     )
-    assert "MALFORMED_COMPLETION_REPORT" in app.published[0][3]
+    assert "MALFORMED_COMPLETION_REPORT" in app.published[0][4]
 
 
 def test_technical_model_failure_publishes_no_semantic_check(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class App:
-        published: list[object] = []
+        completed: list[object] = []
+        started = 0
 
         def m10_evidence_packet(self, *args: object) -> EvidencePacket:
             return _m10_packet()
@@ -363,8 +370,12 @@ def test_technical_model_failure_publishes_no_semantic_check(
         def assert_current(self, *args: object) -> None:
             return None
 
-        def publish_check(self, *args: object) -> None:
-            self.published.append(args)
+        def start_check(self, *args: object) -> int:
+            self.started += 1
+            return 99
+
+        def complete_check(self, *args: object) -> None:
+            self.completed.append(args)
 
     app = App()
 
@@ -374,7 +385,8 @@ def test_technical_model_failure_publishes_no_semantic_check(
     monkeypatch.setattr(semantic_cli, "request_response", fail)
     with pytest.raises(SemanticReviewError, match="TIMEOUT"):
         semantic_cli._review(app, "mbh-solutions/supportability-gate", "token", {})  # type: ignore[arg-type]
-    assert app.published == []
+    assert app.started == 1
+    assert app.completed == []
 
 
 def test_evidence_packet_is_immutable_after_construction() -> None:

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -299,7 +299,7 @@ def test_nonproduction_review_skips_completion_preflight(
         def assert_current(self, *args: object) -> None:
             return None
 
-        def start_check(self, *args: object) -> int:
+        def claim_check(self, *args: object) -> int:
             return 99
 
         def complete_check(self, *args: object) -> None:
@@ -335,7 +335,7 @@ def test_production_review_missing_completion_evidence_blocks_before_model(
         def assert_current(self, *args: object) -> None:
             return None
 
-        def start_check(self, *args: object) -> int:
+        def claim_check(self, *args: object) -> int:
             return 99
 
         def complete_check(self, *args: object) -> None:
@@ -370,7 +370,7 @@ def test_technical_model_failure_publishes_no_semantic_check(
         def assert_current(self, *args: object) -> None:
             return None
 
-        def start_check(self, *args: object) -> int:
+        def claim_check(self, *args: object) -> int:
             self.started += 1
             return 99
 

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -299,7 +299,7 @@ def test_nonproduction_review_skips_completion_preflight(
         def assert_current(self, *args: object) -> None:
             return None
 
-        def claim_check(self, *args: object) -> int:
+        def start_check(self, *args: object) -> int:
             return 99
 
         def complete_check(self, *args: object) -> None:
@@ -335,7 +335,7 @@ def test_production_review_missing_completion_evidence_blocks_before_model(
         def assert_current(self, *args: object) -> None:
             return None
 
-        def claim_check(self, *args: object) -> int:
+        def start_check(self, *args: object) -> int:
             return 99
 
         def complete_check(self, *args: object) -> None:
@@ -370,7 +370,7 @@ def test_technical_model_failure_publishes_no_semantic_check(
         def assert_current(self, *args: object) -> None:
             return None
 
-        def claim_check(self, *args: object) -> int:
+        def start_check(self, *args: object) -> int:
             self.started += 1
             return 99
 


### PR DESCRIPTION
## Summary
- authenticate GitHub review, review-comment, and review-thread deliveries
- webhook workers only invalidate current review state; scheduled reconciliation alone owns model evaluation and verdict completion
- make fresh evidence pending before model evaluation and re-read state immediately before completion
- reuse exact-digest completed/pending checks for duplicate and out-of-order delivery

## Direct proof
- directly relevant suite: 107 passed
- final exact-head source proof: Ruff lint/format/C901, strict mypy, Import Linter, 284 passed / 2 skipped, compileall, immutable-standard tamper, exact-range diff check
- fresh exact-lock wheel install and installed CLI help passed
- wheel SHA-256: `4daf32dcd123a6a892c2538227f18830ed96fd0d2203a93276c8e64b05fc5c54`
- immutable standard SHA-256: `81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2`
- production runtime, scheduled-task configuration, App configuration, rulesets, and TWMN unchanged

Closes #67

