### PR TITLE
Fix inline review enforcement after workflow reruns

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,37 +2,26 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "dfc034d070977fcead8742dbe5a05a919a9de825"
+base_sha = "97b0b9dcb54083e057deb75007f6bfb8d6e10604"
 overall_result = "PASS"
 responsibility_changes = [
-    "review_events authenticates supported review-state deliveries and reduces each payload to repository, pull-request, and delivery identity.",
-    "GitHubApp reuses exact-digest pending checks; event processing never evaluates the model.",
-    "The scheduled CLI holds one cross-process advisory lock across full reconciliation, then re-reads base, head, and review state immediately before completion.",
+    "semantic_cli publishes unresolved review-thread failures before handoff, replay, or model transport and enriches only clean packets with M10 evidence.",
+    "GitHubApp selects the newest completed exact-head workflow attempt and trusts it only when its result, artifact, digest, head, run ID, attempt, and provenance agree.",
+    "Clean review events preserve full-packet replay binding while unresolved review events invalidate from review evidence without acquiring handoff evidence.",
 ]
 simplified_functions = [
-    "GitHubApp._check_runs",
-    "GitHubApp.pull",
-    "GitHubApp.replay_result",
-    "GitHubApp.start_check",
-    "_authenticated",
-    "_complete_current_check",
-    "_evaluation_lock",
-    "_lock",
-    "_payload",
+    "GitHubApp._handoff_run",
+    "GitHubApp._handoff_run_order",
+    "GitHubApp.m10_evidence_packet",
     "_review",
-    "_unlock",
-    "handle_review_event",
-    "main",
-    "parse_review_event",
     "process_review_event",
-    "reconcile_open_pulls",
 ]
 boundary_rationale = [
-    "review_events owns webhook authentication and strict delivery identity only.",
-    "github_app owns authenticated current-state and check-run transport; semantic_cli owns event orchestration and cross-process serialization of scheduled evaluation.",
+    "github_app owns authenticated workflow-attempt selection, artifact acquisition, and exact provenance binding.",
+    "semantic_cli owns deterministic unresolved-thread blocking, event invalidation, replay, and model orchestration.",
 ]
 remaining_risks = [
-    "S02 ships protected source capability only; S04 owns production runtime, App event configuration, and ruleset cutover.",
+    "GitHub transport, model transport, or publication failure intentionally leaves required semantic enforcement non-green.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -52,16 +41,16 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-authenticated-review-event-boundary"
-text = "Supported review, review-comment, and review-thread deliveries require a valid HMAC SHA-256 signature and strict repository, pull-request, action, and delivery identity."
-citations = ["src/supportability_gate/review_events.py:29-74"]
+id = "claim-unresolved-review-threads-block-first"
+text = "Unresolved review threads publish deterministic failures before handoff evidence, replay, or model transport."
+citations = ["src/supportability_gate/semantic_cli.py:134-160"]
 
 [[completion_report.claims]]
-id = "claim-idempotent-current-state-reconciliation"
-text = "Event processing discards mutable event state, reuses an exact completed verdict or pending invalidation check, and never calls the model. The scheduled CLI holds a nonblocking cross-process advisory lock across full reconciliation; contention fails non-green before evidence, model, or check mutation, so one process owns model and PATCH work."
-citations = ["src/supportability_gate/github_app.py:181-187", "src/supportability_gate/github_app.py:207-238", "src/supportability_gate/github_app.py:947-986", "src/supportability_gate/semantic_cli.py:90-132", "src/supportability_gate/semantic_cli.py:135-215", "src/supportability_gate/semantic_cli.py:246-259"]
+id = "claim-newest-exact-attempt-provenance"
+text = "The newest completed exact-head workflow attempt must be successful before its exact attempt-bound artifact and provenance can be trusted."
+citations = ["src/supportability_gate/github_app.py:308-354"]
 
 [[completion_report.claims]]
-id = "claim-stable-evaluation-publication"
-text = "A fresh digest becomes pending before model transport, and base, head, and normalized review state are re-read immediately before the same digest-bound check can complete success or failure."
-citations = ["src/supportability_gate/github_app.py:188-204", "src/supportability_gate/github_app.py:947-986", "src/supportability_gate/semantic_cli.py:77-203"]
+id = "claim-event-packet-binding"
+text = "Clean review events enrich the captured packet for exact completed-result replay, while unresolved review events invalidate directly from review evidence without handoff acquisition."
+citations = ["src/supportability_gate/semantic_cli.py:208-220"]

--- a/docs/product_completion_contract.md
+++ b/docs/product_completion_contract.md
@@ -719,13 +719,20 @@ workflow, check-run, ruleset, or GitHub state supports them.
     changed.
 - Remaining work: None for S03 after protected merge and Project #6 closure readback. Retain the
   proof repository; stop. S04 is not authorized.
-- S04 Atomic production cutover and closure: `COMPLETE` upon protected merge of the pull request
-  closing issues #69 and #65; Evidence `Complete`; Scope `On scope`; Stop confirmed `Yes`.
+- S04 Atomic production cutover and closure: `IN_PROGRESS`; Evidence `Missing`; Scope `On scope`;
+  Stop confirmed `No` after owner-authorized defect repair reopened issues #69 and #65 on
+  2026-08-02.
 - Authority: owner-authorized issue #69 under Project #6. Owner corrected the permanent production
   architecture in issues #65 and #69 to GitHub-native required conversation resolution, complete
   paginated semantic evidence, and one-minute scheduled full reconciliation. Production webhook
   hosting and GitHub App event subscriptions are not required.
 - Completion evidence:
+  - Reopened defect evidence: TWMN PR #54 exact head
+    `3db4a6550e50c7bcd4a2bdf78fc41a26e585543d` has three current unresolved review threads while
+    the required semantic check is absent. Workflow run `30758110802` completed successfully on
+    attempt `2`, but the installed reviewer rejects every attempt greater than one before it can
+    publish the deterministic thread block. Prior S04 completion therefore does not establish the
+    terminal capability for this state.
   - Protected source head `9ebf26921ff2f8fc4d558899c60763db52f76d29` passed the final Python
     `3.12.13` exact-lock proof once: Ruff lint and format, C901 at maximum 10, strict mypy, both
     import contracts, 284 pytest tests with 2 skips, compileall, immutable-standard tamper test,
@@ -764,19 +771,20 @@ workflow, check-run, ruleset, or GitHub state supports them.
   - Proof-only webhook `660203958`, scheduled task, listener process, and proof runtime were removed
     with absence readback. Merged S03 local branches and merged TWMN proof branch were removed;
     TWMN is clean on `main == origin/main == 781fb24a37d1a0c6ff03a8d217acd98f82acfab8`.
-    Generated build caches and package metadata were removed. Retained protected proof repository
-    `mbh-solutions/supportability-s03-proof-20260802` remains available through S04 closure exactly
-    as issue #68 requires.
-- Remaining work: None after protected closure merge, Project #6 field readback, final rollback-artifact
-  cleanup, and retained proof-repository disposition. Stop; no successor work is authorized.
+    Generated build caches and package metadata were removed. Protected proof repository
+    `mbh-solutions/supportability-s03-proof-20260802` was retained through the original S04 closure
+    and later deleted under the owner-confirmed disposition already completed outside this repair.
+- Remaining work: protected source repair, exact-wheel deployment, required semantic failure naming
+  all three PR #54 threads, authenticated attempt-two artifact readback, rejected normal merge,
+  closure evidence, and Project #6 readback. No successor work is authorized.
 
 ## Product status
 
 ```text
 Historical deterministic gate deployable to target repositories: YES
 Full Supportability Standard enforcement deployable to target repositories: YES
-Full Supportability Standard runtime: YES
-Current authorized work: Project #6 S04 only — complete upon protected merge and #69/#65 closure; stop
+Full Supportability Standard runtime: NO — S04 defect repair is in progress
+Current authorized work: Project #6 S04 defect repair under reopened issue #69; stop after #69/#65 closure
 Next milestone authorized: NO — Project #6 ends with S04
 ```
 

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -322,11 +322,13 @@ class GitHubApp:
             and row.get("head_sha") == head_sha
             and row.get("event") == "pull_request"
             and row.get("status") == "completed"
-            and row.get("conclusion") == "success"
         ]
         if not runs:
             raise SemanticReviewError("HANDOFF_EVIDENCE_UNAVAILABLE")
