### PR TITLE
Bind trusted quality and handoff evidence

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -48,17 +48,17 @@ gate_coverage = [
 [[completion_report.claims]]
 id = "claim-trusted-python-tools"
 text = "Every Python module quality tool uses isolated mode, the fixed target environment omits PYTHONPATH, and generated pytest and mypy configuration supplies intended source discovery."
-citations = ["src/supportability_gate/quality_profile.py:14-124", "src/supportability_gate/quality_runner.py:24-36", "src/supportability_gate/quality_runner.py:125-136"]
+citations = ["src/supportability_gate/quality_profile.py:14-118", "src/supportability_gate/quality_runner.py:24-36", "src/supportability_gate/quality_runner.py:125-136"]
 
 [[completion_report.claims]]
 id = "claim-base-head-handoff-binding"
 text = "Handoff collection searches successful exact-head runs newest-first and accepts only an authenticated result whose base and head identities match the current packet."
-citations = ["src/supportability_gate/github_app.py:278-303", "src/supportability_gate/github_app.py:313-339", "src/supportability_gate/github_app.py:429-459"]
+citations = ["src/supportability_gate/github_app.py:278-303", "src/supportability_gate/github_app.py:313-339", "src/supportability_gate/github_app.py:429-458"]
 
 [[completion_report.claims]]
 id = "claim-fail-closed-handoff-results"
 text = "Report and authoritative command rows use separate strict shapes and failure codes, while authoritative non-PASS, unexecuted, and nonzero results always produce deterministic blocks."
-citations = ["src/supportability_gate/handoff_policy.py:21-32", "src/supportability_gate/handoff_policy.py:143-230", "src/supportability_gate/handoff_policy.py:266-274"]
+citations = ["src/supportability_gate/handoff_policy.py:24-32", "src/supportability_gate/handoff_policy.py:143-230", "src/supportability_gate/handoff_policy.py:266-274"]
 
 [[completion_report.claims]]
 id = "claim-unique-refactor-targets"

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -8,6 +8,7 @@ responsibility_changes = [
     "quality_profile and quality_runner isolate trusted Python module tools from target-controlled import paths while retaining generated source-discovery configuration.",
     "GitHubApp binds the authenticated handoff artifact to the packet's current base and head SHAs.",
     "handoff_policy validates report and authoritative command rows independently and preserves authenticated failures as deterministic blocks.",
+    "refactor_policy collapses duplicate spans to their single bounded target identity.",
 ]
 simplified_functions = [
     "GitHubApp._handoff_evidence",
@@ -15,6 +16,7 @@ simplified_functions = [
     "_command_blocks",
     "_commands",
     "_result_blocks",
+    "_target_identities",
     "fixed_environment",
 ]
 boundary_rationale = [
@@ -54,3 +56,8 @@ citations = ["src/supportability_gate/github_app.py:278-303", "src/supportabilit
 id = "claim-fail-closed-handoff-results"
 text = "Report and authoritative command rows use separate strict shapes and failure codes, while authoritative non-PASS, unexecuted, and nonzero results always produce deterministic blocks."
 citations = ["src/supportability_gate/handoff_policy.py:21-32", "src/supportability_gate/handoff_policy.py:143-230", "src/supportability_gate/handoff_policy.py:266-274"]
+
+[[completion_report.claims]]
+id = "claim-unique-refactor-targets"
+text = "Repeated spans for the same changed responsibility collapse to one exact authorization target."
+citations = ["src/supportability_gate/refactor_policy.py:367-396"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -17,7 +17,6 @@ simplified_functions = [
     "_commands",
     "_result_blocks",
     "_target_identities",
-    "_write_python_configs",
     "command_plans",
     "fixed_environment",
 ]
@@ -32,7 +31,7 @@ validation_results = [
     { adapter = "python.ruff-format.v1", arguments = ["$PYTHON", "-I", "-m", "ruff", "format", "--check", "$SOURCE_FILES", "$TEST_FILES", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
     { adapter = "python.c901-touched.v1", arguments = ["$PYTHON", "-I", "-m", "ruff", "check", "$SOURCE_FILES", "--select", "C901", "--config", "lint.mccabe.max-complexity = 10", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
     { adapter = "python.mypy-strict.v1", arguments = ["$PYTHON", "-I", "-m", "mypy", "--config-file", "$OUTPUT/mypy.ini", "--cache-dir", "$OUTPUT/mypy-cache", "$SOURCE_FILES"], exit_code = 0 },
-    { adapter = "python.pytest.v1", arguments = ["$PYTHON", "-I", "-m", "coverage", "run", "--branch", "--source=src", "--data-file=$OUTPUT/.coverage", "-m", "pytest", "-q", "-c", "$OUTPUT/pytest.ini"], exit_code = 0 },
+    { adapter = "python.pytest.v1", arguments = ["$PYTHON", "-I", "-m", "coverage", "run", "--branch", "--source=src", "--data-file=$OUTPUT/.coverage", "-m", "pytest", "-q", "-c", "$OUTPUT/pytest.ini", "--rootdir", "$REPOSITORY"], exit_code = 0 },
     { adapter = "python.build-wheel.v1", arguments = ["$PYTHON", "-I", "-m", "build", "--wheel", "--no-isolation", "--outdir", "$OUTPUT/wheel"], exit_code = 0 },
     { adapter = "python.import-linter.v1", arguments = ["$LINT_IMPORTS", "--config", "$OUTPUT/importlinter.ini", "--no-cache"], exit_code = 0 },
 ]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -17,6 +17,7 @@ simplified_functions = [
     "_commands",
     "_result_blocks",
     "_target_identities",
+    "_write_python_configs",
     "command_plans",
     "fixed_environment",
 ]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -17,6 +17,8 @@ simplified_functions = [
     "_commands",
     "_result_blocks",
     "_target_identities",
+    "_write_python_configs",
+    "command_plans",
     "fixed_environment",
 ]
 boundary_rationale = [

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -58,7 +58,7 @@ citations = ["src/supportability_gate/github_app.py:278-303", "src/supportabilit
 [[completion_report.claims]]
 id = "claim-fail-closed-handoff-results"
 text = "Report and authoritative command rows use separate strict shapes and failure codes, while authoritative non-PASS, unexecuted, and nonzero results always produce deterministic blocks."
-citations = ["src/supportability_gate/handoff_policy.py:24-32", "src/supportability_gate/handoff_policy.py:143-230", "src/supportability_gate/handoff_policy.py:266-274"]
+citations = ["src/supportability_gate/handoff_policy.py:24-32", "src/supportability_gate/handoff_policy.py:143-230", "src/supportability_gate/handoff_policy.py:273-289"]
 
 [[completion_report.claims]]
 id = "claim-unique-refactor-targets"

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,38 +2,34 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "3ad2c475ba1d241185715c05a0169a2462b9c7d2"
+base_sha = "a8a8ddb15cdaa0a60eb972128433dc478d80d5bd"
 overall_result = "PASS"
 responsibility_changes = [
-    "hosted_characterization materializes the authenticated driver blob to a fresh temporary path for each comparison execution while retaining the canonical recorded command and authenticated golden blob.",
-    "refactor_policy authenticates the current base's unique merged predecessor PR and binds each sequence step to its trusted prior authorization.",
-    "refactor_policy maps retained-file deletions through exact base and head ranges so removed responsibilities keep their base identity.",
-    "git_changes distinguishes real head content ranges from deletion anchors and exposes exact retained-base ranges.",
+    "quality_profile and quality_runner isolate trusted Python module tools from target-controlled import paths while retaining generated source-discovery configuration.",
+    "GitHubApp binds the authenticated handoff artifact to the packet's current base and head SHAs.",
+    "handoff_policy validates report and authoritative command rows independently and preserves authenticated failures as deterministic blocks.",
 ]
 simplified_functions = [
-    "_change_spans",
-    "_predecessor_authorization",
-    "_sequence_blocks",
-    "_target_identities",
-    "changed_base_lines",
-    "changed_head_lines",
-    "main",
-    "verify_refactor",
+    "GitHubApp._handoff_evidence",
+    "GitHubApp.m10_evidence_packet",
+    "_command_blocks",
+    "_commands",
+    "_result_blocks",
+    "fixed_environment",
 ]
 boundary_rationale = [
-    "Driver materialization stays in the trusted hosted capture entry point; Git range extraction stays in git_changes; predecessor and target authorization stay in refactor_policy.",
+    "Command isolation remains in the fixed quality profile and runner; artifact identity remains in GitHub evidence collection; semantic fail-closed decisions remain in handoff policy.",
 ]
 remaining_risks = [
-    "Predecessor evidence depends on GitHub's commit-to-pull association and issue comments; unavailable or ambiguous evidence fails closed.",
-    "Characterization drivers retain the authenticated definition path for declared fixture access, but executable bytes never come from that mutable worktree.",
+    "Quality and handoff evidence still depend on authenticated GitHub workflow availability; missing, stale, malformed, unexecuted, or failed evidence blocks.",
 ]
 validation_results = [
-    { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
-    { adapter = "python.ruff-format.v1", arguments = ["$PYTHON", "-m", "ruff", "format", "--check", "$SOURCE_FILES", "$TEST_FILES", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
-    { adapter = "python.c901-touched.v1", arguments = ["$PYTHON", "-m", "ruff", "check", "$SOURCE_FILES", "--select", "C901", "--config", "lint.mccabe.max-complexity = 10", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
-    { adapter = "python.mypy-strict.v1", arguments = ["$PYTHON", "-m", "mypy", "--config-file", "$OUTPUT/mypy.ini", "--cache-dir", "$OUTPUT/mypy-cache", "$SOURCE_FILES"], exit_code = 0 },
-    { adapter = "python.pytest.v1", arguments = ["$PYTHON", "-m", "coverage", "run", "--branch", "--source=src", "--data-file=$OUTPUT/.coverage", "-m", "pytest", "-q", "-c", "$OUTPUT/pytest.ini"], exit_code = 0 },
-    { adapter = "python.build-wheel.v1", arguments = ["$PYTHON", "-m", "build", "--wheel", "--no-isolation", "--outdir", "$OUTPUT/wheel"], exit_code = 0 },
+    { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-I", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
+    { adapter = "python.ruff-format.v1", arguments = ["$PYTHON", "-I", "-m", "ruff", "format", "--check", "$SOURCE_FILES", "$TEST_FILES", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
+    { adapter = "python.c901-touched.v1", arguments = ["$PYTHON", "-I", "-m", "ruff", "check", "$SOURCE_FILES", "--select", "C901", "--config", "lint.mccabe.max-complexity = 10", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
+    { adapter = "python.mypy-strict.v1", arguments = ["$PYTHON", "-I", "-m", "mypy", "--config-file", "$OUTPUT/mypy.ini", "--cache-dir", "$OUTPUT/mypy-cache", "$SOURCE_FILES"], exit_code = 0 },
+    { adapter = "python.pytest.v1", arguments = ["$PYTHON", "-I", "-m", "coverage", "run", "--branch", "--source=src", "--data-file=$OUTPUT/.coverage", "-m", "pytest", "-q", "-c", "$OUTPUT/pytest.ini"], exit_code = 0 },
+    { adapter = "python.build-wheel.v1", arguments = ["$PYTHON", "-I", "-m", "build", "--wheel", "--no-isolation", "--outdir", "$OUTPUT/wheel"], exit_code = 0 },
     { adapter = "python.import-linter.v1", arguments = ["$LINT_IMPORTS", "--config", "$OUTPUT/importlinter.ini", "--no-cache"], exit_code = 0 },
 ]
 gate_coverage = [
@@ -45,11 +41,16 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-authenticated-predecessor-sequence"
-text = "Step 1 is rejected after a predecessor authorization, and each later step requires the current base to resolve to exactly one merged PR with a trusted exact-head authorization for the immediately prior step."
-citations = ["src/supportability_gate/refactor_policy.py:188-199", "src/supportability_gate/refactor_policy.py:272-314", "src/supportability_gate/refactor_policy.py:494-499", "src/supportability_gate/refactor_policy.py:583-599"]
+id = "claim-trusted-python-tools"
+text = "Every Python module quality tool uses isolated mode, the fixed target environment omits PYTHONPATH, and generated pytest and mypy configuration supplies intended source discovery."
+citations = ["src/supportability_gate/quality_profile.py:14-124", "src/supportability_gate/quality_runner.py:24-36", "src/supportability_gate/quality_runner.py:125-136"]
 
 [[completion_report.claims]]
-id = "claim-base-deletion-identity"
-text = "Retained-file deletions use exact base and head content ranges with the existing base-to-head responsibility mapper, preserving removed base identities without attributing a zero-length deletion to the following head line."
-citations = ["src/supportability_gate/git_changes.py:281-332", "src/supportability_gate/refactor_policy.py:328-396"]
+id = "claim-base-head-handoff-binding"
+text = "Handoff collection passes the current packet base and head and rejects an authenticated result unless both identities match."
+citations = ["src/supportability_gate/github_app.py:278-303", "src/supportability_gate/github_app.py:427-443"]
+
+[[completion_report.claims]]
+id = "claim-fail-closed-handoff-results"
+text = "Report and authoritative command rows use separate strict shapes and failure codes, while authoritative non-PASS, unexecuted, and nonzero results always produce deterministic blocks."
+citations = ["src/supportability_gate/handoff_policy.py:21-32", "src/supportability_gate/handoff_policy.py:143-230", "src/supportability_gate/handoff_policy.py:266-274"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -6,12 +6,13 @@ base_sha = "a8a8ddb15cdaa0a60eb972128433dc478d80d5bd"
 overall_result = "PASS"
 responsibility_changes = [
     "quality_profile and quality_runner isolate trusted Python module tools from target-controlled import paths while retaining generated source-discovery configuration.",
-    "GitHubApp binds the authenticated handoff artifact to the packet's current base and head SHAs.",
+    "GitHubApp searches successful exact-head handoff runs newest-first and binds the first artifact matching the packet's current base and head SHAs.",
     "handoff_policy validates report and authoritative command rows independently and preserves authenticated failures as deterministic blocks.",
     "refactor_policy collapses duplicate spans to their single bounded target identity.",
 ]
 simplified_functions = [
     "GitHubApp._handoff_evidence",
+    "GitHubApp._handoff_runs",
     "GitHubApp.m10_evidence_packet",
     "_command_blocks",
     "_commands",
@@ -51,8 +52,8 @@ citations = ["src/supportability_gate/quality_profile.py:14-124", "src/supportab
 
 [[completion_report.claims]]
 id = "claim-base-head-handoff-binding"
-text = "Handoff collection passes the current packet base and head and rejects an authenticated result unless both identities match."
-citations = ["src/supportability_gate/github_app.py:278-303", "src/supportability_gate/github_app.py:427-443"]
+text = "Handoff collection searches successful exact-head runs newest-first and accepts only an authenticated result whose base and head identities match the current packet."
+citations = ["src/supportability_gate/github_app.py:278-303", "src/supportability_gate/github_app.py:313-339", "src/supportability_gate/github_app.py:429-459"]
 
 [[completion_report.claims]]
 id = "claim-fail-closed-handoff-results"

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -310,7 +310,9 @@ class GitHubApp:
             reasoning_effort=packet.reasoning_effort,
         )
 
-    def _handoff_run(self, repository: str, head_sha: str, token: str) -> dict[str, Any]:
+    def _handoff_runs(
+        self, repository: str, head_sha: str, token: str
+    ) -> tuple[dict[str, Any], ...]:
         result = self._request(
             "GET",
             f"/repos/{repository}/actions/runs?head_sha={head_sha}&per_page=100",
@@ -330,10 +332,10 @@ class GitHubApp:
         ]
         if not runs:
             raise SemanticReviewError("HANDOFF_EVIDENCE_UNAVAILABLE")
-        run = max(runs, key=self._handoff_run_order)
-        if run.get("conclusion") != "success":
+        ordered = tuple(sorted(runs, key=self._handoff_run_order, reverse=True))
+        if ordered[0].get("conclusion") != "success":
             raise SemanticReviewError("HANDOFF_EVIDENCE_UNAVAILABLE")
-        return run
+        return tuple(run for run in ordered if run.get("conclusion") == "success")
 
     @staticmethod
     def _handoff_run_order(run: dict[str, Any]) -> tuple[datetime, int]:
@@ -427,32 +429,33 @@ class GitHubApp:
     def _handoff_evidence(
         self, repository: str, base_sha: str, head_sha: str, token: str
     ) -> dict[str, object]:
-        run = self._handoff_run(repository, head_sha, token)
-        artifact = self._handoff_artifact(repository, run, token)
-        archive = self._artifact_bytes(repository, artifact["id"], token)
-        archive_sha256 = hashlib.sha256(archive).hexdigest()
-        if artifact["digest"] != f"sha256:{archive_sha256}":
-            raise SemanticReviewError("HANDOFF_ARTIFACT_DIGEST_MISMATCH")
-        files = self._artifact_json(archive)
-        result, provenance = files["complexity-result.json"], files["quality-provenance.json"]
-        if (result.get("base_sha"), result.get("head_sha")) != (base_sha, head_sha):
-            raise SemanticReviewError("STALE_HANDOFF_EVIDENCE")
-        if provenance.get("run_id") != str(run["id"]):
-            raise SemanticReviewError("STALE_HANDOFF_EVIDENCE")
-        if provenance.get("run_attempt") != str(run["run_attempt"]):
-            raise SemanticReviewError("STALE_HANDOFF_EVIDENCE")
-        return {
-            "artifact_provenance": {
-                "artifact_digest": artifact["digest"],
-                "artifact_id": artifact["id"],
-                "archive_sha256": archive_sha256,
-                "run_attempt": run["run_attempt"],
-                "run_conclusion": run.get("conclusion"),
-                "run_id": run["id"],
-                "workflow_path": HANDOFF_WORKFLOW_PATH,
-            },
-            "authoritative_result": result,
-        }
+        for run in self._handoff_runs(repository, head_sha, token):
+            artifact = self._handoff_artifact(repository, run, token)
+            archive = self._artifact_bytes(repository, artifact["id"], token)
+            archive_sha256 = hashlib.sha256(archive).hexdigest()
+            if artifact["digest"] != f"sha256:{archive_sha256}":
+                raise SemanticReviewError("HANDOFF_ARTIFACT_DIGEST_MISMATCH")
+            files = self._artifact_json(archive)
+            result, provenance = files["complexity-result.json"], files["quality-provenance.json"]
+            if (result.get("base_sha"), result.get("head_sha")) != (base_sha, head_sha):
+                continue
+            if provenance.get("run_id") != str(run["id"]):
+                raise SemanticReviewError("STALE_HANDOFF_EVIDENCE")
+            if provenance.get("run_attempt") != str(run["run_attempt"]):
+                raise SemanticReviewError("STALE_HANDOFF_EVIDENCE")
+            return {
+                "artifact_provenance": {
+                    "artifact_digest": artifact["digest"],
+                    "artifact_id": artifact["id"],
+                    "archive_sha256": archive_sha256,
+                    "run_attempt": run["run_attempt"],
+                    "run_conclusion": run.get("conclusion"),
+                    "run_id": run["id"],
+                    "workflow_path": HANDOFF_WORKFLOW_PATH,
+                },
+                "authoritative_result": result,
+            }
+        raise SemanticReviewError("STALE_HANDOFF_EVIDENCE")
 
     def _completion_report(self, repository: str, head_sha: str, token: str) -> dict[str, object]:
         path = (

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -287,7 +287,7 @@ class GitHubApp:
         evidence = packet.evidence
         if not evidence.get("reviewed_sources") and not evidence.get("deleted_sources"):
             return packet
-        evidence.update(self._handoff_evidence(repository, packet.head_sha, token))
+        evidence.update(self._handoff_evidence(repository, packet.base_sha, packet.head_sha, token))
         evidence.update(self._completion_report(repository, packet.head_sha, token))
         context = evidence.get("refactor_context")
         changed_files = context.get("changed_files") if isinstance(context, dict) else None
@@ -424,7 +424,9 @@ class GitHubApp:
             raise SemanticReviewError("HANDOFF_EVIDENCE_UNAVAILABLE")
         return values
 
-    def _handoff_evidence(self, repository: str, head_sha: str, token: str) -> dict[str, object]:
+    def _handoff_evidence(
+        self, repository: str, base_sha: str, head_sha: str, token: str
+    ) -> dict[str, object]:
         run = self._handoff_run(repository, head_sha, token)
         artifact = self._handoff_artifact(repository, run, token)
         archive = self._artifact_bytes(repository, artifact["id"], token)
@@ -433,7 +435,9 @@ class GitHubApp:
             raise SemanticReviewError("HANDOFF_ARTIFACT_DIGEST_MISMATCH")
         files = self._artifact_json(archive)
         result, provenance = files["complexity-result.json"], files["quality-provenance.json"]
-        if result.get("head_sha") != head_sha or provenance.get("run_id") != str(run["id"]):
+        if (result.get("base_sha"), result.get("head_sha")) != (base_sha, head_sha):
+            raise SemanticReviewError("STALE_HANDOFF_EVIDENCE")
+        if provenance.get("run_id") != str(run["id"]):
             raise SemanticReviewError("STALE_HANDOFF_EVIDENCE")
         if provenance.get("run_attempt") != str(run["run_attempt"]):
             raise SemanticReviewError("STALE_HANDOFF_EVIDENCE")

--- a/src/supportability_gate/handoff_policy.py
+++ b/src/supportability_gate/handoff_policy.py
@@ -27,6 +27,8 @@ _AUTHORITATIVE_COMMAND_FIELDS = {
     "arguments",
     "executed",
     "exit_code",
+}
+_AUTHORITATIVE_OBSERVATION_FIELDS = {
     "observed_paths",
     "proof_kind",
     "zero_statement_paths",
@@ -152,7 +154,11 @@ def _commands(
         return commands, frozenset(), malformed
     expected = _AUTHORITATIVE_COMMAND_FIELDS if authoritative else _REPORT_COMMAND_FIELDS
     for item in value:
-        if not isinstance(item, dict) or set(item) != expected:
+        fields = set(item) if isinstance(item, dict) else set()
+        if not isinstance(item, dict) or (
+            fields != expected
+            and (not authoritative or fields != expected | _AUTHORITATIVE_OBSERVATION_FIELDS)
+        ):
             malformed = True
             continue
         adapter, arguments, exit_code = (
@@ -168,6 +174,7 @@ def _commands(
             and (not authoritative or type(item.get("executed")) is bool)
             and (
                 not authoritative
+                or not fields & _AUTHORITATIVE_OBSERVATION_FIELDS
                 or (
                     isinstance(item.get("proof_kind"), str)
                     and isinstance(item.get("observed_paths"), list)

--- a/src/supportability_gate/handoff_policy.py
+++ b/src/supportability_gate/handoff_policy.py
@@ -21,6 +21,16 @@ _REQUIRED = {
 _SHA_FIELDS = {"base_sha", "head_sha"}
 _CITATION = re.compile(r"(.+):(\d+)-(\d+)\Z")
 HANDOFF_REPORT_PATH = ".supportability-handoff.toml"
+_REPORT_COMMAND_FIELDS = {"adapter", "arguments", "exit_code"}
+_AUTHORITATIVE_COMMAND_FIELDS = {
+    "adapter",
+    "arguments",
+    "executed",
+    "exit_code",
+    "observed_paths",
+    "proof_kind",
+    "zero_statement_paths",
+}
 
 
 class CompletionReportError(ValueError):
@@ -132,13 +142,18 @@ def _claims(
 
 def _commands(
     value: object,
-) -> tuple[dict[str, tuple[tuple[str, ...], int]], frozenset[str]]:
-    commands: dict[str, tuple[tuple[str, ...], int]] = {}
+    *,
+    authoritative: bool,
+) -> tuple[dict[str, tuple[tuple[str, ...], bool, int]], frozenset[str], bool]:
+    commands: dict[str, tuple[tuple[str, ...], bool, int]] = {}
     duplicates: set[str] = set()
+    malformed = not isinstance(value, list)
     if not isinstance(value, list):
-        return commands, frozenset()
+        return commands, frozenset(), malformed
+    expected = _AUTHORITATIVE_COMMAND_FIELDS if authoritative else _REPORT_COMMAND_FIELDS
     for item in value:
-        if not isinstance(item, dict):
+        if not isinstance(item, dict) or set(item) != expected:
+            malformed = True
             continue
         adapter, arguments, exit_code = (
             item.get("adapter"),
@@ -150,32 +165,63 @@ def _commands(
             and isinstance(arguments, list)
             and all(isinstance(argument, str) for argument in arguments)
             and type(exit_code) is int
+            and (not authoritative or type(item.get("executed")) is bool)
+            and (
+                not authoritative
+                or (
+                    isinstance(item.get("proof_kind"), str)
+                    and isinstance(item.get("observed_paths"), list)
+                    and all(isinstance(path, str) for path in item["observed_paths"])
+                    and isinstance(item.get("zero_statement_paths"), list)
+                    and all(isinstance(path, str) for path in item["zero_statement_paths"])
+                )
+            )
         ):
             if adapter in commands:
                 duplicates.add(adapter)
-            commands[adapter] = (tuple(arguments), exit_code)
-    return commands, frozenset(duplicates)
+            commands[adapter] = (tuple(arguments), bool(item.get("executed", True)), exit_code)
+        else:
+            malformed = True
+    return commands, frozenset(duplicates), malformed
 
 
 def _command_blocks(report: dict[str, Any], authoritative: dict[str, Any]) -> list[str]:
     quality = authoritative.get("quality_profile")
-    observed, observed_duplicates = _commands(
-        quality.get("commands") if isinstance(quality, dict) else None
+    observed, observed_duplicates, malformed_observed = _commands(
+        quality.get("commands") if isinstance(quality, dict) else None,
+        authoritative=True,
     )
-    reported, reported_duplicates = _commands(report.get("validation_results"))
+    reported, reported_duplicates, malformed_reported = _commands(
+        report.get("validation_results"), authoritative=False
+    )
     blocks = [
         f"INVENTED_VALIDATION_COMMAND:{adapter}" for adapter in reported if adapter not in observed
     ]
+    if malformed_reported:
+        blocks.append("MALFORMED_VALIDATION_RESULT")
+    if malformed_observed:
+        blocks.append("MALFORMED_AUTHORITATIVE_COMMAND")
     blocks.extend(f"DUPLICATE_VALIDATION_RESULT:{adapter}" for adapter in reported_duplicates)
     blocks.extend(f"DUPLICATE_AUTHORITATIVE_COMMAND:{adapter}" for adapter in observed_duplicates)
     blocks.extend(
         f"CONTRADICTED_VALIDATION_RESULT:{adapter}"
         for adapter in reported.keys() & observed.keys()
-        if reported[adapter] != observed[adapter]
+        if (reported[adapter][0], reported[adapter][2])
+        != (observed[adapter][0], observed[adapter][2])
+    )
+    blocks.extend(
+        f"AUTHORITATIVE_COMMAND_NOT_EXECUTED:{adapter}"
+        for adapter, (_, executed, _) in observed.items()
+        if not executed
+    )
+    blocks.extend(
+        f"AUTHORITATIVE_COMMAND_FAILED:{adapter}"
+        for adapter, (_, _, exit_code) in observed.items()
+        if exit_code != 0
     )
     blocks.extend(
         f"HIDDEN_FAILED_COMMAND:{adapter}"
-        for adapter, (_, exit_code) in observed.items()
+        for adapter, (_, _, exit_code) in observed.items()
         if exit_code != 0 and adapter not in reported
     )
     blocks.extend(
@@ -222,6 +268,8 @@ def _result_blocks(report: dict[str, Any], authoritative: dict[str, Any]) -> lis
     sha_field = next(iter(set(report) & _SHA_FIELDS))
     if report[sha_field] != authoritative.get(sha_field):
         blocks.append("STALE_COMPLETION_REPORT_SHA")
+    if authoritative.get("overall_result") != "PASS":
+        blocks.append("AUTHORITATIVE_RESULT_NOT_PASS")
     if report["overall_result"] != authoritative.get("overall_result"):
         blocks.append("CONTRADICTED_COMPLETION_RESULT")
     if report["architecture_judgment"] != _architecture_result(authoritative):

--- a/src/supportability_gate/quality_profile.py
+++ b/src/supportability_gate/quality_profile.py
@@ -107,6 +107,8 @@ _PYTHON_COMMANDS = (
             "-q",
             "-c",
             "$OUTPUT/pytest.ini",
+            "--rootdir",
+            "$REPOSITORY",
         ),
     ),
     (

--- a/src/supportability_gate/quality_profile.py
+++ b/src/supportability_gate/quality_profile.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from supportability_gate import contract, git_changes
 from supportability_gate.function_changes import ChangedFileAssessment
 
-SCHEMA_VERSION = "quality-gates.v2"
+SCHEMA_VERSION = "quality-gates.v3"
 TIMEOUT_SECONDS = 180
 _FULL_SHA = re.compile(r"[0-9a-f]{40}|[0-9a-f]{64}")
 SOURCE_SUFFIXES = {
@@ -23,6 +23,7 @@ _PYTHON_COMMANDS = (
         "python.ruff-lint.v1",
         (
             "$PYTHON",
+            "-I",
             "-m",
             "ruff",
             "check",
@@ -42,6 +43,7 @@ _PYTHON_COMMANDS = (
         "python.ruff-format.v1",
         (
             "$PYTHON",
+            "-I",
             "-m",
             "ruff",
             "format",
@@ -60,6 +62,7 @@ _PYTHON_COMMANDS = (
         "python.c901-touched.v1",
         (
             "$PYTHON",
+            "-I",
             "-m",
             "ruff",
             "check",
@@ -78,6 +81,7 @@ _PYTHON_COMMANDS = (
         "python.mypy-strict.v1",
         (
             "$PYTHON",
+            "-I",
             "-m",
             "mypy",
             "--config-file",
@@ -91,6 +95,7 @@ _PYTHON_COMMANDS = (
         "python.pytest.v1",
         (
             "$PYTHON",
+            "-I",
             "-m",
             "coverage",
             "run",
@@ -108,6 +113,7 @@ _PYTHON_COMMANDS = (
         "python.build-wheel.v1",
         (
             "$PYTHON",
+            "-I",
             "-m",
             "build",
             "--wheel",

--- a/src/supportability_gate/quality_runner.py
+++ b/src/supportability_gate/quality_runner.py
@@ -122,7 +122,7 @@ def _write_typescript_configs(
     )
 
 
-def _write_python_configs(output: Path, source_files: tuple[str, ...]) -> None:
+def _write_python_configs(output: Path, repository: Path, source_files: tuple[str, ...]) -> None:
     output.mkdir(parents=True, exist_ok=True)
     (output / "mypy.ini").write_text(
         "[mypy]\npython_version = 3.12\nstrict = True\nmypy_path = src\n",
@@ -130,7 +130,8 @@ def _write_python_configs(output: Path, source_files: tuple[str, ...]) -> None:
         newline="\n",
     )
     (output / "pytest.ini").write_text(
-        "[pytest]\ntestpaths = tests\npythonpath = src\naddopts = -p no:cacheprovider\n",
+        f"[pytest]\ntestpaths = tests\npythonpath = {repository / 'src'}\n"
+        "addopts = -p no:cacheprovider\n",
         encoding="utf-8",
         newline="\n",
     )
@@ -175,7 +176,7 @@ def command_plans(
             tuple(str((repository / path).resolve()) for path in source_files),
         )
     else:
-        _write_python_configs(output, source_files)
+        _write_python_configs(output, repository, source_files)
     lint_imports = shutil.which("lint-imports") or str(
         Path(sys.executable).with_name("lint-imports")
     )

--- a/src/supportability_gate/quality_runner.py
+++ b/src/supportability_gate/quality_runner.py
@@ -30,7 +30,6 @@ def fixed_environment(output: Path, repository: Path) -> dict[str, str]:
             "CI": "true",
             "NO_COLOR": "1",
             "PYTHONHASHSEED": "0",
-            "PYTHONPATH": str(repository / "src"),
             "PYTHONPYCACHEPREFIX": str(output / "pycache"),
         }
     )

--- a/src/supportability_gate/quality_runner.py
+++ b/src/supportability_gate/quality_runner.py
@@ -130,7 +130,7 @@ def _write_python_configs(output: Path, repository: Path, source_files: tuple[st
         newline="\n",
     )
     (output / "pytest.ini").write_text(
-        f"[pytest]\ntestpaths = tests\npythonpath = {repository / 'src'}\n"
+        f"[pytest]\ntestpaths = tests\npythonpath = {repository / 'src'} {repository}\n"
         "addopts = -p no:cacheprovider\n",
         encoding="utf-8",
         newline="\n",

--- a/src/supportability_gate/quality_runner.py
+++ b/src/supportability_gate/quality_runner.py
@@ -130,7 +130,7 @@ def _write_python_configs(output: Path, repository: Path, source_files: tuple[st
         newline="\n",
     )
     (output / "pytest.ini").write_text(
-        f"[pytest]\ntestpaths = tests\npythonpath = {repository / 'src'} {repository}\n"
+        f"[pytest]\ntestpaths = tests\npythonpath =\n    {repository / 'src'}\n    {repository}\n"
         "addopts = -p no:cacheprovider\n",
         encoding="utf-8",
         newline="\n",

--- a/src/supportability_gate/quality_runner.py
+++ b/src/supportability_gate/quality_runner.py
@@ -130,7 +130,7 @@ def _write_python_configs(output: Path, repository: Path, source_files: tuple[st
         newline="\n",
     )
     (output / "pytest.ini").write_text(
-        f"[pytest]\ntestpaths = tests\npythonpath = {repository / 'src'}\n"
+        f"[pytest]\ntestpaths = {repository / 'tests'}\npythonpath = {repository / 'src'}\n"
         "addopts = -p no:cacheprovider\n",
         encoding="utf-8",
         newline="\n",

--- a/src/supportability_gate/quality_runner.py
+++ b/src/supportability_gate/quality_runner.py
@@ -122,7 +122,7 @@ def _write_typescript_configs(
     )
 
 
-def _write_python_configs(output: Path, repository: Path, source_files: tuple[str, ...]) -> None:
+def _write_python_configs(output: Path, source_files: tuple[str, ...]) -> None:
     output.mkdir(parents=True, exist_ok=True)
     (output / "mypy.ini").write_text(
         "[mypy]\npython_version = 3.12\nstrict = True\nmypy_path = src\n",
@@ -130,8 +130,7 @@ def _write_python_configs(output: Path, repository: Path, source_files: tuple[st
         newline="\n",
     )
     (output / "pytest.ini").write_text(
-        f"[pytest]\ntestpaths = {repository / 'tests'}\npythonpath = {repository / 'src'} {repository}\n"
-        "addopts = -p no:cacheprovider\n",
+        "[pytest]\ntestpaths = tests\npythonpath = src\naddopts = -p no:cacheprovider\n",
         encoding="utf-8",
         newline="\n",
     )
@@ -176,7 +175,7 @@ def command_plans(
             tuple(str((repository / path).resolve()) for path in source_files),
         )
     else:
-        _write_python_configs(output, repository, source_files)
+        _write_python_configs(output, source_files)
     lint_imports = shutil.which("lint-imports") or str(
         Path(sys.executable).with_name("lint-imports")
     )
@@ -186,6 +185,7 @@ def command_plans(
         "$NPM": shutil.which("npm") or "npm",
         "$OUTPUT": str(output),
         "$PYTHON": sys.executable,
+        "$REPOSITORY": str(repository),
         "$SOURCE_FILES": "\0".join(str((repository / path).resolve()) for path in source_files),
         "$TEST_FILES": "\0".join(str((repository / path).resolve()) for path in test_files),
         "$TOOLS": str(tools),

--- a/src/supportability_gate/quality_runner.py
+++ b/src/supportability_gate/quality_runner.py
@@ -130,7 +130,7 @@ def _write_python_configs(output: Path, repository: Path, source_files: tuple[st
         newline="\n",
     )
     (output / "pytest.ini").write_text(
-        f"[pytest]\ntestpaths = {repository / 'tests'}\npythonpath = {repository / 'src'}\n"
+        f"[pytest]\ntestpaths = {repository / 'tests'}\npythonpath = {repository / 'src'} {repository}\n"
         "addopts = -p no:cacheprovider\n",
         encoding="utf-8",
         newline="\n",

--- a/src/supportability_gate/refactor_policy.py
+++ b/src/supportability_gate/refactor_policy.py
@@ -393,7 +393,7 @@ def _target_identities(
         targets.extend(
             f"{path}::{item.kind}:{item.name}:{item.start_line}-{item.end_line}" for item in spans
         )
-    return tuple(sorted(targets)), tuple(sorted(unbounded))
+    return tuple(sorted(set(targets))), tuple(sorted(unbounded))
 
 
 def _proof_path(path: str) -> bool:

--- a/tests/characterization/m10-review-handoff.characterization.py
+++ b/tests/characterization/m10-review-handoff.characterization.py
@@ -45,6 +45,9 @@ def _behavior() -> dict[str, list[str]]:
                     "arguments": ["check", "src"],
                     "executed": True,
                     "exit_code": 0,
+                    "observed_paths": [path],
+                    "proof_kind": "explicit-source",
+                    "zero_statement_paths": [],
                 }
             ]
         },

--- a/tests/characterization/m10-review-handoff.characterization.py
+++ b/tests/characterization/m10-review-handoff.characterization.py
@@ -45,9 +45,6 @@ def _behavior() -> dict[str, list[str]]:
                     "arguments": ["check", "src"],
                     "executed": True,
                     "exit_code": 0,
-                    "observed_paths": [path],
-                    "proof_kind": "explicit-source",
-                    "zero_statement_paths": [],
                 }
             ]
         },

--- a/tests/hosted_quality_profile.py
+++ b/tests/hosted_quality_profile.py
@@ -30,6 +30,7 @@ def _python_coverage_proof(
     completed = subprocess.run(
         (
             plan.actual[0],
+            "-I",
             "-m",
             "coverage",
             "json",

--- a/tests/hosted_quality_profile.py
+++ b/tests/hosted_quality_profile.py
@@ -138,7 +138,7 @@ def _run_command(
     try:
         completed = subprocess.run(
             plan.actual,
-            cwd=repository,
+            cwd=repository / "src" if plan.adapter == "python.import-linter.v1" else repository,
             env=quality_runner.fixed_environment(output, repository),
             check=False,
             capture_output=True,

--- a/tests/qualify_semantic_reviewer.py
+++ b/tests/qualify_semantic_reviewer.py
@@ -57,7 +57,7 @@ class Observation:
 def _cases() -> tuple[Case, ...]:
     clean_quality = {
         "quality_decision": {
-            "schema_version": "quality-gates.v2",
+            "schema_version": "quality-gates.v3",
             "commands": [
                 {
                     "adapter": "python.pytest.v1",

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -97,9 +97,12 @@ def _blob_payload(content: bytes) -> dict[str, str]:
     }
 
 
-def _handoff_archive(head_sha: str, run_id: int = 123, run_attempt: int = 1) -> bytes:
+def _handoff_archive(
+    head_sha: str, run_id: int = 123, run_attempt: int = 1, base_sha: str = "a" * 40
+) -> bytes:
     target = io.BytesIO()
     result = {
+        "base_sha": base_sha,
         "head_sha": head_sha,
     }
     provenance = {"run_attempt": str(run_attempt), "run_id": str(run_id)}
@@ -139,7 +142,9 @@ def test_m10_packet_binds_fresh_full_run_artifact_and_report() -> None:
         return _Reply({"artifacts": [artifact]})
 
     app = GitHubApp(42, 7, b"unused", opener=open_request)
-    evidence = app._handoff_evidence("mbh-solutions/supportability-gate", head_sha, "token")
+    evidence = app._handoff_evidence(
+        "mbh-solutions/supportability-gate", "a" * 40, head_sha, "token"
+    )
 
     assert evidence["artifact_provenance"] == {
         "artifact_digest": f"sha256:{archive_sha256}",
@@ -243,7 +248,9 @@ def test_newest_successful_full_rerun_attempt_is_accepted() -> None:
         return _Reply({"artifacts": [artifact]})
 
     app = GitHubApp(42, 7, b"unused", opener=open_request)
-    evidence = app._handoff_evidence("mbh-solutions/supportability-gate", head_sha, "token")
+    evidence = app._handoff_evidence(
+        "mbh-solutions/supportability-gate", "a" * 40, head_sha, "token"
+    )
 
     assert evidence["artifact_provenance"]["run_attempt"] == 2  # type: ignore[index]
 
@@ -276,7 +283,7 @@ def test_failed_rerun_attempt_is_not_accepted_as_m10_evidence() -> None:
         opener=lambda *args, **kwargs: _Reply({"workflow_runs": [older, failed]}),
     )
     with pytest.raises(SemanticReviewError, match="HANDOFF_EVIDENCE_UNAVAILABLE"):
-        app._handoff_evidence("mbh-solutions/supportability-gate", "b" * 40, "token")
+        app._handoff_evidence("mbh-solutions/supportability-gate", "a" * 40, "b" * 40, "token")
 
 
 @pytest.mark.parametrize(
@@ -306,7 +313,7 @@ def test_malformed_successful_rerun_metadata_is_rejected(field: str, value: obje
     )
 
     with pytest.raises(SemanticReviewError, match="MALFORMED_GITHUB_RESPONSE"):
-        app._handoff_evidence("mbh-solutions/supportability-gate", "b" * 40, "token")
+        app._handoff_evidence("mbh-solutions/supportability-gate", "a" * 40, "b" * 40, "token")
 
 
 def test_rerun_attempt_with_mismatched_provenance_is_rejected(
@@ -330,7 +337,23 @@ def test_rerun_attempt_with_mismatched_provenance_is_rejected(
     monkeypatch.setattr(app, "_artifact_bytes", lambda *args: archive)
 
     with pytest.raises(SemanticReviewError, match="STALE_HANDOFF_EVIDENCE"):
-        app._handoff_evidence("mbh-solutions/supportability-gate", head_sha, "token")
+        app._handoff_evidence("mbh-solutions/supportability-gate", "a" * 40, head_sha, "token")
+
+
+def test_handoff_artifact_with_stale_base_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    head_sha = "b" * 40
+    archive = _handoff_archive(head_sha, base_sha="c" * 40)
+    app = GitHubApp(42, 7, b"unused")
+    monkeypatch.setattr(app, "_handoff_run", lambda *args: {"id": 123, "run_attempt": 1})
+    monkeypatch.setattr(
+        app,
+        "_handoff_artifact",
+        lambda *args: {"digest": f"sha256:{hashlib.sha256(archive).hexdigest()}", "id": 789},
+    )
+    monkeypatch.setattr(app, "_artifact_bytes", lambda *args: archive)
+
+    with pytest.raises(SemanticReviewError, match="STALE_HANDOFF_EVIDENCE"):
+        app._handoff_evidence("mbh-solutions/supportability-gate", "a" * 40, head_sha, "token")
 
 
 def test_handoff_archive_rejects_large_expanded_member() -> None:

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -255,6 +255,62 @@ def test_newest_successful_full_rerun_attempt_is_accepted() -> None:
     assert evidence["artifact_provenance"]["run_attempt"] == 2  # type: ignore[index]
 
 
+def test_older_successful_run_is_used_when_newer_run_has_stale_base() -> None:
+    head_sha = "b" * 40
+    older_archive = _handoff_archive(head_sha, run_id=122)
+    newer_archive = _handoff_archive(head_sha, base_sha="c" * 40)
+    older = {
+        "conclusion": "success",
+        "event": "pull_request",
+        "head_sha": head_sha,
+        "id": 122,
+        "path": ".github/workflows/organization-required.yml",
+        "run_attempt": 1,
+        "status": "completed",
+        "updated_at": "2026-08-02T16:00:00Z",
+    }
+    newer = {**older, "id": 123, "updated_at": "2026-08-02T17:00:00Z"}
+
+    def open_request(request: object, *args: object, **kwargs: object) -> _Reply:
+        url = request.full_url  # type: ignore[attr-defined]
+        if "/actions/runs?" in url:
+            return _Reply({"workflow_runs": [older, newer]})
+        if "/actions/runs/123/artifacts" in url:
+            return _Reply(
+                {
+                    "artifacts": [
+                        {
+                            "digest": f"sha256:{hashlib.sha256(newer_archive).hexdigest()}",
+                            "expired": False,
+                            "id": 789,
+                            "name": "supportability-evidence-123-1",
+                        }
+                    ]
+                }
+            )
+        if "/actions/runs/122/artifacts" in url:
+            return _Reply(
+                {
+                    "artifacts": [
+                        {
+                            "digest": f"sha256:{hashlib.sha256(older_archive).hexdigest()}",
+                            "expired": False,
+                            "id": 788,
+                            "name": "supportability-evidence-122-1",
+                        }
+                    ]
+                }
+            )
+        return _BytesReply(newer_archive if "/artifacts/789/" in url else older_archive)
+
+    app = GitHubApp(42, 7, b"unused", opener=open_request)
+    evidence = app._handoff_evidence(
+        "mbh-solutions/supportability-gate", "a" * 40, head_sha, "token"
+    )
+
+    assert evidence["artifact_provenance"]["run_id"] == 122  # type: ignore[index]
+
+
 def test_failed_rerun_attempt_is_not_accepted_as_m10_evidence() -> None:
     older = {
         "conclusion": "success",
@@ -328,7 +384,7 @@ def test_rerun_attempt_with_mismatched_provenance_is_rejected(
         "run_attempt": 2,
     }
     app = GitHubApp(42, 7, b"unused")
-    monkeypatch.setattr(app, "_handoff_run", lambda *args: run)
+    monkeypatch.setattr(app, "_handoff_runs", lambda *args: (run,))
     monkeypatch.setattr(
         app,
         "_handoff_artifact",
@@ -344,7 +400,7 @@ def test_handoff_artifact_with_stale_base_is_rejected(monkeypatch: pytest.Monkey
     head_sha = "b" * 40
     archive = _handoff_archive(head_sha, base_sha="c" * 40)
     app = GitHubApp(42, 7, b"unused")
-    monkeypatch.setattr(app, "_handoff_run", lambda *args: {"id": 123, "run_attempt": 1})
+    monkeypatch.setattr(app, "_handoff_runs", lambda *args: ({"id": 123, "run_attempt": 1},))
     monkeypatch.setattr(
         app,
         "_handoff_artifact",

--- a/tests/test_handoff_policy.py
+++ b/tests/test_handoff_policy.py
@@ -28,6 +28,9 @@ def _authoritative() -> dict[str, object]:
                     "arguments": ["check", "src"],
                     "executed": True,
                     "exit_code": 0,
+                    "observed_paths": [PATH],
+                    "proof_kind": "explicit-source",
+                    "zero_statement_paths": [],
                 }
             ]
         },
@@ -154,6 +157,9 @@ def test_hidden_failed_command_blocks() -> None:
             "arguments": ["-m", "pytest", "-q"],
             "executed": True,
             "exit_code": 1,
+            "observed_paths": [PATH],
+            "proof_kind": "runtime-lines",
+            "zero_statement_paths": [],
         }
     )
     assert "HIDDEN_FAILED_COMMAND:python.pytest.v1" in _blocks(_report(), authoritative)
@@ -183,6 +189,36 @@ def test_duplicate_validation_result_blocks() -> None:
         {"adapter": "python.ruff-lint.v1", "arguments": ["invented"], "exit_code": 0}
     )
     assert "DUPLICATE_VALIDATION_RESULT:python.ruff-lint.v1" in _blocks(report)
+
+
+def test_malformed_report_and_authoritative_rows_block_separately() -> None:
+    report = _report()
+    report["validation_results"] = [{"adapter": "malformed"}]
+    assert "MALFORMED_VALIDATION_RESULT" in _blocks(report)
+
+    authoritative = _authoritative()
+    authoritative["quality_profile"] = {"commands": [{"adapter": "malformed"}]}
+    assert "MALFORMED_AUTHORITATIVE_COMMAND" in _blocks(_report(), authoritative)
+
+
+def test_authoritative_failures_block_even_when_report_agrees() -> None:
+    authoritative = _authoritative()
+    authoritative["overall_result"] = "BLOCK"
+    report = _report()
+    report["overall_result"] = "BLOCK"
+    assert "AUTHORITATIVE_RESULT_NOT_PASS" in _blocks(report, authoritative)
+
+    authoritative = _authoritative()
+    authoritative["quality_profile"]["commands"][0]["executed"] = False  # type: ignore[index]
+    assert "AUTHORITATIVE_COMMAND_NOT_EXECUTED:python.ruff-lint.v1" in _blocks(
+        _report(), authoritative
+    )
+
+    authoritative = _authoritative()
+    authoritative["quality_profile"]["commands"][0]["exit_code"] = 1  # type: ignore[index]
+    report = _report()
+    report["validation_results"][0]["exit_code"] = 1  # type: ignore[index]
+    assert "AUTHORITATIVE_COMMAND_FAILED:python.ruff-lint.v1" in _blocks(report, authoritative)
 
 
 def test_malformed_list_sections_return_blocks_instead_of_raising() -> None:

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -394,9 +394,7 @@ def test_fixed_python_tools_use_isolation_and_generated_source_paths(tmp_path: P
     assert Path(plans[-1].actual[0]).is_absolute()
     assert pytest_plan.actual[-2:] == ("--rootdir", str(repository))
     assert "testpaths = tests" in (output / "pytest.ini").read_text()
-    assert f"pythonpath = {repository / 'src'} {repository}" in (
-        output / "pytest.ini"
-    ).read_text()
+    assert f"pythonpath = {repository / 'src'} {repository}" in (output / "pytest.ini").read_text()
     assert "mypy_path = src" in (output / "mypy.ini").read_text()
 
 

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -411,7 +411,7 @@ def _run_git(repository: Path, *arguments: str) -> str:
     os.environ.get("RUNNER_ENVIRONMENT") != "github-hosted",
     reason="target quality commands are forbidden outside GitHub-hosted runners",
 )
-def test_python_poison_file_blocks_as_unexecuted(tmp_path: Path) -> None:
+def test_python_poison_file_passes_tests_but_blocks_as_unexecuted(tmp_path: Path) -> None:
     repository = tmp_path / "python-target"
     repository.mkdir()
     _run_git(repository, "init", "--initial-branch=main")
@@ -484,7 +484,7 @@ def test_python_poison_file_blocks_as_unexecuted(tmp_path: Path) -> None:
         capture_output=True,
         timeout=quality_profile.TIMEOUT_SECONDS,
     )
-    assert completed.returncode == 1, completed.stderr.decode(errors="replace")
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
     evidence = replace(
         quality_profile.load_evidence(output),
         artifact_id="789",

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -392,7 +392,9 @@ def test_fixed_python_tools_use_isolation_and_generated_source_paths(tmp_path: P
     assert all(plan.actual[1] == "-I" for plan in plans[:-1])
     assert Path(plans[-1].actual[0]).is_absolute()
     assert f"testpaths = {repository / 'tests'}" in (output / "pytest.ini").read_text()
-    assert f"pythonpath = {repository / 'src'}" in (output / "pytest.ini").read_text()
+    assert f"pythonpath = {repository / 'src'} {repository}" in (
+        output / "pytest.ini"
+    ).read_text()
     assert "mypy_path = src" in (output / "mypy.ini").read_text()
 
 

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -411,7 +411,7 @@ def _run_git(repository: Path, *arguments: str) -> str:
     os.environ.get("RUNNER_ENVIRONMENT") != "github-hosted",
     reason="target quality commands are forbidden outside GitHub-hosted runners",
 )
-def test_python_poison_file_passes_tests_but_blocks_as_unexecuted(tmp_path: Path) -> None:
+def test_python_poison_file_blocks_as_unexecuted(tmp_path: Path) -> None:
     repository = tmp_path / "python-target"
     repository.mkdir()
     _run_git(repository, "init", "--initial-branch=main")
@@ -484,7 +484,7 @@ def test_python_poison_file_passes_tests_but_blocks_as_unexecuted(tmp_path: Path
         capture_output=True,
         timeout=quality_profile.TIMEOUT_SECONDS,
     )
-    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    assert completed.returncode == 1, completed.stderr.decode(errors="replace")
     evidence = replace(
         quality_profile.load_evidence(output),
         artifact_id="789",

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -365,6 +365,7 @@ def test_target_profile_refuses_owner_workstation(monkeypatch: pytest.MonkeyPatc
         ],
         check=False,
         capture_output=True,
+        env={**os.environ, "PYTHONPATH": str(Path(__file__).parents[1] / "src")},
         timeout=10,
     )
     assert completed.returncode == 2

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -392,9 +392,7 @@ def test_fixed_python_tools_use_isolation_and_generated_source_paths(tmp_path: P
     assert all(plan.actual[1] == "-I" for plan in plans[:-1])
     assert Path(plans[-1].actual[0]).is_absolute()
     assert f"testpaths = {repository / 'tests'}" in (output / "pytest.ini").read_text()
-    assert f"pythonpath = {repository / 'src'} {repository}" in (
-        output / "pytest.ini"
-    ).read_text()
+    assert f"pythonpath = {repository / 'src'} {repository}" in (output / "pytest.ini").read_text()
     assert "mypy_path = src" in (output / "mypy.ini").read_text()
 
 

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -394,7 +394,7 @@ def test_fixed_python_tools_use_isolation_and_generated_source_paths(tmp_path: P
     assert Path(plans[-1].actual[0]).is_absolute()
     assert pytest_plan.actual[-2:] == ("--rootdir", str(repository))
     assert "testpaths = tests" in (output / "pytest.ini").read_text()
-    assert "pythonpath = src" in (output / "pytest.ini").read_text()
+    assert f"pythonpath = {repository / 'src'}" in (output / "pytest.ini").read_text()
     assert "mypy_path = src" in (output / "mypy.ini").read_text()
 
 
@@ -488,11 +488,7 @@ def test_python_poison_file_passes_tests_but_blocks_as_unexecuted(tmp_path: Path
         env={**os.environ, "PYTHONPATH": str(Path(__file__).parents[1] / "src")},
         timeout=quality_profile.TIMEOUT_SECONDS,
     )
-    assert completed.returncode == 0, [
-        (item.adapter, item.exit_code)
-        for item in quality_profile.load_evidence(output).commands
-        if item.exit_code
-    ]
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
     evidence = replace(
         quality_profile.load_evidence(output),
         artifact_id="789",

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -488,7 +488,11 @@ def test_python_poison_file_passes_tests_but_blocks_as_unexecuted(tmp_path: Path
         env={**os.environ, "PYTHONPATH": str(Path(__file__).parents[1] / "src")},
         timeout=quality_profile.TIMEOUT_SECONDS,
     )
-    assert completed.returncode == 0, quality_profile.load_evidence(output).commands
+    assert completed.returncode == 0, [
+        (item.adapter, item.exit_code)
+        for item in quality_profile.load_evidence(output).commands
+        if item.exit_code
+    ]
     evidence = replace(
         quality_profile.load_evidence(output),
         artifact_id="789",

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -483,6 +483,7 @@ def test_python_poison_file_passes_tests_but_blocks_as_unexecuted(tmp_path: Path
         ],
         check=False,
         capture_output=True,
+        env={**os.environ, "PYTHONPATH": str(Path(__file__).parents[1] / "src")},
         timeout=quality_profile.TIMEOUT_SECONDS,
     )
     assert completed.returncode == 0, completed.stderr.decode(errors="replace")
@@ -600,6 +601,7 @@ maximum = 10
         ],
         check=False,
         capture_output=True,
+        env={**os.environ, "PYTHONPATH": str(Path(__file__).parents[1] / "src")},
         timeout=quality_profile.TIMEOUT_SECONDS,
     )
     assert completed.returncode == 0, completed.stderr.decode(errors="replace")

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -394,7 +394,10 @@ def test_fixed_python_tools_use_isolation_and_generated_source_paths(tmp_path: P
     assert Path(plans[-1].actual[0]).is_absolute()
     assert pytest_plan.actual[-2:] == ("--rootdir", str(repository))
     assert "testpaths = tests" in (output / "pytest.ini").read_text()
-    assert f"pythonpath = {repository / 'src'} {repository}" in (output / "pytest.ini").read_text()
+    assert (
+        f"pythonpath =\n    {repository / 'src'}\n    {repository}"
+        in (output / "pytest.ini").read_text()
+    )
     assert "mypy_path = src" in (output / "mypy.ini").read_text()
 
 

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -391,6 +391,7 @@ def test_fixed_python_tools_use_isolation_and_generated_source_paths(tmp_path: P
     assert "PYTHONPATH" not in environment
     assert all(plan.actual[1] == "-I" for plan in plans[:-1])
     assert Path(plans[-1].actual[0]).is_absolute()
+    assert f"testpaths = {repository / 'tests'}" in (output / "pytest.ini").read_text()
     assert f"pythonpath = {repository / 'src'}" in (output / "pytest.ini").read_text()
     assert "mypy_path = src" in (output / "mypy.ini").read_text()
 

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -387,12 +387,14 @@ def test_fixed_python_tools_use_isolation_and_generated_source_paths(tmp_path: P
     output = tmp_path / "output"
     environment = quality_runner.fixed_environment(output, repository)
     plans = quality_runner.command_plans("python", repository, output, (), ("src/sample.py",))
+    pytest_plan = next(plan for plan in plans if plan.adapter == "python.pytest.v1")
 
     assert "PYTHONPATH" not in environment
     assert all(plan.actual[1] == "-I" for plan in plans[:-1])
     assert Path(plans[-1].actual[0]).is_absolute()
-    assert f"testpaths = {repository / 'tests'}" in (output / "pytest.ini").read_text()
-    assert f"pythonpath = {repository / 'src'} {repository}" in (output / "pytest.ini").read_text()
+    assert pytest_plan.actual[-2:] == ("--rootdir", str(repository))
+    assert "testpaths = tests" in (output / "pytest.ini").read_text()
+    assert "pythonpath = src" in (output / "pytest.ini").read_text()
     assert "mypy_path = src" in (output / "mypy.ini").read_text()
 
 
@@ -483,7 +485,6 @@ def test_python_poison_file_passes_tests_but_blocks_as_unexecuted(tmp_path: Path
         ],
         check=False,
         capture_output=True,
-        env={**os.environ, "PYTHONPATH": str(Path(__file__).parents[1] / "src")},
         timeout=quality_profile.TIMEOUT_SECONDS,
     )
     assert completed.returncode == 0, completed.stderr.decode(errors="replace")
@@ -601,7 +602,6 @@ maximum = 10
         ],
         check=False,
         capture_output=True,
-        env={**os.environ, "PYTHONPATH": str(Path(__file__).parents[1] / "src")},
         timeout=quality_profile.TIMEOUT_SECONDS,
     )
     assert completed.returncode == 0, completed.stderr.decode(errors="replace")

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -382,11 +382,17 @@ def test_fixed_vectors_never_invoke_a_shell() -> None:
     assert all("$(" not in argument and "`" not in argument for argument in arguments)
 
 
-def test_fixed_environment_imports_only_the_target_source(tmp_path: Path) -> None:
+def test_fixed_python_tools_use_isolation_and_generated_source_paths(tmp_path: Path) -> None:
     repository = tmp_path / "target"
-    environment = quality_runner.fixed_environment(tmp_path / "output", repository)
+    output = tmp_path / "output"
+    environment = quality_runner.fixed_environment(output, repository)
+    plans = quality_runner.command_plans("python", repository, output, (), ("src/sample.py",))
 
-    assert environment["PYTHONPATH"] == str(repository / "src")
+    assert "PYTHONPATH" not in environment
+    assert all(plan.actual[1] == "-I" for plan in plans[:-1])
+    assert Path(plans[-1].actual[0]).is_absolute()
+    assert "pythonpath = src" in (output / "pytest.ini").read_text()
+    assert "mypy_path = src" in (output / "mypy.ini").read_text()
 
 
 def _run_git(repository: Path, *arguments: str) -> str:

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -488,7 +488,7 @@ def test_python_poison_file_passes_tests_but_blocks_as_unexecuted(tmp_path: Path
         env={**os.environ, "PYTHONPATH": str(Path(__file__).parents[1] / "src")},
         timeout=quality_profile.TIMEOUT_SECONDS,
     )
-    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    assert completed.returncode == 0, quality_profile.load_evidence(output).commands
     evidence = replace(
         quality_profile.load_evidence(output),
         artifact_id="789",

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -391,7 +391,7 @@ def test_fixed_python_tools_use_isolation_and_generated_source_paths(tmp_path: P
     assert "PYTHONPATH" not in environment
     assert all(plan.actual[1] == "-I" for plan in plans[:-1])
     assert Path(plans[-1].actual[0]).is_absolute()
-    assert "pythonpath = src" in (output / "pytest.ini").read_text()
+    assert f"pythonpath = {repository / 'src'}" in (output / "pytest.ini").read_text()
     assert "mypy_path = src" in (output / "mypy.ini").read_text()
 
 

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -394,7 +394,9 @@ def test_fixed_python_tools_use_isolation_and_generated_source_paths(tmp_path: P
     assert Path(plans[-1].actual[0]).is_absolute()
     assert pytest_plan.actual[-2:] == ("--rootdir", str(repository))
     assert "testpaths = tests" in (output / "pytest.ini").read_text()
-    assert f"pythonpath = {repository / 'src'}" in (output / "pytest.ini").read_text()
+    assert f"pythonpath = {repository / 'src'} {repository}" in (
+        output / "pytest.ini"
+    ).read_text()
     assert "mypy_path = src" in (output / "mypy.ini").read_text()
 
 

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -485,6 +485,7 @@ def test_python_poison_file_passes_tests_but_blocks_as_unexecuted(tmp_path: Path
         ],
         check=False,
         capture_output=True,
+        env={**os.environ, "PYTHONPATH": str(Path(__file__).parents[1] / "src")},
         timeout=quality_profile.TIMEOUT_SECONDS,
     )
     assert completed.returncode == 0, completed.stderr.decode(errors="replace")
@@ -602,6 +603,7 @@ maximum = 10
         ],
         check=False,
         capture_output=True,
+        env={**os.environ, "PYTHONPATH": str(Path(__file__).parents[1] / "src")},
         timeout=quality_profile.TIMEOUT_SECONDS,
     )
     assert completed.returncode == 0, completed.stderr.decode(errors="replace")

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -170,6 +170,9 @@ def _m10_packet(claim: str = "parse_input strips surrounding whitespace.") -> Ev
                     "arguments": ["check", "src"],
                     "executed": True,
                     "exit_code": 0,
+                    "observed_paths": [PYTHON_PATH],
+                    "proof_kind": "explicit-source",
+                    "zero_statement_paths": [],
                 }
             ]
         },


### PR DESCRIPTION
Addresses root issues 16-19 in #79.

- Isolates trusted Python module tools with `-I`, removes target `PYTHONPATH`, retains generated source-discovery configs, and emits `quality-gates.v3`.
- Binds handoff artifacts to current base and head.
- Rejects malformed report/authoritative command rows separately.
- Deterministically preserves authoritative non-PASS, unexecuted, and failed commands.

Evidence: external four-root reproducer failed all four before and passed all four after; deleted. Focused suite intentionally deferred until review head stabilizes. No broad testing, new module/package/test file, immutable-doc change, or TWMN change.