### PR TITLE
Bind source responsibility boundaries

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,20 +2,32 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "aaa7a602819d3a987de722f5a11d517f94af14ef"
+base_sha = "0b5c647317eebe196eaa287e4a755e4356ec4737"
 overall_result = "PASS"
 responsibility_changes = [
-    "clause_inventory enforces exact Standard-line profile scope and milestone-owned evidence and blocking-test authority.",
-    "normative_clause_inventory assigns repeated principle rows to their real milestone owners.",
+    "function_changes owns parser-derived Python, stub, TypeScript, and React-class responsibility identity across base and head.",
+    "github_app owns authenticated source acquisition while delegating responsibility mapping to function_changes.",
 ]
 simplified_functions = [
-    "_verify_coverage",
+    "GitHubApp._boundaries",
+    "GitHubApp._responsibility_spans",
+    "GitHubApp._reviewed_source",
+    "GitHubApp._source_boundaries",
+    "GitHubApp._source_evidence",
+    "GitHubApp._source_record",
+    "_FunctionCollector._visit_function",
+    "_TypeScriptFunctionCollector.__init__",
+    "_TypeScriptFunctionCollector._react_component",
+    "_TypeScriptFunctionCollector.visit",
+    "changed_responsibility_spans",
+    "parse_typescript_file",
+    "responsibility_spans",
 ]
 boundary_rationale = [
-    "clause_inventory owns deterministic completeness and authority validation for the immutable Standard inventory.",
+    "function_changes parses source identity without importing target code; github_app binds those spans to authenticated GitHub blobs.",
 ]
 remaining_risks = [
-    "Inventory loading validates blocking-test ownership references but does not execute those referenced tests.",
+    "Responsibility identity uses exact qualified names; a deliberate rename remains a removed base responsibility plus a new head responsibility.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -35,11 +47,11 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-profile-authority"
-text = "Every inventory row is bound to frontend-only, Python-only, or both profiles by its immutable Standard source line."
-citations = ["src/supportability_gate/clause_inventory.py:12-21", "src/supportability_gate/clause_inventory.py:410-415"]
+id = "claim-source-identity"
+text = "Semantic source review accepts exactly Python, stub, CTS, MTS, TS, and TSX suffixes and maps deletion-touched surviving responsibilities to head spans while retaining removed responsibilities on base."
+citations = ["src/supportability_gate/github_app.py:48-48", "src/supportability_gate/github_app.py:756-824", "src/supportability_gate/function_changes.py:346-375"]
 
 [[completion_report.claims]]
-id = "claim-milestone-authority"
-text = "Repeated principle clauses and their evidence and blocking-test references are bound to the milestone that enforces them."
-citations = ["src/supportability_gate/clause_inventory.py:22-77", "src/supportability_gate/clause_inventory.py:411-432"]
+id = "claim-parser-boundaries"
+text = "Python spans begin at the earliest decorator and supported React component classes receive aggregate component spans while their methods remain separately reviewable."
+citations = ["src/supportability_gate/function_changes.py:121-136", "src/supportability_gate/function_changes.py:184-255", "src/supportability_gate/function_changes.py:304-343"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -10,6 +10,7 @@ responsibility_changes = [
 ]
 simplified_functions = [
     "GitHubApp._boundaries",
+    "GitHubApp._deletion_evidence",
     "GitHubApp._responsibility_spans",
     "GitHubApp._reviewed_source",
     "GitHubApp._source_boundaries",
@@ -49,9 +50,9 @@ gate_coverage = [
 [[completion_report.claims]]
 id = "claim-source-identity"
 text = "Semantic source review accepts exactly Python, stub, CTS, MTS, TS, and TSX suffixes and maps deletion-touched surviving responsibilities to head spans while retaining removed responsibilities on base."
-citations = ["src/supportability_gate/github_app.py:48-48", "src/supportability_gate/github_app.py:756-824", "src/supportability_gate/function_changes.py:346-373"]
+citations = ["src/supportability_gate/github_app.py:48-48", "src/supportability_gate/github_app.py:756-844", "src/supportability_gate/function_changes.py:343-370"]
 
 [[completion_report.claims]]
 id = "claim-parser-boundaries"
 text = "Python spans begin at the earliest decorator and supported React component classes receive aggregate component spans while their methods remain separately reviewable."
-citations = ["src/supportability_gate/function_changes.py:121-136", "src/supportability_gate/function_changes.py:184-255", "src/supportability_gate/function_changes.py:304-343"]
+citations = ["src/supportability_gate/function_changes.py:121-136", "src/supportability_gate/function_changes.py:184-255", "src/supportability_gate/function_changes.py:304-340"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -29,6 +29,7 @@ boundary_rationale = [
 ]
 remaining_risks = [
     "Responsibility identity uses exact qualified names; a deliberate rename remains a removed base responsibility plus a new head responsibility.",
+    "Whitespace-only changed lines are omitted because they have no reviewable source responsibility.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -50,9 +51,9 @@ gate_coverage = [
 [[completion_report.claims]]
 id = "claim-source-identity"
 text = "Semantic source review accepts exactly Python, stub, CTS, MTS, TS, and TSX suffixes and maps deletion-touched surviving responsibilities to head spans while retaining removed responsibilities on base."
-citations = ["src/supportability_gate/github_app.py:48-48", "src/supportability_gate/github_app.py:756-844", "src/supportability_gate/function_changes.py:343-370"]
+citations = ["src/supportability_gate/github_app.py:48-48", "src/supportability_gate/github_app.py:756-844", "src/supportability_gate/function_changes.py:349-376"]
 
 [[completion_report.claims]]
 id = "claim-parser-boundaries"
 text = "Python spans begin at the earliest decorator and supported React component classes receive aggregate component spans while their methods remain separately reviewable."
-citations = ["src/supportability_gate/function_changes.py:121-136", "src/supportability_gate/function_changes.py:184-255", "src/supportability_gate/function_changes.py:304-340"]
+citations = ["src/supportability_gate/function_changes.py:121-136", "src/supportability_gate/function_changes.py:184-255", "src/supportability_gate/function_changes.py:304-346"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -49,7 +49,7 @@ gate_coverage = [
 [[completion_report.claims]]
 id = "claim-source-identity"
 text = "Semantic source review accepts exactly Python, stub, CTS, MTS, TS, and TSX suffixes and maps deletion-touched surviving responsibilities to head spans while retaining removed responsibilities on base."
-citations = ["src/supportability_gate/github_app.py:48-48", "src/supportability_gate/github_app.py:756-824", "src/supportability_gate/function_changes.py:346-375"]
+citations = ["src/supportability_gate/github_app.py:48-48", "src/supportability_gate/github_app.py:756-824", "src/supportability_gate/function_changes.py:346-373"]
 
 [[completion_report.claims]]
 id = "claim-parser-boundaries"

--- a/src/supportability_gate/function_changes.py
+++ b/src/supportability_gate/function_changes.py
@@ -333,11 +333,8 @@ def responsibility_spans(
         )
         for span in touched
     )
-    covered = {
-        line
-        for span in (*components, *touched)
-        for line in range(span.start_line, span.end_line + 1)
-    }
+    covered = {line for span in components for line in range(span.start_line, span.end_line + 1)}
+    covered.update(line for span in touched for line in range(span.start_line, span.end_line + 1))
     module_spans = _line_spans(changed_lines - covered)
     boundaries.extend(ResponsibilitySpan(start, end, "module", path) for start, end in module_spans)
     return tuple(boundaries)

--- a/src/supportability_gate/function_changes.py
+++ b/src/supportability_gate/function_changes.py
@@ -335,7 +335,13 @@ def responsibility_spans(
     )
     covered = {line for span in components for line in range(span.start_line, span.end_line + 1)}
     covered.update(line for span in touched for line in range(span.start_line, span.end_line + 1))
-    module_spans = _line_spans(changed_lines - covered)
+    source_lines = content.decode("utf-8").splitlines()
+    module_lines = {
+        line
+        for line in changed_lines - covered
+        if 1 <= line <= len(source_lines) and source_lines[line - 1].strip()
+    }
+    module_spans = _line_spans(module_lines)
     boundaries.extend(ResponsibilitySpan(start, end, "module", path) for start, end in module_spans)
     return tuple(boundaries)
 

--- a/src/supportability_gate/function_changes.py
+++ b/src/supportability_gate/function_changes.py
@@ -68,6 +68,7 @@ class ParsedSourceFile:
     path: str
     content: bytes
     functions: tuple[FunctionDefinition, ...]
+    components: tuple[ResponsibilitySpan, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -124,7 +125,10 @@ class _FunctionCollector(ast.NodeVisitor):
             raise PythonSourceError(
                 "MISSING_AST_SPAN", f"missing AST end line: {self.path}:{node.lineno}"
             )
-        span = FunctionSpan(self.path, qualified_name, node.lineno, end_line)
+        start_line = min(
+            (decorator.lineno for decorator in node.decorator_list), default=node.lineno
+        )
+        span = FunctionSpan(self.path, qualified_name, start_line, end_line)
         self.functions.append(FunctionDefinition(span, node))
         self.context.append(node.name)
         for child in node.body:
@@ -183,6 +187,7 @@ class _TypeScriptFunctionCollector:
         self.content = content
         self.context: list[str] = []
         self.functions: list[FunctionDefinition] = []
+        self.components: list[ResponsibilitySpan] = []
 
     def _name(self, node: Node) -> str:
         name = node.child_by_field_name("name")
@@ -207,7 +212,18 @@ class _TypeScriptFunctionCollector:
 
     def visit(self, node: Node) -> None:
         if node.type in {"class_declaration", "class_expression"}:
-            self.context.append(self._name(node))
+            name = self._name(node)
+            qualified_name = ".".join([*self.context, name])
+            if self._react_component(node):
+                self.components.append(
+                    ResponsibilitySpan(
+                        node.start_point.row + 1,
+                        node.end_point.row + 1,
+                        "component",
+                        qualified_name,
+                    )
+                )
+            self.context.append(name)
             for child in node.named_children:
                 self.visit(child)
             self.context.pop()
@@ -217,6 +233,26 @@ class _TypeScriptFunctionCollector:
             return
         for child in node.named_children:
             self.visit(child)
+
+    def _react_component(self, node: Node) -> bool:
+        heritage = next(
+            (child for child in node.named_children if child.type == "class_heritage"), None
+        )
+        extends = (
+            next(
+                (child for child in heritage.named_children if child.type == "extends_clause"),
+                None,
+            )
+            if heritage is not None
+            else None
+        )
+        value = extends.child_by_field_name("value") if extends is not None else None
+        return value is not None and _typescript_text(value, self.content) in {
+            "React.Component",
+            "React.PureComponent",
+            "Component",
+            "PureComponent",
+        }
 
     def _visit_function(self, node: Node) -> None:
         name = self._name(node)
@@ -247,7 +283,12 @@ def parse_typescript_file(path: str, content: bytes) -> ParsedSourceFile:
         raise PythonSourceError("SYNTAX_ERROR", f"syntax error in changed production file: {path}")
     collector = _TypeScriptFunctionCollector(path, content)
     collector.visit(tree.root_node)
-    return ParsedSourceFile(path, content, _unique_functions(path, collector.functions))
+    return ParsedSourceFile(
+        path,
+        content,
+        _unique_functions(path, collector.functions),
+        tuple(collector.components),
+    )
 
 
 def _line_spans(lines: set[int]) -> list[tuple[int, int]]:
@@ -266,7 +307,7 @@ def responsibility_spans(
     """Map changed lines to exact parser-derived responsibility spans."""
     parsed = (
         parse_python_file(path, content)
-        if path.endswith(".py")
+        if path.endswith((".py", ".pyi"))
         else parse_typescript_file(path, content)
     )
     touched = tuple(
@@ -274,21 +315,64 @@ def responsibility_spans(
         for item in parsed.functions
         if changed_lines.intersection(range(item.span.start_line, item.span.end_line + 1))
     )
-    boundaries = [
+    components = tuple(
+        item
+        for item in parsed.components
+        if changed_lines.intersection(range(item.start_line, item.end_line + 1))
+    )
+    boundaries = list(components)
+    boundaries.extend(
         ResponsibilitySpan(
             span.start_line,
             span.end_line,
             "component"
-            if not path.endswith(".py") and span.qualified_name.rsplit(".", 1)[-1][:1].isupper()
+            if not path.endswith((".py", ".pyi"))
+            and span.qualified_name.rsplit(".", 1)[-1][:1].isupper()
             else "function",
             span.qualified_name,
         )
         for span in touched
-    ]
-    covered = {line for span in touched for line in range(span.start_line, span.end_line + 1)}
+    )
+    covered = {
+        line
+        for span in (*components, *touched)
+        for line in range(span.start_line, span.end_line + 1)
+    }
     module_spans = _line_spans(changed_lines - covered)
     boundaries.extend(ResponsibilitySpan(start, end, "module", path) for start, end in module_spans)
     return tuple(boundaries)
+
+
+def changed_responsibility_spans(
+    path: str,
+    base_content: bytes,
+    head_content: bytes,
+    base_changed_lines: set[int],
+    head_changed_lines: set[int],
+) -> tuple[tuple[ResponsibilitySpan, ...], tuple[ResponsibilitySpan, ...]]:
+    """Map retained base responsibilities to head and keep removed ones base-bound."""
+    base = responsibility_spans(path, base_content, base_changed_lines)
+    head = responsibility_spans(path, head_content, head_changed_lines)
+    all_head = responsibility_spans(
+        path, head_content, set(range(1, len(head_content.splitlines()) + 1))
+    )
+    head_by_identity = {
+        (span.kind, span.name): span for span in all_head if span.kind != "module"
+    }
+    mapped = [
+        head_by_identity[(span.kind, span.name)]
+        for span in base
+        if (span.kind, span.name) in head_by_identity
+    ]
+    deleted = [
+        span
+        for span in base
+        if span.kind == "module" or (span.kind, span.name) not in head_by_identity
+    ]
+    surviving = {
+        (span.start_line, span.end_line, span.kind, span.name): span for span in (*head, *mapped)
+    }
+    return tuple(surviving[key] for key in sorted(surviving)), tuple(deleted)
 
 
 def _deltas(

--- a/src/supportability_gate/function_changes.py
+++ b/src/supportability_gate/function_changes.py
@@ -335,7 +335,7 @@ def responsibility_spans(
     )
     covered = {line for span in components for line in range(span.start_line, span.end_line + 1)}
     covered.update(line for span in touched for line in range(span.start_line, span.end_line + 1))
-    source_lines = content.decode("utf-8").splitlines()
+    source_lines = content.splitlines()
     module_lines = {
         line
         for line in changed_lines - covered

--- a/src/supportability_gate/function_changes.py
+++ b/src/supportability_gate/function_changes.py
@@ -356,9 +356,7 @@ def changed_responsibility_spans(
     all_head = responsibility_spans(
         path, head_content, set(range(1, len(head_content.splitlines()) + 1))
     )
-    head_by_identity = {
-        (span.kind, span.name): span for span in all_head if span.kind != "module"
-    }
+    head_by_identity = {(span.kind, span.name): span for span in all_head if span.kind != "module"}
     mapped = [
         head_by_identity[(span.kind, span.name)]
         for span in base

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -765,63 +765,83 @@ class GitHubApp:
             return [], []
         production_paths = self._production_paths(repository, base_sha, token)
         production = self._production_candidates(candidates, production_paths)
-        sources_by_path = {
-            source["path"]: source
+        sources_by_path: dict[str, dict[str, Any]] = {
+            str(source["path"]): source
             for item in production
             if (source := self._reviewed_source(repository, item, token)) is not None
         }
-        deleted = []
+        deleted: list[dict[str, Any]] = []
         for item in production:
-            patch = item.get("patch")
-            if not isinstance(patch, str) or not patch:
-                raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
-            if not self._changed_lines(patch, "-"):
-                continue
-            path = item.get("previous_filename", item["filename"])
-            if not isinstance(path, str):
-                raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
-            result = self._request(
-                "GET",
-                f"/repos/{repository}/contents/{urllib.parse.quote(path)}"
-                f"?ref={urllib.parse.quote(base_sha)}",
-                token,
-            )
-            blob_sha = result.get("sha") if isinstance(result, dict) else None
-            if not isinstance(blob_sha, str) or not SHA_PATTERN.fullmatch(blob_sha):
-                raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
-            content = self._blob_content(repository, blob_sha, token)
-            head_path, head_blob_sha = item["filename"], item.get("sha")
-            if not isinstance(head_blob_sha, str) or not SHA_PATTERN.fullmatch(head_blob_sha):
-                raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
-            head_content = self._blob_content(repository, head_blob_sha, token)
-            try:
-                surviving, removed = changed_responsibility_spans(
-                    head_path,
-                    content.encode(),
-                    head_content.encode(),
-                    self._changed_lines(patch, "-"),
-                    self._changed_lines(patch),
-                )
-            except PythonSourceError as error:
-                raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE") from error
-            if not surviving and not removed:
-                raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
-            if surviving:
-                sources_by_path[head_path] = self._source_record(
-                    head_path, head_blob_sha, head_content, surviving
-                )
-            if removed:
-                deleted.append(
-                    {
-                        "blob_sha": blob_sha,
-                        "boundaries": self._boundaries(removed),
-                        "line_count": len(content.splitlines()),
-                        "path": path,
-                    }
-                )
+            surviving, removed = self._deletion_evidence(repository, base_sha, item, token)
+            if surviving is not None:
+                sources_by_path[str(surviving["path"])] = surviving
+            if removed is not None:
+                deleted.append(removed)
         sources = [sources_by_path[path] for path in sorted(sources_by_path)]
         self._validate_review_size(sources)
         return sources, deleted
+
+    def _deletion_evidence(
+        self,
+        repository: str,
+        base_sha: str,
+        item: dict[str, Any],
+        token: str,
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        patch = item.get("patch")
+        if not isinstance(patch, str) or not patch:
+            raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
+        base_lines = self._changed_lines(patch, "-")
+        if not base_lines:
+            return None, None
+        path = item.get("previous_filename", item.get("filename"))
+        head_path, head_blob_sha = item.get("filename"), item.get("sha")
+        if not isinstance(path, str) or not isinstance(head_path, str):
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        result = self._request(
+            "GET",
+            f"/repos/{repository}/contents/{urllib.parse.quote(path)}"
+            f"?ref={urllib.parse.quote(base_sha)}",
+            token,
+        )
+        blob_sha = result.get("sha") if isinstance(result, dict) else None
+        if (
+            not isinstance(blob_sha, str)
+            or not SHA_PATTERN.fullmatch(blob_sha)
+            or not isinstance(head_blob_sha, str)
+            or not SHA_PATTERN.fullmatch(head_blob_sha)
+        ):
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        content = self._blob_content(repository, blob_sha, token)
+        head_content = self._blob_content(repository, head_blob_sha, token)
+        try:
+            surviving, removed = changed_responsibility_spans(
+                head_path,
+                content.encode(),
+                head_content.encode(),
+                base_lines,
+                self._changed_lines(patch),
+            )
+        except PythonSourceError as error:
+            raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE") from error
+        if not surviving and not removed:
+            raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
+        source = (
+            self._source_record(head_path, head_blob_sha, head_content, surviving)
+            if surviving
+            else None
+        )
+        deleted = (
+            {
+                "blob_sha": blob_sha,
+                "boundaries": self._boundaries(removed),
+                "line_count": len(content.splitlines()),
+                "path": path,
+            }
+            if removed
+            else None
+        )
+        return source, deleted
 
     def _production_candidates(
         self, candidates: tuple[dict[str, Any], ...], production_paths: tuple[str, ...]

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -23,7 +23,12 @@ from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 from supportability_gate.architecture_policy import source_imports
 from supportability_gate.contract import ContractError, parse_contract
-from supportability_gate.function_changes import PythonSourceError, responsibility_spans
+from supportability_gate.function_changes import (
+    PythonSourceError,
+    ResponsibilitySpan,
+    changed_responsibility_spans,
+    responsibility_spans,
+)
 from supportability_gate.handoff_policy import (
     HANDOFF_REPORT_PATH,
     CompletionReportError,
@@ -40,7 +45,7 @@ from supportability_gate.semantic_contract import (
 
 API = "https://api.github.com"
 CHECK_NAME = "Supportability Semantic Review"
-REVIEWED_SUFFIXES = frozenset({".py", ".ts", ".tsx"})
+REVIEWED_SUFFIXES = frozenset({".py", ".pyi", ".cts", ".mts", ".ts", ".tsx"})
 HUNK_PATTERN = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 SourceBoundary = dict[str, int | str]
 HANDOFF_WORKFLOW_PATH = ".github/workflows/organization-required.yml"
@@ -760,11 +765,11 @@ class GitHubApp:
             return [], []
         production_paths = self._production_paths(repository, base_sha, token)
         production = self._production_candidates(candidates, production_paths)
-        sources = [
-            source
+        sources_by_path = {
+            source["path"]: source
             for item in production
             if (source := self._reviewed_source(repository, item, token)) is not None
-        ]
+        }
         deleted = []
         for item in production:
             patch = item.get("patch")
@@ -785,17 +790,36 @@ class GitHubApp:
             if not isinstance(blob_sha, str) or not SHA_PATTERN.fullmatch(blob_sha):
                 raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
             content = self._blob_content(repository, blob_sha, token)
-            boundaries = self._source_boundaries(path, content, patch, "-")
-            if not boundaries:
+            head_path, head_blob_sha = item["filename"], item.get("sha")
+            if not isinstance(head_blob_sha, str) or not SHA_PATTERN.fullmatch(head_blob_sha):
+                raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+            head_content = self._blob_content(repository, head_blob_sha, token)
+            try:
+                surviving, removed = changed_responsibility_spans(
+                    head_path,
+                    content.encode(),
+                    head_content.encode(),
+                    self._changed_lines(patch, "-"),
+                    self._changed_lines(patch),
+                )
+            except PythonSourceError as error:
+                raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE") from error
+            if not surviving and not removed:
                 raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
-            deleted.append(
-                {
-                    "blob_sha": blob_sha,
-                    "boundaries": boundaries,
-                    "line_count": len(content.splitlines()),
-                    "path": path,
-                }
-            )
+            if surviving:
+                sources_by_path[head_path] = self._source_record(
+                    head_path, head_blob_sha, head_content, surviving
+                )
+            if removed:
+                deleted.append(
+                    {
+                        "blob_sha": blob_sha,
+                        "boundaries": self._boundaries(removed),
+                        "line_count": len(content.splitlines()),
+                        "path": path,
+                    }
+                )
+        sources = [sources_by_path[path] for path in sorted(sources_by_path)]
         self._validate_review_size(sources)
         return sources, deleted
 
@@ -834,9 +858,19 @@ class GitHubApp:
         if not isinstance(patch, str) or not patch:
             raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
         content = self._blob_content(repository, blob_sha, token)
-        boundaries = self._source_boundaries(path, content, patch)
-        if not boundaries:
+        spans = self._responsibility_spans(path, content, patch)
+        if not spans:
             return None
+        return self._source_record(path, blob_sha, content, spans)
+
+    def _source_record(
+        self,
+        path: str,
+        blob_sha: str,
+        content: str,
+        spans: tuple[ResponsibilitySpan, ...],
+    ) -> dict[str, Any]:
+        boundaries = self._boundaries(spans)
         return {
             "boundaries": boundaries,
             "blob_sha": blob_sha,
@@ -849,15 +883,16 @@ class GitHubApp:
             "path": path,
         }
 
-    def _source_boundaries(
+    def _responsibility_spans(
         self, path: str, content: str, patch: str, side: str = "+"
-    ) -> list[SourceBoundary]:
-        changed_lines = self._changed_lines(patch, side)
+    ) -> tuple[ResponsibilitySpan, ...]:
         try:
-            spans = responsibility_spans(path, content.encode(), changed_lines)
+            return responsibility_spans(path, content.encode(), self._changed_lines(patch, side))
         except PythonSourceError as error:
             raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE") from error
-        boundaries: list[SourceBoundary] = [
+
+    def _boundaries(self, spans: tuple[ResponsibilitySpan, ...]) -> list[SourceBoundary]:
+        return [
             {
                 "end_line": span.end_line,
                 "kind": span.kind,
@@ -866,7 +901,11 @@ class GitHubApp:
             }
             for span in spans
         ]
-        return boundaries
+
+    def _source_boundaries(
+        self, path: str, content: str, patch: str, side: str = "+"
+    ) -> list[SourceBoundary]:
+        return self._boundaries(self._responsibility_spans(path, content, patch, side))
 
     def _changed_lines(self, patch: str, side: str = "+") -> set[int]:
         changed: set[int] = set()

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -655,7 +655,6 @@ def test_deletion_only_change_maps_surviving_head_and_removed_base_responsibilit
             "blob_sha": base_blob,
             "boundaries": [
                 {"end_line": 6, "kind": "function", "name": "obsolete", "start_line": 5},
-                {"end_line": 4, "kind": "module", "name": "src/a.py", "start_line": 4},
             ],
             "line_count": 6,
             "path": "src/a.py",
@@ -815,7 +814,6 @@ def test_mixed_source_change_reviews_head_and_identifies_deleted_base_responsibi
     assert deleted["blob_sha"] == base_blob
     assert deleted["boundaries"] == [
         {"end_line": 5, "kind": "function", "name": "obsolete", "start_line": 4},
-        {"end_line": 3, "kind": "module", "name": "src/a.py", "start_line": 3},
     ]
     assert app._completion_sources(
         "mbh-solutions/supportability-gate",

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -12,6 +12,7 @@ import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
+from supportability_gate.function_changes import ResponsibilitySpan, responsibility_spans
 from supportability_gate.github_app import CHECK_NAME, REVIEWED_SUFFIXES, GitHubApp, app_jwt
 from supportability_gate.semantic_contract import EvidencePacket, SemanticReviewError
 
@@ -580,6 +581,10 @@ def test_supported_source_boundaries_include_stubs_decorators_and_react_classes(
     assert app._source_boundaries("src/routes.pyi", decorated, "@@ -0,0 +1 @@\n+@route('/x')") == [
         {"end_line": 3, "kind": "function", "name": "handle", "start_line": 1}
     ]
+    latin = b"# coding: latin-1\nlabel = 'caf\xe9'\n"
+    assert responsibility_spans("src/labels.py", latin, {2}) == (
+        ResponsibilitySpan(2, 2, "module", "src/labels.py"),
+    )
 
     frontend = (
         "class Panel extends React.PureComponent<Props> {\n"

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -12,7 +12,7 @@ import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-from supportability_gate.github_app import CHECK_NAME, GitHubApp, app_jwt
+from supportability_gate.github_app import CHECK_NAME, REVIEWED_SUFFIXES, GitHubApp, app_jwt
 from supportability_gate.semantic_contract import EvidencePacket, SemanticReviewError
 
 CONTRACT = b"""schema_version = "1.0"
@@ -564,11 +564,49 @@ def test_frontend_component_boundary_uses_complete_parser_span() -> None:
     assert [item["line"] for item in app._source_excerpt(source, boundaries)] == [1, 2, 3, 4]
 
 
-def test_deletion_only_surviving_source_uses_base_identity_without_head_boundary() -> None:
-    base = b"def keep():\n    return 1\n\ndef obsolete():\n    return 2\n"
+def test_supported_source_boundaries_include_stubs_decorators_and_react_classes() -> None:
+    app = GitHubApp(42, 7, b"unused")
+    candidates = app._source_candidates(
+        tuple(
+            {"filename": f"src/sample{suffix}", "status": "modified"}
+            for suffix in (*sorted(REVIEWED_SUFFIXES), ".js", ".jsx")
+        )
+    )
+    assert {item["filename"].rsplit("sample", 1)[1] for item in candidates} == set(
+        REVIEWED_SUFFIXES
+    )
+
+    decorated = "@route('/x')\ndef handle():\n    return 1\n"
+    assert app._source_boundaries(
+        "src/routes.pyi", decorated, "@@ -0,0 +1 @@\n+@route('/x')"
+    ) == [{"end_line": 3, "kind": "function", "name": "handle", "start_line": 1}]
+
+    frontend = (
+        "class Panel extends React.PureComponent<Props> {\n"
+        "  render() { return <div />; }\n}\n"
+        "class Plain {\n  method() {}\n}\n"
+    )
+    assert app._source_boundaries(
+        "src/panel.tsx",
+        frontend,
+        "@@ -2 +2 @@\n-  render() { return null; }\n"
+        "+  render() { return <div />; }\n"
+        "@@ -5 +5 @@\n-  old() {}\n+  method() {}",
+    ) == [
+        {"end_line": 3, "kind": "component", "name": "Panel", "start_line": 1},
+        {"end_line": 2, "kind": "function", "name": "Panel.render", "start_line": 2},
+        {"end_line": 5, "kind": "function", "name": "Plain.method", "start_line": 5},
+    ]
+
+
+def test_deletion_only_change_maps_surviving_head_and_removed_base_responsibilities() -> None:
+    base = b"def keep():\n    removed = 1\n    return 1\n\ndef obsolete():\n    return 2\n"
     head = b"def keep():\n    return 1\n"
     base_blob, head_blob, contract_blob = map(_blob_sha, (base, head, CONTRACT))
-    patch = "@@ -1,5 +1,2 @@\n def keep():\n     return 1\n-\n-def obsolete():\n-    return 2"
+    patch = (
+        "@@ -1,6 +1,2 @@\n def keep():\n-    removed = 1\n"
+        "     return 1\n-\n-def obsolete():\n-    return 2"
+    )
 
     def open_request(request: Any, **kwargs: object) -> _Reply:
         if "/issues/3/comments" in request.full_url:
@@ -599,15 +637,29 @@ def test_deletion_only_surviving_source_uses_base_identity_without_head_boundary
     pull = {"number": 3, "base": {"sha": "a" * 40}, "head": {"sha": "b" * 40}}
     packet = app.evidence_packet("mbh-solutions/supportability-gate", pull, "token")
 
-    assert packet.evidence["reviewed_sources"] == []
+    assert packet.evidence["reviewed_sources"] == [
+        {
+            "blob_sha": head_blob,
+            "boundaries": [
+                {"end_line": 2, "kind": "function", "name": "keep", "start_line": 1}
+            ],
+            "imports": [],
+            "line_count": 2,
+            "lines": [
+                {"line": 1, "text": "def keep():"},
+                {"line": 2, "text": "    return 1"},
+            ],
+            "path": "src/a.py",
+        }
+    ]
     assert packet.evidence["deleted_sources"] == [
         {
             "blob_sha": base_blob,
             "boundaries": [
-                {"end_line": 5, "kind": "function", "name": "obsolete", "start_line": 4},
-                {"end_line": 3, "kind": "module", "name": "src/a.py", "start_line": 3},
+                {"end_line": 6, "kind": "function", "name": "obsolete", "start_line": 5},
+                {"end_line": 4, "kind": "module", "name": "src/a.py", "start_line": 4},
             ],
-            "line_count": 5,
+            "line_count": 6,
             "path": "src/a.py",
         }
     ]
@@ -764,7 +816,6 @@ def test_mixed_source_change_reviews_head_and_identifies_deleted_base_responsibi
     deleted = packet.evidence["deleted_sources"][0]
     assert deleted["blob_sha"] == base_blob
     assert deleted["boundaries"] == [
-        {"end_line": 2, "kind": "function", "name": "keep", "start_line": 1},
         {"end_line": 5, "kind": "function", "name": "obsolete", "start_line": 4},
         {"end_line": 3, "kind": "module", "name": "src/a.py", "start_line": 3},
     ]

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -577,9 +577,9 @@ def test_supported_source_boundaries_include_stubs_decorators_and_react_classes(
     )
 
     decorated = "@route('/x')\ndef handle():\n    return 1\n"
-    assert app._source_boundaries(
-        "src/routes.pyi", decorated, "@@ -0,0 +1 @@\n+@route('/x')"
-    ) == [{"end_line": 3, "kind": "function", "name": "handle", "start_line": 1}]
+    assert app._source_boundaries("src/routes.pyi", decorated, "@@ -0,0 +1 @@\n+@route('/x')") == [
+        {"end_line": 3, "kind": "function", "name": "handle", "start_line": 1}
+    ]
 
     frontend = (
         "class Panel extends React.PureComponent<Props> {\n"
@@ -640,9 +640,7 @@ def test_deletion_only_change_maps_surviving_head_and_removed_base_responsibilit
     assert packet.evidence["reviewed_sources"] == [
         {
             "blob_sha": head_blob,
-            "boundaries": [
-                {"end_line": 2, "kind": "function", "name": "keep", "start_line": 1}
-            ],
+            "boundaries": [{"end_line": 2, "kind": "function", "name": "keep", "start_line": 1}],
             "imports": [],
             "line_count": 2,
             "lines": [


### PR DESCRIPTION
Addresses root issues 3-6 in #79.

Implemented:
- exact reviewed suffixes: `.py`, `.pyi`, `.cts`, `.mts`, `.ts`, `.tsx`;
- base/head qualified-identity mapping for deletion-touched retained responsibilities;
- base-only evidence for fully removed responsibilities;
- decorator-inclusive Python spans;
- aggregate supported React class-component spans while retaining method spans;
- nonblank-only residual module responsibility spans, preserving PEP 263 Python encodings.

Evidence on exact head `31145d122c22c8590dda3f1e0fb44cf033b4c367`:
- external four-root reproducer: FAIL before, PASS after, deleted;
- focused suite once: `100 passed in 0.51s`;
- Source Validation: PASS (`92037712034`);
- Characterize Base/Head: PASS (`92037711775`, `92037711623`);
- Quality Profile: PASS (`92037711950`);
- Supportability Gate: PASS (`92037948732`);
- Supportability Semantic Review: PASS (`92038519515`), packet `9fe64a5e600ec7f6980a7e2750664ced5f9bc989569ad7f83b7641a8c08c8249`, instruction `abdff17625095ad86be7891b621e101dc7896d52e394b2fd23a3e4920bbb4d8d`.

The semantic review used the exact committed candidate reviewer because the deployed runtime contains the blank-span defect this PR repairs. No installed runtime or scheduled-task definition was changed; deployment will use the protected merge before PR 4.

No TWMN, package, module, public API, policy, or broad-test change.