-        return max(runs, key=self._handoff_run_order)
+        run = max(runs, key=self._handoff_run_order)
+        if run.get("conclusion") != "success":
+            raise SemanticReviewError("HANDOFF_EVIDENCE_UNAVAILABLE")
+        return run
 
     @staticmethod
     def _handoff_run_order(run: dict[str, Any]) -> tuple[datetime, int]:

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -15,6 +15,7 @@ import urllib.request
 import zipfile
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, cast
 
 from cryptography.hazmat.primitives import hashes, serialization
@@ -270,10 +271,14 @@ class GitHubApp:
         )
 
     def m10_evidence_packet(
-        self, repository: str, pull: dict[str, Any], token: str
+        self,
+        repository: str,
+        pull: dict[str, Any],
+        token: str,
+        packet: EvidencePacket | None = None,
     ) -> EvidencePacket:
         """Add authenticated M10 report and workflow evidence to one exact-head packet."""
-        packet = self.evidence_packet(repository, pull, token)
+        packet = packet or self.evidence_packet(repository, pull, token)
         evidence = packet.evidence
         if not evidence.get("reviewed_sources") and not evidence.get("deleted_sources"):
             return packet
@@ -317,11 +322,34 @@ class GitHubApp:
             and row.get("head_sha") == head_sha
             and row.get("event") == "pull_request"
             and row.get("status") == "completed"
