### PR TITLE
Terminate impossible semantic reviews visibly

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,23 +2,19 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "97b0b9dcb54083e057deb75007f6bfb8d6e10604"
+base_sha = "0df70d249ce2930663758cd9626e5c6d091103c9"
 overall_result = "PASS"
 responsibility_changes = [
-    "semantic_cli publishes unresolved review-thread failures before handoff, replay, or model transport and enriches only clean packets with M10 evidence.",
-    "GitHubApp selects the newest completed exact-head workflow attempt and trusts it only when its result, artifact, digest, head, run ID, attempt, and provenance agree.",
-    "Clean review events preserve full-packet replay binding while unresolved review events invalidate from review evidence without acquiring handoff evidence.",
+    "semantic_review bounds returned ownership evidence by the exact parser-derived boundary set and still requires exact identity equality.",
+    "semantic_cli completes deterministic invalid completed responses visibly while leaving transport and retryable model states uncompleted.",
 ]
 simplified_functions = [
-    "GitHubApp._handoff_run",
-    "GitHubApp._handoff_run_order",
-    "GitHubApp.m10_evidence_packet",
+    "_boundary_evidence",
     "_review",
-    "process_review_event",
 ]
 boundary_rationale = [
-    "github_app owns authenticated workflow-attempt selection, artifact acquisition, and exact provenance binding.",
-    "semantic_cli owns deterministic unresolved-thread blocking, event invalidation, replay, and model orchestration.",
+    "semantic_review owns exact response validation against trusted parser-derived boundaries.",
+    "semantic_cli owns scheduled model orchestration and terminal check lifecycle.",
 ]
 remaining_risks = [
     "GitHub transport, model transport, or publication failure intentionally leaves required semantic enforcement non-green.",
@@ -41,16 +37,11 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-unresolved-review-threads-block-first"
-text = "Unresolved review threads publish deterministic failures before handoff evidence, replay, or model transport."
-citations = ["src/supportability_gate/semantic_cli.py:134-160"]
+id = "claim-exact-boundary-cardinality"
+text = "Returned boundary cardinality is bounded by the exact trusted boundary set before exact identity equality is required."
+citations = ["src/supportability_gate/semantic_review.py:229-255"]
 
 [[completion_report.claims]]
-id = "claim-newest-exact-attempt-provenance"
-text = "The newest completed exact-head workflow attempt must be successful before its exact attempt-bound artifact and provenance can be trusted."
-citations = ["src/supportability_gate/github_app.py:308-354"]
-
-[[completion_report.claims]]
-id = "claim-event-packet-binding"
-text = "Clean review events enrich the captured packet for exact completed-result replay, while unresolved review events invalidate directly from review evidence without handoff acquisition."
-citations = ["src/supportability_gate/semantic_cli.py:208-220"]
+id = "claim-terminal-invalid-response"
+text = "Deterministic invalid completed responses finish the current check, while incomplete, refused, or model-drift responses remain retryable."
+citations = ["src/supportability_gate/semantic_cli.py:184-199"]

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -181,7 +181,20 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
             "BLOCK\n" + "\n".join(preflight),
         )
         return False
