### PR TITLE
Bind characterization and refactor sequence evidence

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,30 +2,23 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "34f0cb88c4c397c42d6c792f635ddbe20a0577cb"
+base_sha = "3ad2c475ba1d241185715c05a0169a2462b9c7d2"
 overall_result = "PASS"
 responsibility_changes = [
-    "architecture_policy owns strict domain dependencies, production-root layers, and NodeNext source resolution.",
-    "modularity_policy owns pre-existing same-package ownership and executed quality coverage for new locations.",
-    "semantic_review binds dependency-direction prose to every trusted structured import citation.",
-    "cli passes authenticated quality evidence into deterministic modularity evaluation.",
+    "hosted_characterization materializes the authenticated driver blob to a fresh temporary path for each comparison execution while retaining the canonical recorded command and authenticated golden blob.",
+    "refactor_policy authenticates the current base's unique merged predecessor PR and binds each sequence step to its trusted prior authorization.",
+    "refactor_policy maps retained-file deletions through exact base and head ranges so removed responsibilities keep their base identity.",
+    "git_changes distinguishes real head content ranges from deletion anchors and exposes exact retained-base ranges.",
 ]
 simplified_functions = [
-    "_architecture_evidence",
-    "_blocks",
-    "_claim_blocks",
-    "_evaluate",
-    "_layer",
-    "_package",
-    "_typescript_target",
-    "evaluate_modularity",
+    "_target_identities",
 ]
 boundary_rationale = [
-    "Static source topology stays in architecture_policy; authenticated run observations stay in quality evidence; modularity consumes both without executing target code.",
+    "Driver materialization stays in the trusted hosted capture entry point; Git range extraction stays in git_changes; predecessor and target authorization stay in refactor_policy.",
 ]
 remaining_risks = [
-    "The domain allowlist is intentionally closed; new pure-domain standard-library needs require a separately authorized policy change.",
-    "NodeNext mapping covers relative JS-family specifiers and their index candidates; package export maps remain outside this fixed source resolver.",
+    "Predecessor evidence depends on GitHub's commit-to-pull association and issue comments; unavailable or ambiguous evidence fails closed.",
+    "Characterization drivers retain the authenticated definition path for declared fixture access, but executable bytes never come from that mutable worktree.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -45,16 +38,11 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-architecture-policy"
-text = "Domain code accepts only the fixed pure-Python allowlist, TypeScript domain code accepts no external dependency, NodeNext relative specifiers resolve to TypeScript sources, and production-root layer names are retained."
-citations = ["src/supportability_gate/architecture_policy.py:36-60", "src/supportability_gate/architecture_policy.py:125-131", "src/supportability_gate/architecture_policy.py:206-222", "src/supportability_gate/architecture_policy.py:276-285"]
+id = "claim-authenticated-predecessor-sequence"
+text = "Step 1 is rejected after a predecessor authorization, and each later step requires the current base to resolve to exactly one merged PR with a trusted exact-head authorization for the immediately prior step."
+citations = ["src/supportability_gate/refactor_policy.py:188-199", "src/supportability_gate/refactor_policy.py:272-314", "src/supportability_gate/refactor_policy.py:505-510", "src/supportability_gate/refactor_policy.py:594-610"]
 
 [[completion_report.claims]]
-id = "claim-modularity-evidence"
-text = "A new location requires a pre-existing governed owner in the same package and counts gate coverage only from successful executed commands that observed the path or proved it has zero statements."
-citations = ["src/supportability_gate/modularity_policy.py:91-98", "src/supportability_gate/modularity_policy.py:108-133", "src/supportability_gate/modularity_policy.py:136-166", "src/supportability_gate/cli.py:479-485"]
-
-[[completion_report.claims]]
-id = "claim-dependency-prose"
-text = "Dependency-direction prose must contain every exact trusted source-line-specifier token represented by its structured architecture citations."
-citations = ["src/supportability_gate/semantic_contract.py:294-295", "src/supportability_gate/semantic_review.py:259-286"]
+id = "claim-base-deletion-identity"
+text = "Retained-file deletions use exact base and head content ranges with the existing base-to-head responsibility mapper, preserving removed base identities without attributing a zero-length deletion to the following head line."
+citations = ["src/supportability_gate/git_changes.py:281-332", "src/supportability_gate/refactor_policy.py:328-407"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -11,7 +11,14 @@ responsibility_changes = [
     "git_changes distinguishes real head content ranges from deletion anchors and exposes exact retained-base ranges.",
 ]
 simplified_functions = [
+    "_change_spans",
+    "_predecessor_authorization",
+    "_sequence_blocks",
     "_target_identities",
+    "changed_base_lines",
+    "changed_head_lines",
+    "main",
+    "verify_refactor",
 ]
 boundary_rationale = [
     "Driver materialization stays in the trusted hosted capture entry point; Git range extraction stays in git_changes; predecessor and target authorization stay in refactor_policy.",
@@ -40,9 +47,9 @@ gate_coverage = [
 [[completion_report.claims]]
 id = "claim-authenticated-predecessor-sequence"
 text = "Step 1 is rejected after a predecessor authorization, and each later step requires the current base to resolve to exactly one merged PR with a trusted exact-head authorization for the immediately prior step."
-citations = ["src/supportability_gate/refactor_policy.py:188-199", "src/supportability_gate/refactor_policy.py:272-314", "src/supportability_gate/refactor_policy.py:505-510", "src/supportability_gate/refactor_policy.py:594-610"]
+citations = ["src/supportability_gate/refactor_policy.py:188-199", "src/supportability_gate/refactor_policy.py:272-314", "src/supportability_gate/refactor_policy.py:494-499", "src/supportability_gate/refactor_policy.py:583-599"]
 
 [[completion_report.claims]]
 id = "claim-base-deletion-identity"
 text = "Retained-file deletions use exact base and head content ranges with the existing base-to-head responsibility mapper, preserving removed base identities without attributing a zero-length deletion to the following head line."
-citations = ["src/supportability_gate/git_changes.py:281-332", "src/supportability_gate/refactor_policy.py:328-407"]
+citations = ["src/supportability_gate/git_changes.py:281-332", "src/supportability_gate/refactor_policy.py:328-396"]

--- a/src/supportability_gate/git_changes.py
+++ b/src/supportability_gate/git_changes.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 GIT_TIMEOUT_SECONDS = 30
 _FULL_SHA = re.compile(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}")
 _HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+_BASE_HUNK = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+\d+(?:,\d+)? @@")
 
 
 class GitError(RuntimeError):
@@ -283,6 +284,8 @@ def changed_head_lines(
     head_sha: str,
     path: str,
     records: list[CommandRecord],
+    *,
+    include_deletion_anchor: bool = True,
 ) -> tuple[int, ...]:
     """Return exact changed line numbers in the head blob."""
     patch = run_git(
@@ -296,5 +299,34 @@ def changed_head_lines(
         if match:
             start = int(match.group(1))
             count = int(match.group(2) or "1")
-            lines.update(range(start, start + count) if count else (max(1, start),))
+            lines.update(
+                range(start, start + count)
+                if count
+                else (max(1, start),)
+                if include_deletion_anchor
+                else ()
+            )
+    return tuple(sorted(lines))
+
+
+def changed_base_lines(
+    repository: Path,
+    base_sha: str,
+    head_sha: str,
+    path: str,
+    records: list[CommandRecord],
+) -> tuple[int, ...]:
+    """Return exact removed or modified line numbers in a retained base blob."""
+    patch = run_git(
+        repository,
+        ("diff", "--unified=0", "--no-color", "--no-ext-diff", base_sha, head_sha, "--", path),
+        records,
+    ).decode("utf-8", errors="strict")
+    lines: set[int] = set()
+    for line in patch.splitlines():
+        match = _BASE_HUNK.match(line)
+        if match:
+            start = int(match.group(1))
+            count = int(match.group(2) or "1")
+            lines.update(range(start, start + count))
     return tuple(sorted(lines))

--- a/src/supportability_gate/refactor_policy.py
+++ b/src/supportability_gate/refactor_policy.py
@@ -185,6 +185,20 @@ def _authorization_blocks(event: dict[str, Any], authorization: Authorization) -
     return blocks
 
 
+def _sequence_blocks(
+    authorization: Authorization,
+    predecessor: Authorization | None,
+    predecessor_block: str | None,
+) -> list[str]:
+    if predecessor_block is not None:
+        return [predecessor_block]
+    if authorization.sequence.step == 1:
+        return ["INVALID_STRANGLER_SEQUENCE"] if predecessor is not None else []
+    if predecessor is None or predecessor.sequence.step != authorization.sequence.step - 1:
+        return ["INVALID_STRANGLER_SEQUENCE"]
+    return []
+
+
 def _owner_authorization(
     event: dict[str, Any], comments: tuple[dict[str, Any], ...]
 ) -> tuple[Authorization, int]:
@@ -255,6 +269,51 @@ def _github_comments(
     return tuple(value)
 
 
+def _predecessor_authorization(
+    repository: str,
+    base_sha: str,
+    token: str,
+    opener: Any = urllib.request.urlopen,
+) -> tuple[Authorization | None, str | None]:
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repository}/commits/{base_sha}/pulls?per_page=100",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with opener(request, timeout=30) as response:
+            value = json.loads(response.read())
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return None, "GITHUB_AUTHORIZATION_EVIDENCE_FAILURE"
+    if not isinstance(value, list) or len(value) >= 100:
+        return None, "GITHUB_AUTHORIZATION_EVIDENCE_FAILURE"
+    merged = [
+        item
+        for item in value
+        if isinstance(item, dict)
+        and item.get("merge_commit_sha") == base_sha
+        and isinstance(item.get("merged_at"), str)
+    ]
+    if not merged:
+        return None, None
+    if len(merged) != 1 or type(merged[0].get("number")) is not int:
+        return None, "INVALID_STRANGLER_SEQUENCE"
+    event = {"repository": {"full_name": repository}, "pull_request": merged[0]}
+    try:
+        comments = _github_comments(repository, merged[0]["number"], token, opener)
+        authorization, _ = _owner_authorization(event, comments)
+    except RefactorPolicyError as error:
+        if error.code == "MISSING_OWNER_AUTHORIZATION":
+            return None, None
+        return None, error.code
+    if _authorization_blocks(event, authorization):
+        return None, "INVALID_STRANGLER_SEQUENCE"
+    return authorization, None
+
+
 def _profile_source(path: str, language: str) -> bool:
     suffixes = (".py", ".pyi") if language == "python" else (".cts", ".mts", ".ts", ".tsx")
     return path.endswith(suffixes)
@@ -264,6 +323,45 @@ def _changed_scope(changes: tuple[git_changes.ChangedPath, ...]) -> tuple[str, .
     return tuple(
         sorted({path for item in changes for path in (item.old_path, item.new_path) if path})
     )
+
+
+def _change_spans(
+    repository: Path,
+    identity: git_changes.RepositoryIdentity,
+    change: git_changes.ChangedPath,
+    path: str,
+    records: list[git_changes.CommandRecord],
+) -> tuple[function_changes.ResponsibilitySpan, ...]:
+    if change.new_path is None:
+        content = git_changes.read_regular_blob(
+            repository, identity.base_sha, path, records
+        ).content
+        return function_changes.responsibility_spans(
+            path, content, set(range(1, len(content.splitlines()) + 1))
+        )
+    head = git_changes.read_regular_blob(repository, identity.head_sha, path, records).content
+    head_lines = set(
+        git_changes.changed_head_lines(
+            repository,
+            identity.base_sha,
+            identity.head_sha,
+            path,
+            records,
+            include_deletion_anchor=False,
+        )
+    )
+    if change.old_path != change.new_path:
+        return function_changes.responsibility_spans(path, head, head_lines)
+    base = git_changes.read_regular_blob(repository, identity.base_sha, path, records).content
+    base_lines = set(
+        git_changes.changed_base_lines(
+            repository, identity.base_sha, identity.head_sha, path, records
+        )
+    )
+    surviving, deleted = function_changes.changed_responsibility_spans(
+        path, base, head, base_lines, head_lines
+    )
+    return (*surviving, *deleted)
 
 
 def _target_identities(
@@ -282,24 +380,14 @@ def _target_identities(
         if not _profile_source(path, policy.language):
             unbounded.append(path)
             continue
-        deleted = change.new_path is None
-        commit = identity.base_sha if deleted else identity.head_sha
-        blob = git_changes.read_regular_blob(repository, commit, path, records)
-        lines = (
-            tuple(range(1, len(blob.content.splitlines()) + 1))
-            if deleted
-            else git_changes.changed_head_lines(
-                repository, identity.base_sha, identity.head_sha, path, records
-            )
-        )
-        if not lines:
+        try:
+            spans = _change_spans(repository, identity, change, path, records)
+        except function_changes.PythonSourceError:
+            if change.new_path is not None:
+                raise
             unbounded.append(path)
             continue
-        try:
-            spans = function_changes.responsibility_spans(path, blob.content, set(lines))
-        except function_changes.PythonSourceError:
-            if not deleted:
-                raise
+        if not spans:
             unbounded.append(path)
             continue
         targets.extend(
@@ -384,6 +472,8 @@ def verify_refactor(
     event: dict[str, Any],
     characterization: dict[str, Any],
     comments: tuple[dict[str, Any], ...],
+    predecessor: Authorization | None = None,
+    predecessor_block: str | None = None,
 ) -> dict[str, object]:
     """Return deterministic M8 authorization, focus, runnability, and sequence evidence."""
     records: list[git_changes.CommandRecord] = []
@@ -405,6 +495,7 @@ def verify_refactor(
         try:
             authorization, authorization_comment_id = _owner_authorization(event, comments)
             blocks.extend(_authorization_blocks(event, authorization))
+            blocks.extend(_sequence_blocks(authorization, predecessor, predecessor_block))
             blocks.extend(_focus_blocks(authorization, actual_scope, targets, unbounded, policy))
         except RefactorPolicyError as error:
             blocks.append(error.code)
@@ -494,7 +585,18 @@ def main(argv: list[str] | None = None) -> int:
         if not token:
             raise RefactorPolicyError("GITHUB_AUTHORIZATION_EVIDENCE_FAILURE")
         comments = _github_comments(repository_name, pull_number, token)
-        result = verify_refactor(Path(arguments.repository), event, characterization, comments)
+        _, base_sha, _, _ = _event_values(event)
+        predecessor, predecessor_block = _predecessor_authorization(
+            repository_name, base_sha, token
+        )
+        result = verify_refactor(
+            Path(arguments.repository),
+            event,
+            characterization,
+            comments,
+            predecessor,
+            predecessor_block,
+        )
         _write_result(Path(arguments.output), result)
     except Exception as error:  # fail closed at hosted-job boundary
         print(getattr(error, "code", "TECHNICAL_FAILURE"))

--- a/src/supportability_gate/refactor_policy.py
+++ b/src/supportability_gate/refactor_policy.py
@@ -364,6 +364,32 @@ def _change_spans(
     return (*surviving, *deleted)
 
 
+def _change_targets(
+    repository: Path,
+    identity: git_changes.RepositoryIdentity,
+    policy: contract.Contract,
+    change: git_changes.ChangedPath,
+    records: list[git_changes.CommandRecord],
+) -> tuple[tuple[str, ...], str | None]:
+    path = change.new_path or change.old_path
+    if path is None or not policy.is_production_path(path):
+        return (), None
+    if not _profile_source(path, policy.language):
+        return (), path
+    try:
+        spans = _change_spans(repository, identity, change, path, records)
+    except function_changes.PythonSourceError:
+        if change.new_path is not None:
+            raise
+        return (), path
+    return (
+        tuple(
+            f"{path}::{item.kind}:{item.name}:{item.start_line}-{item.end_line}" for item in spans
+        ),
+        None if spans else path,
+    )
+
+
 def _target_identities(
     repository: Path,
     identity: git_changes.RepositoryIdentity,
@@ -374,25 +400,10 @@ def _target_identities(
     targets: list[str] = []
     unbounded: list[str] = []
     for change in changes:
-        path = change.new_path or change.old_path
-        if path is None or not policy.is_production_path(path):
-            continue
-        if not _profile_source(path, policy.language):
-            unbounded.append(path)
-            continue
-        try:
-            spans = _change_spans(repository, identity, change, path, records)
-        except function_changes.PythonSourceError:
-            if change.new_path is not None:
-                raise
-            unbounded.append(path)
-            continue
-        if not spans:
-            unbounded.append(path)
-            continue
-        targets.extend(
-            f"{path}::{item.kind}:{item.name}:{item.start_line}-{item.end_line}" for item in spans
-        )
+        bounded, missing = _change_targets(repository, identity, policy, change, records)
+        targets.extend(bounded)
+        if missing is not None:
+            unbounded.append(missing)
     return tuple(sorted(targets)), tuple(sorted(unbounded))
 
 

--- a/src/supportability_gate/refactor_policy.py
+++ b/src/supportability_gate/refactor_policy.py
@@ -364,32 +364,6 @@ def _change_spans(
     return (*surviving, *deleted)
 
 
-def _change_targets(
-    repository: Path,
-    identity: git_changes.RepositoryIdentity,
-    policy: contract.Contract,
-    change: git_changes.ChangedPath,
-    records: list[git_changes.CommandRecord],
-) -> tuple[tuple[str, ...], str | None]:
-    path = change.new_path or change.old_path
-    if path is None or not policy.is_production_path(path):
-        return (), None
-    if not _profile_source(path, policy.language):
-        return (), path
-    try:
-        spans = _change_spans(repository, identity, change, path, records)
-    except function_changes.PythonSourceError:
-        if change.new_path is not None:
-            raise
-        return (), path
-    return (
-        tuple(
-            f"{path}::{item.kind}:{item.name}:{item.start_line}-{item.end_line}" for item in spans
-        ),
-        None if spans else path,
-    )
-
-
 def _target_identities(
     repository: Path,
     identity: git_changes.RepositoryIdentity,
@@ -400,10 +374,25 @@ def _target_identities(
     targets: list[str] = []
     unbounded: list[str] = []
     for change in changes:
-        bounded, missing = _change_targets(repository, identity, policy, change, records)
-        targets.extend(bounded)
-        if missing is not None:
-            unbounded.append(missing)
+        path = change.new_path or change.old_path
+        if path is None or not policy.is_production_path(path):
+            continue
+        if not _profile_source(path, policy.language):
+            unbounded.append(path)
+            continue
+        try:
+            spans = _change_spans(repository, identity, change, path, records)
+        except function_changes.PythonSourceError:
+            if change.new_path is not None:
+                raise
+            unbounded.append(path)
+            continue
+        if not spans:
+            unbounded.append(path)
+            continue
+        targets.extend(
+            f"{path}::{item.kind}:{item.name}:{item.start_line}-{item.end_line}" for item in spans
+        )
     return tuple(sorted(targets)), tuple(sorted(unbounded))
 
 

--- a/tests/hosted_characterization.py
+++ b/tests/hosted_characterization.py
@@ -6,6 +6,7 @@ import argparse
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 from supportability_gate import characterization, contract, git_changes
@@ -57,23 +58,27 @@ def _run_driver(
     definition: Path,
     scenario: characterization.Scenario,
     language: str,
+    content: bytes,
 ) -> dict[str, object]:
     relative_driver, _ = characterization._scenario_paths(scenario, language)
-    arguments, recorded = _command(language, relative_driver, definition / relative_driver)
-    try:
-        completed = subprocess.run(
-            arguments,
-            cwd=target,
-            env=_safe_environment(target, definition),
-            check=False,
-            capture_output=True,
-            timeout=EXECUTION_TIMEOUT_SECONDS,
-        )
-        stdout, stderr, exit_code = completed.stdout, completed.stderr, completed.returncode
-    except subprocess.TimeoutExpired as error:
-        stdout, stderr, exit_code = error.stdout or b"", error.stderr or b"", -1
-    except OSError as error:
-        stdout, stderr, exit_code = b"", str(error).encode(errors="replace"), -127
+    with tempfile.TemporaryDirectory(dir=os.environ.get("RUNNER_TEMP")) as temporary:
+        materialized = Path(temporary) / Path(relative_driver).name
+        materialized.write_bytes(content)
+        arguments, recorded = _command(language, relative_driver, materialized)
+        try:
+            completed = subprocess.run(
+                arguments,
+                cwd=target,
+                env=_safe_environment(target, definition),
+                check=False,
+                capture_output=True,
+                timeout=EXECUTION_TIMEOUT_SECONDS,
+            )
+            stdout, stderr, exit_code = completed.stdout, completed.stderr, completed.returncode
+        except subprocess.TimeoutExpired as error:
+            stdout, stderr, exit_code = error.stdout or b"", error.stderr or b"", -1
+        except OSError as error:
+            stdout, stderr, exit_code = b"", str(error).encode(errors="replace"), -127
     behavior, error_code = _behavior(stdout, scenario.id) if exit_code == 0 else (None, None)
     return {
         "behavior": behavior,
@@ -102,8 +107,8 @@ def _scenario_capture(
     driver = git_changes.read_regular_blob(definition, definition_sha, driver_path, records)
     golden = git_changes.read_regular_blob(definition, definition_sha, golden_path, records)
     golden_behavior = characterization._read_json_bytes(golden.content, "MALFORMED_GOLDEN_OUTPUT")
-    first = _run_driver(target, definition, scenario, language)
-    second = _run_driver(target, definition, scenario, language)
+    first = _run_driver(target, definition, scenario, language, driver.content)
+    second = _run_driver(target, definition, scenario, language, driver.content)
     return {
         "behavior": first["behavior"],
         "behavior_sha256": first["behavior_sha256"],

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -225,6 +225,46 @@ def _captures(
     return base, head
 
 
+def test_driver_executes_authenticated_blob_from_fresh_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "target"
+    definition = tmp_path / "definition"
+    target.mkdir()
+    relative, _ = characterization._scenario_paths(
+        characterization.Scenario("victim", "regression", ("src/sample.py",)), "python"
+    )
+    mutable = definition / relative
+    _write(
+        mutable,
+        "import json\n"
+        "print(json.dumps({'schema_version':'1.0','scenario':'victim',"
+        "'behavior':{'source':'mutable'}}))\n",
+    )
+    authenticated = mutable.read_bytes().replace(b"mutable", b"authenticated")
+    seen: list[Path] = []
+    command = hosted_characterization._command
+
+    def record(language: str, driver: str, materialized: Path) -> tuple[list[str], list[str]]:
+        seen.append(materialized)
+        return command(language, driver, materialized)
+
+    monkeypatch.setattr(hosted_characterization, "_command", record)
+    scenario = characterization.Scenario("victim", "regression", ("src/sample.py",))
+
+    first = hosted_characterization._run_driver(
+        target, definition, scenario, "python", authenticated
+    )
+    second = hosted_characterization._run_driver(
+        target, definition, scenario, "python", authenticated
+    )
+
+    assert first["behavior"] == second["behavior"] == {"source": "authenticated"}
+    assert first["command"] == ["python3.12", "-P", relative]
+    assert len(set(seen)) == 2
+    assert all(not path.is_relative_to(definition) and not path.exists() for path in seen)
+
+
 def _write_artifacts(
     tmp_path: Path, base: dict[str, object], head: dict[str, object]
 ) -> tuple[Path, Path]:

--- a/tests/test_refactor_policy.py
+++ b/tests/test_refactor_policy.py
@@ -96,6 +96,7 @@ def _authorization(
     *,
     broad: bool = False,
     predecessor_sha: str | None = None,
+    step: int = 1,
 ) -> str:
     value = {
         "base_sha": base_sha,
@@ -104,7 +105,7 @@ def _authorization(
         "repository": "example/fixture",
         "schema_version": "1.0",
         "scope": sorted(scope),
-        "sequence": {"predecessor_sha": predecessor_sha or base_sha, "step": 1},
+        "sequence": {"predecessor_sha": predecessor_sha or base_sha, "step": step},
         "targets": sorted(targets),
     }
     return refactor_policy.AUTHORIZATION_PREFIX + json.dumps(value, separators=(",", ":"))
@@ -152,10 +153,14 @@ def _verify(
     characterization: dict[str, object],
     *,
     owner_id: int = refactor_policy.TRUSTED_OWNER_ID,
+    predecessor: refactor_policy.Authorization | None = None,
+    predecessor_block: str | None = None,
 ) -> dict[str, object]:
     body = event["pull_request"]["body"]  # type: ignore[index]
     comments = () if body is None else ({"body": body, "id": 11, "user": {"id": owner_id}},)
-    return refactor_policy.verify_refactor(repository, event, characterization, comments)
+    return refactor_policy.verify_refactor(
+        repository, event, characterization, comments, predecessor, predecessor_block
+    )
 
 
 @pytest.mark.parametrize(
@@ -315,6 +320,26 @@ def test_exact_authorized_python_deletion_uses_base_responsibilities(tmp_path: P
     assert first["unbounded_paths"] == []
 
 
+def test_retained_file_deletion_uses_deleted_base_responsibility(tmp_path: Path) -> None:
+    repository, base_sha, _ = _repository(tmp_path)
+    _git(repository, "reset", "--hard", base_sha)
+    path = "src/sample.py"
+    _write(
+        repository / path,
+        "def removed() -> int:\n    return 1\n\ndef retained() -> int:\n    return 2\n",
+    )
+    base_sha = _commit(repository, "two functions")
+    _write(repository / path, "def retained() -> int:\n    return 2\n")
+    head_sha = _commit(repository, "delete first function")
+    target = f"{path}::function:removed:1-2"
+    event = _event(base_sha, head_sha, _authorization(base_sha, head_sha, [path], [target]))
+
+    result = _verify(repository, event, _characterization(base_sha, head_sha, [path]))
+
+    assert result["overall_result"] == "PASS"
+    assert result["targets"] == [target]
+
+
 def test_existing_addition_enforcement_is_unchanged(tmp_path: Path) -> None:
     repository, base_sha, _ = _repository(tmp_path)
     _git(repository, "reset", "--hard", base_sha)
@@ -427,6 +452,84 @@ def test_github_comment_evidence_uses_fixed_authenticated_endpoint() -> None:
     assert comments[0]["id"] == 11
     assert requests[0].full_url.endswith("/repos/example/fixture/issues/7/comments?per_page=100")
     assert requests[0].get_header("Authorization") == "Bearer token"
+
+
+def test_predecessor_uses_exact_merged_pr_and_trusted_authorization() -> None:
+    merge_sha, prior_base, prior_head = "a" * 40, "b" * 40, "c" * 40
+    body = _authorization(
+        prior_base,
+        prior_head,
+        ["src/sample.py"],
+        ["src/sample.py::function:calculate:1-2"],
+        step=2,
+    )
+    responses = iter(
+        [
+            [
+                {
+                    "base": {"sha": prior_base},
+                    "head": {"sha": prior_head},
+                    "merge_commit_sha": merge_sha,
+                    "merged_at": "2026-08-04T00:00:00Z",
+                    "number": 6,
+                }
+            ],
+            [{"body": body, "id": 11, "user": {"id": refactor_policy.TRUSTED_OWNER_ID}}],
+        ]
+    )
+    requests: list[Any] = []
+
+    def opener(request: Any, **kwargs: object) -> _Reply:
+        requests.append(request)
+        assert kwargs == {"timeout": 30}
+        return _Reply(next(responses))
+
+    predecessor, block = refactor_policy._predecessor_authorization(
+        "example/fixture", merge_sha, "token", opener
+    )
+
+    assert block is None
+    assert predecessor is not None and predecessor.sequence.step == 2
+    assert requests[0].full_url.endswith(f"/commits/{merge_sha}/pulls?per_page=100")
+    assert requests[1].full_url.endswith("/issues/6/comments?per_page=100")
+
+
+def test_sequence_step_requires_immediate_authenticated_predecessor() -> None:
+    previous = refactor_policy._parse_authorization(
+        _authorization(
+            "d" * 40,
+            "e" * 40,
+            ["src/sample.py"],
+            ["src/sample.py::function:calculate:1-2"],
+            step=2,
+        )
+    )
+    step_three = refactor_policy._parse_authorization(
+        _authorization(
+            "a" * 40,
+            "b" * 40,
+            ["src/sample.py"],
+            ["src/sample.py::function:calculate:1-2"],
+            step=3,
+        )
+    )
+    reset = refactor_policy._parse_authorization(
+        _authorization(
+            "a" * 40,
+            "b" * 40,
+            ["src/sample.py"],
+            ["src/sample.py::function:calculate:1-2"],
+        )
+    )
+
+    assert refactor_policy._sequence_blocks(step_three, previous, None) == []
+    assert refactor_policy._sequence_blocks(reset, previous, None) == ["INVALID_STRANGLER_SEQUENCE"]
+    assert refactor_policy._sequence_blocks(step_three, None, None) == [
+        "INVALID_STRANGLER_SEQUENCE"
+    ]
+    assert refactor_policy._sequence_blocks(
+        step_three, previous, "GITHUB_AUTHORIZATION_EVIDENCE_FAILURE"
+    ) == ["GITHUB_AUTHORIZATION_EVIDENCE_FAILURE"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Addresses root issues 13-15 in #79.

- Executes each authenticated characterization driver blob from a fresh temporary path for both comparison runs while preserving the canonical command and authenticated golden blob.
- Resolves the current base to exactly one merged predecessor PR and binds sequence steps to its trusted exact-head authorization.
- Uses exact retained-base/head ranges and existing responsibility mapping for deleted functions.

Evidence on exact head `acd22a4f44a524118fc060c3c711dd0141ca714b`:
- External three-root reproducer: all three failed before; all three passed after; deleted.
- Characterize Base, Characterize Head, Quality Profile, Source Validation, and Supportability Gate: PASS.
- Exact production completion preflight: zero blocks; report/authoritative changed-function sets equal.
- Semantic Review check `92122621812`: PASS; evidence packet `21a21eb140661b43095f6884a6624074eb742dac26187f30195d82b7bcca63bd`; instruction SHA-256 `de5e7d0b5410bd3fe2a7f11ee88885d29fea27b636100eaf4a9832158de5a184`.
- Focused Python 3.12.12 suite: `50 passed in 66.44s`.

No new module, package, broad local test, immutable-doc change, or TWMN repository change.