-            and row.get("run_attempt") == 1
+            and row.get("conclusion") == "success"
         ]
-        if len(runs) != 1 or not isinstance(runs[0].get("id"), int):
+        if not runs:
             raise SemanticReviewError("HANDOFF_EVIDENCE_UNAVAILABLE")
-        return runs[0]
+        return max(runs, key=self._handoff_run_order)
+
+    @staticmethod
+    def _handoff_run_order(run: dict[str, Any]) -> tuple[datetime, int]:
+        """Validate and order successful exact-head workflow attempts."""
+        updated_at, run_id, run_attempt = (
+            run.get("updated_at"),
+            run.get("id"),
+            run.get("run_attempt"),
+        )
+        if (
+            not isinstance(updated_at, str)
+            or re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z", updated_at) is None
+            or type(run_id) is not int
+            or run_id < 1
+            or type(run_attempt) is not int
+            or run_attempt < 1
+        ):
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        try:
+            updated = datetime.fromisoformat(updated_at[:-1] + "+00:00")
+        except ValueError as error:
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE") from error
+        return updated, run_id
 
     def _handoff_artifact(self, repository: str, run: dict[str, Any], token: str) -> dict[str, Any]:
         run_id, run_attempt = run["id"], run["run_attempt"]

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -210,6 +210,9 @@ def process_review_event(app: GitHubApp, token: str, event: ReviewEvent) -> bool
     pull = app.pull(event.repository, event.pull_number, token)
     packet = app.evidence_packet(event.repository, pull, token)
     app.assert_current(packet, event.pull_number, token)
+    if not unresolved_review_blocks(packet.evidence):
+        packet = app.m10_evidence_packet(event.repository, pull, token, packet)
+        app.assert_current(packet, event.pull_number, token)
     replay = app.replay_result(packet, token)
     if replay is not None:
         return replay

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -132,7 +132,7 @@ def _evaluation_lock(path: Path) -> Iterator[None]:
 
 
 def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]) -> bool:
-    packet = app.m10_evidence_packet(repository, pull, token)
+    packet = app.evidence_packet(repository, pull, token)
     evidence = packet.evidence
     review_blocks = unresolved_review_blocks(evidence)
     pull_number = evidence.get("pull_request")
@@ -151,6 +151,9 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
             "BLOCK\n" + "\n".join(review_blocks),
         )
         return False
+    packet = app.m10_evidence_packet(repository, pull, token, packet)
+    evidence = packet.evidence
+    app.assert_current(packet, pull_number, token)
     replay = app.replay_result(packet, token)
     if replay is not None:
         return replay
@@ -205,7 +208,7 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
 def process_review_event(app: GitHubApp, token: str, event: ReviewEvent) -> bool:
     """Invalidate changed current state; scheduled reconciliation alone evaluates it."""
     pull = app.pull(event.repository, event.pull_number, token)
-    packet = app.m10_evidence_packet(event.repository, pull, token)
+    packet = app.evidence_packet(event.repository, pull, token)
     app.assert_current(packet, event.pull_number, token)
     replay = app.replay_result(packet, token)
     if replay is not None:

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -96,12 +96,12 @@ def _blob_payload(content: bytes) -> dict[str, str]:
     }
 
 
-def _handoff_archive(head_sha: str, run_id: int = 123) -> bytes:
+def _handoff_archive(head_sha: str, run_id: int = 123, run_attempt: int = 1) -> bytes:
     target = io.BytesIO()
     result = {
         "head_sha": head_sha,
     }