-    verdict = parse_response(packet, request_response(packet))
+    response = request_response(packet)
+    try:
+        verdict = parse_response(packet, response)
+    except SemanticReviewError as error:
+        _complete_current_check(
+            app,
+            packet,
+            pull_number,
+            token,
+            check_id,
+            "failure",
+            f"TECHNICAL_FAILURE\n{error.code}",
+        )
+        return False
     if verdict.verdict == "PASS":
         _complete_current_check(
             app,

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -185,6 +185,8 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
     try:
         verdict = parse_response(packet, response)
     except SemanticReviewError as error:
+        if error.code in {"INCOMPLETE_RESPONSE", "MODEL_DRIFT", "REFUSAL"}:
+            raise
         _complete_current_check(
             app,
             packet,

--- a/src/supportability_gate/semantic_review.py
+++ b/src/supportability_gate/semantic_review.py
@@ -229,8 +229,13 @@ def _boundary_evidence(
     expected_paths = tuple(sources)
     if tuple(reviewed) != expected_paths:
         raise SemanticReviewError("MISSING_REVIEWED_PATHS")
+    expected_boundaries = {
+        (path, start, end, kind, name)
+        for path, (_, _, trusted, _) in sources.items()
+        for start, end, kind, name in trusted
+    }
     raw_boundaries = data.get("boundaries")
-    if not isinstance(raw_boundaries, list) or len(raw_boundaries) > 100:
+    if not isinstance(raw_boundaries, list) or len(raw_boundaries) > len(expected_boundaries):
         raise SemanticReviewError("MALFORMED_SCHEMA")
     boundaries = tuple(
         sorted(
@@ -243,11 +248,6 @@ def _boundary_evidence(
     }
     if len(identities) != len(boundaries):
         raise SemanticReviewError("MALFORMED_SCHEMA")
-    expected_boundaries = {
-        (path, start, end, kind, name)
-        for path, (_, _, trusted, _) in sources.items()
-        for start, end, kind, name in trusted
-    }
     if identities != expected_boundaries:
         raise SemanticReviewError("MISSING_BOUNDARY_EVIDENCE")
     prefixes = tuple(f"{item.path}:{item.start_line}-{item.end_line}" for item in boundaries)

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -398,6 +398,58 @@ def test_technical_model_failure_publishes_no_semantic_check(
     assert app.completed == []
 
 
+def test_deterministic_response_failure_completes_once_without_recalling_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packet = _m10_packet()
+
+    class App:
+        completed: list[object] = []
+        result: bool | None = None
+        started = 0
+
+        def evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def replay_result(self, *args: object) -> bool | None:
+            return self.result
+
+        def assert_current(self, *args: object) -> None:
+            return None
+
+        def start_check(self, *args: object) -> int:
+            self.started += 1
+            return 99
+
+        def complete_check(self, *args: object) -> None:
+            self.completed.append(args)
+            self.result = False
+
+    app = App()
+    calls = 0
+    response = _response(packet)
+    response["output"][0]["content"][0]["text"] = "not json"  # type: ignore[index]
+
+    def malformed(*args: object) -> object:
+        nonlocal calls
+        calls += 1
+        return response
+
+    monkeypatch.setattr(semantic_cli, "request_response", malformed)
+
+    assert not semantic_cli._review(  # type: ignore[arg-type]
+        app, "mbh-solutions/supportability-gate", "token", {}
+    )
+    assert not semantic_cli._review(  # type: ignore[arg-type]
+        app, "mbh-solutions/supportability-gate", "token", {}
+    )
+    assert (app.started, calls, len(app.completed)) == (1, 1, 1)
+    assert app.completed[0][3:] == ("failure", "TECHNICAL_FAILURE\nMALFORMED_SCHEMA")
+
+
 def test_evidence_packet_is_immutable_after_construction() -> None:
     evidence = {"diff": "+safe", "reviewed_sources": []}
     packet = EvidencePacket("mbh-solutions/supportability-gate", "a" * 40, "b" * 40, 42, evidence)
@@ -556,6 +608,37 @@ def test_invalid_responsibility_evidence_blocks(defect: str, code: str) -> None:
             packet,
             _response(packet, reviewed_paths=reviewed_paths, boundaries=boundaries),
         )
+
+
+def test_exact_102_boundaries_pass_but_missing_one_blocks() -> None:
+    source_boundaries = [
+        {"start_line": line, "end_line": line, "kind": "function", "name": f"boundary_{line}"}
+        for line in range(1, 103)
+    ]
+    source = {
+        "blob_sha": "c" * 40,
+        "boundaries": source_boundaries,
+        "imports": [],
+        "line_count": 102,
+        "lines": [{"line": line, "text": f"def boundary_{line}(): pass"} for line in range(1, 103)],
+        "path": PYTHON_PATH,
+    }
+    packet = _packet({"reviewed_sources": [source], "completion_sources": [source]})
+    returned = [
+        {
+            **boundary,
+            "path": PYTHON_PATH,
+            "owns": f"Boundary {boundary['name']} responsibility.",
+            "does_not_own": "Other boundaries.",
+            "basis": "responsibility",
+            "evidence_lines": [boundary["start_line"]],
+        }
+        for boundary in source_boundaries
+    ]
+
+    assert len(parse_response(packet, _response(packet, boundaries=returned)).boundaries) == 102
+    with pytest.raises(SemanticReviewError, match="MISSING_BOUNDARY_EVIDENCE"):
+        parse_response(packet, _response(packet, boundaries=returned[:-1]))
 
 
 def test_evidence_path_not_in_exact_head_blocks() -> None:

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -360,8 +360,10 @@ def test_production_review_missing_completion_evidence_blocks_before_model(
     assert "MALFORMED_COMPLETION_REPORT" in app.published[0][4]
 
 
+@pytest.mark.parametrize("code", ["TIMEOUT", "INCOMPLETE_RESPONSE", "REFUSAL", "MODEL_DRIFT"])
 def test_technical_model_failure_publishes_no_semantic_check(
     monkeypatch: pytest.MonkeyPatch,
+    code: str,
 ) -> None:
     class App:
         completed: list[object] = []
@@ -389,10 +391,19 @@ def test_technical_model_failure_publishes_no_semantic_check(
     app = App()
 
     def fail(*args: object) -> object:
-        raise SemanticReviewError("TIMEOUT")
+        if code == "TIMEOUT":
+            raise SemanticReviewError(code)
+        response = _response(_m10_packet())
+        if code == "INCOMPLETE_RESPONSE":
+            response["status"] = "incomplete"
+        elif code == "REFUSAL":
+            response["output"][0]["content"][0] = {"type": "refusal", "refusal": "no"}  # type: ignore[index]
+        else:
+            response["model"] = "other"
+        return response
 
     monkeypatch.setattr(semantic_cli, "request_response", fail)
-    with pytest.raises(SemanticReviewError, match="TIMEOUT"):
+    with pytest.raises(SemanticReviewError, match=code):
         semantic_cli._review(app, "mbh-solutions/supportability-gate", "token", {})  # type: ignore[arg-type]
     assert app.started == 1
     assert app.completed == []


### PR DESCRIPTION
## Summary

- bound returned boundary cardinality to the exact trusted input set instead of an arbitrary 100-item ceiling
- complete deterministic post-transport validation failures as visible non-green checks with stable error codes
- prove exact 102-boundary acceptance, missing-boundary rejection, and no model recall after terminal failure

Closes #77

## Focused validation

- `python -m pytest -q tests/test_semantic_review.py::test_exact_102_boundaries_pass_but_missing_one_blocks tests/test_semantic_review.py::test_deterministic_response_failure_completes_once_without_recalling_model`
- `python -m pytest -q tests/test_semantic_review.py -k "not test_exact_102_boundaries_pass_but_missing_one_blocks and not test_deterministic_response_failure_completes_once_without_recalling_model"` — 53 passed, 2 deselected
- Ruff lint/format on three changed files
- changed-file `git diff --check`

No TWMN repository files changed. TWMN semantic reviewer remains disabled until protected deployment.