-    provenance = {"run_attempt": "1", "run_id": str(run_id)}
+    provenance = {"run_attempt": str(run_attempt), "run_id": str(run_id)}
     with zipfile.ZipFile(target, "w") as bundle:
         bundle.writestr("complexity-result.json", json.dumps(result))
         bundle.writestr("quality-provenance.json", json.dumps(provenance))
@@ -120,6 +120,7 @@ def test_m10_packet_binds_fresh_full_run_artifact_and_report() -> None:
         "path": ".github/workflows/organization-required.yml",
         "run_attempt": 1,
         "status": "completed",
+        "updated_at": "2026-08-02T17:00:00Z",
     }
     artifact = {
         "digest": f"sha256:{archive_sha256}",
@@ -205,7 +206,48 @@ def test_m10_packet_collects_completion_evidence_for_deletion_only_source(
     assert result.evidence["completion_sources"] == [{"lines": [], "path": "src/a.py"}]
 
 
-def test_rerun_attempt_is_not_accepted_as_m10_evidence() -> None:
+def test_newest_successful_full_rerun_attempt_is_accepted() -> None:
+    head_sha = "b" * 40
+    archive = _handoff_archive(head_sha, run_attempt=2)
+    archive_sha256 = hashlib.sha256(archive).hexdigest()
+    older = {
+        "conclusion": "success",
+        "event": "pull_request",
+        "head_sha": head_sha,
+        "id": 122,
+        "path": ".github/workflows/organization-required.yml",
+        "run_attempt": 1,
+        "status": "completed",
+        "updated_at": "2026-08-02T16:00:00Z",
+    }
+    rerun = {
+        **older,
+        "id": 123,
+        "run_attempt": 2,
+        "updated_at": "2026-08-02T17:00:00Z",
+    }
+    artifact = {
+        "digest": f"sha256:{archive_sha256}",
+        "expired": False,
+        "id": 789,
+        "name": "supportability-evidence-123-2",
+    }
+
+    def open_request(request: object, *args: object, **kwargs: object) -> _Reply:
+        url = request.full_url  # type: ignore[attr-defined]
+        if url.endswith("/zip"):
+            return _BytesReply(archive)
+        if "/actions/runs?" in url:
+            return _Reply({"workflow_runs": [older, rerun]})
+        return _Reply({"artifacts": [artifact]})
+
+    app = GitHubApp(42, 7, b"unused", opener=open_request)
+    evidence = app._handoff_evidence("mbh-solutions/supportability-gate", head_sha, "token")
+
+    assert evidence["artifact_provenance"]["run_attempt"] == 2  # type: ignore[index]
+
+
+def test_failed_rerun_attempt_is_not_accepted_as_m10_evidence() -> None:
     run = {
         "conclusion": "failure",
         "event": "pull_request",
@@ -214,12 +256,67 @@ def test_rerun_attempt_is_not_accepted_as_m10_evidence() -> None:
         "path": ".github/workflows/organization-required.yml",
         "run_attempt": 2,
         "status": "completed",
+        "updated_at": "2026-08-02T17:00:00Z",
     }
     app = GitHubApp(
         42, 7, b"unused", opener=lambda *args, **kwargs: _Reply({"workflow_runs": [run]})
     )
     with pytest.raises(SemanticReviewError, match="HANDOFF_EVIDENCE_UNAVAILABLE"):
         app._handoff_evidence("mbh-solutions/supportability-gate", "b" * 40, "token")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("updated_at", "garbage"),
+        ("updated_at", "20260802T170000Z"),
+        ("id", True),
+        ("id", 0),
+        ("run_attempt", True),
+    ],
+)
+def test_malformed_successful_rerun_metadata_is_rejected(field: str, value: object) -> None:
+    run = {
+        "conclusion": "success",
+        "event": "pull_request",
+        "head_sha": "b" * 40,
+        "id": 123,
+        "path": ".github/workflows/organization-required.yml",
+        "run_attempt": 2,
+        "status": "completed",
+        "updated_at": "2026-08-02T17:00:00Z",
+    }
+    run[field] = value
+    app = GitHubApp(
+        42, 7, b"unused", opener=lambda *args, **kwargs: _Reply({"workflow_runs": [run]})
+    )
+
+    with pytest.raises(SemanticReviewError, match="MALFORMED_GITHUB_RESPONSE"):
+        app._handoff_evidence("mbh-solutions/supportability-gate", "b" * 40, "token")
+
+
+def test_rerun_attempt_with_mismatched_provenance_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    head_sha = "b" * 40
+    archive = _handoff_archive(head_sha, run_attempt=1)
+    digest = f"sha256:{hashlib.sha256(archive).hexdigest()}"
+    run = {
+        "conclusion": "success",
+        "id": 123,
+        "run_attempt": 2,
+    }
+    app = GitHubApp(42, 7, b"unused")
+    monkeypatch.setattr(app, "_handoff_run", lambda *args: run)
+    monkeypatch.setattr(
+        app,
+        "_handoff_artifact",
+        lambda *args: {"digest": digest, "id": 789},
+    )
+    monkeypatch.setattr(app, "_artifact_bytes", lambda *args: archive)
+
+    with pytest.raises(SemanticReviewError, match="STALE_HANDOFF_EVIDENCE"):
+        app._handoff_evidence("mbh-solutions/supportability-gate", head_sha, "token")
 
 
 def test_handoff_archive_rejects_large_expanded_member() -> None:

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -248,7 +248,17 @@ def test_newest_successful_full_rerun_attempt_is_accepted() -> None:
 
 
 def test_failed_rerun_attempt_is_not_accepted_as_m10_evidence() -> None:
-    run = {
+    older = {
+        "conclusion": "success",
+        "event": "pull_request",
+        "head_sha": "b" * 40,
+        "id": 122,
+        "path": ".github/workflows/organization-required.yml",
+        "run_attempt": 1,
+        "status": "completed",
+        "updated_at": "2026-08-02T16:00:00Z",
+    }
+    failed = {
         "conclusion": "failure",
         "event": "pull_request",
         "head_sha": "b" * 40,
@@ -259,7 +269,10 @@ def test_failed_rerun_attempt_is_not_accepted_as_m10_evidence() -> None:
         "updated_at": "2026-08-02T17:00:00Z",
     }
     app = GitHubApp(
-        42, 7, b"unused", opener=lambda *args, **kwargs: _Reply({"workflow_runs": [run]})
+        42,
+        7,
+        b"unused",
+        opener=lambda *args, **kwargs: _Reply({"workflow_runs": [older, failed]}),
     )
     with pytest.raises(SemanticReviewError, match="HANDOFF_EVIDENCE_UNAVAILABLE"):
         app._handoff_evidence("mbh-solutions/supportability-gate", "b" * 40, "token")

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -27,13 +27,19 @@ def _signature(body: bytes, secret: bytes = b"secret") -> str:
     return "sha256=" + hmac.new(secret, body, hashlib.sha256).hexdigest()
 
 
-def _packet(state: str = "current") -> EvidencePacket:
+def _packet(state: str = "current", *, unresolved: bool = False) -> EvidencePacket:
     return EvidencePacket(
         "mbh-solutions/supportability-gate",
         "a" * 40,
         "b" * 40,
         42,
-        {"pull_request": 67, "review_state": {"threads": [], "state": state}},
+        {
+            "pull_request": 67,
+            "review_state": {
+                "threads": ([{"id": "thread-1", "is_resolved": False}] if unresolved else []),
+                "state": state,
+            },
+        },
     )
 
 
@@ -132,6 +138,9 @@ def test_duplicate_and_out_of_order_events_reconcile_current_state() -> None:
         def evidence_packet(self, *args: object) -> EvidencePacket:
             return packet
 
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
         def assert_current(self, *args: object) -> None:
             return None
 
@@ -152,7 +161,7 @@ def test_duplicate_and_out_of_order_events_reconcile_current_state() -> None:
 
 
 def test_new_event_invalidates_without_concurrent_model_evaluation() -> None:
-    packet = _packet("new-event")
+    packet = _packet("new-event", unresolved=True)
 
     class App:
         pending: list[str] = []
@@ -162,6 +171,9 @@ def test_new_event_invalidates_without_concurrent_model_evaluation() -> None:
 
         def evidence_packet(self, *args: object) -> EvidencePacket:
             return packet
+
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            pytest.fail("unresolved event must invalidate before handoff evidence")
 
         def assert_current(self, *args: object) -> None:
             return None

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -129,7 +129,7 @@ def test_duplicate_and_out_of_order_events_reconcile_current_state() -> None:
             self.pulls += 1
             return {"number": 67}
 
-        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+        def evidence_packet(self, *args: object) -> EvidencePacket:
             return packet
 
         def assert_current(self, *args: object) -> None:
@@ -160,7 +160,7 @@ def test_new_event_invalidates_without_concurrent_model_evaluation() -> None:
         def pull(self, *args: object) -> dict[str, object]:
             return {"number": 67}
 
-        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+        def evidence_packet(self, *args: object) -> EvidencePacket:
             return packet
 
         def assert_current(self, *args: object) -> None:
@@ -195,8 +195,13 @@ def test_same_head_change_becomes_pending_before_fresh_evaluation(
     class App:
         calls: list[str] = []
 
+        def evidence_packet(self, *args: object) -> EvidencePacket:
+            self.calls.append("review")
+            return packet
+
         def m10_evidence_packet(self, *args: object) -> EvidencePacket:
-            self.calls.append("read")
+            self.calls.append("handoff")
+            assert args[3] is packet
             return packet
 
         def assert_current(self, *args: object) -> None:
@@ -222,7 +227,7 @@ def test_same_head_change_becomes_pending_before_fresh_evaluation(
 
     with pytest.raises(SemanticReviewError, match="MODEL_TIMEOUT"):
         semantic_cli._review(app, packet.repository, "token", {})  # type: ignore[arg-type]
-    assert app.calls == ["read", "current", "replay", "pending"]
+    assert app.calls == ["review", "current", "handoff", "current", "replay", "pending"]
 
 
 def test_state_change_during_evaluation_never_completes_success(
@@ -233,6 +238,9 @@ def test_state_change_during_evaluation_never_completes_success(
     class App:
         current_reads = 0
         completed = False
+
+        def evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
 
         def m10_evidence_packet(self, *args: object) -> EvidencePacket:
             return packet
@@ -268,6 +276,9 @@ def test_publication_failure_cannot_return_green(monkeypatch: pytest.MonkeyPatch
     packet = _packet("fresh")
 
     class App:
+        def evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
         def m10_evidence_packet(self, *args: object) -> EvidencePacket:
             return packet
 
@@ -315,6 +326,9 @@ def test_missed_event_is_recovered_with_fresh_digest_bound_verdict(
 
         def open_pulls(self, *args: object) -> tuple[dict[str, object], ...]:
             return ({"number": 67},)
+
+        def evidence_packet(self, *args: object) -> EvidencePacket:
+            return fresh
 
         def m10_evidence_packet(self, *args: object) -> EvidencePacket:
             return fresh

--- a/tests/test_review_state.py
+++ b/tests/test_review_state.py
@@ -114,8 +114,11 @@ def test_pr52_omission_is_bound_and_blocks_before_model(monkeypatch: pytest.Monk
     class App:
         published: list[tuple[object, ...]] = []
 
-        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+        def evidence_packet(self, *args: object) -> EvidencePacket:
             return packet
+
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            pytest.fail("unresolved state must block before handoff evidence")
 
         def assert_current(self, *args: object) -> None:
             return None

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -290,6 +290,9 @@ def test_nonproduction_review_skips_completion_preflight(
     class App:
         published: list[object] = []
 
+        def evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
         def m10_evidence_packet(self, *args: object) -> EvidencePacket:
             return packet
 
@@ -326,6 +329,9 @@ def test_production_review_missing_completion_evidence_blocks_before_model(
     class App:
         published: list[object] = []
 
+        def evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
         def m10_evidence_packet(self, *args: object) -> EvidencePacket:
             return packet
 
@@ -360,6 +366,9 @@ def test_technical_model_failure_publishes_no_semantic_check(
     class App:
         completed: list[object] = []
         started = 0
+
+        def evidence_packet(self, *args: object) -> EvidencePacket:
+            return _m10_packet()
 
         def m10_evidence_packet(self, *args: object) -> EvidencePacket:
             return _m10_packet()


### PR DESCRIPTION
## Summary

- publish unresolved review-thread blocks before handoff or model acquisition
- invalidate review events from the captured review packet only
- accept newest successful exact-head workflow reruns with strict attempt artifact/provenance binding
- reopen S04 ledger status until protected runtime proof completes

Refs #69

## Verification

- focused regressions: 11 passed
- directly relevant suite: 117 passed
- exact-head Python 3.12.13 source proof: Ruff lint/format/C901, strict mypy, both import contracts, 291 tests with 2 skips, compileall, wheel build, fresh exact-lock install, installed CLI help, immutable-standard tamper, exact-range whitespace
- final runtime wheel: build from the protected merge after this PR lands

No Vercel, webhook, new repository, dependency, workflow, target-code, or ruleset change.
