### PR TITLE
Remove duplicate mutable status surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,11 @@ isolated GitHub-hosted jobs.
 
 ## Status
 
-- Completed successor scope: Supportability Standard Enforcement Milestones 1–8
-- Current authorized work: Enforcement Milestone 9 — executed quality gates
-- Completed capability: clause inventory through authenticated incremental-refactor enforcement
-- Existing complexity adapter: `python.c901-touched.v1`; maximum complexity: `10`
-- Full Supportability Standard runtime: **incomplete**
+Current product status, authorized work, milestone evidence, and remaining work are recorded only
+in the [Product Completion Contract](docs/product_completion_contract.md).
 
-Delivery state and milestone evidence are tracked in the
-[Supportability Standard Enforcement](https://github.com/orgs/mbh-solutions/projects/3)
-organization project. Project #2 is historical and is not successor execution authority.
+The [Supportability Standard Enforcement](https://github.com/orgs/mbh-solutions/projects/3)
+organization project is successor execution authority. Project #2 is historical.
 
 ## Requirements
 
@@ -23,6 +19,8 @@ organization project. Project #2 is historical and is not successor execution au
 - Dependencies installed from `requirements-dev.lock`
 
 ## Evaluate
+
+Complexity evaluation uses adapter `python.c901-touched.v1` with maximum complexity `10`.
 
 ```powershell
 python -m supportability_gate evaluate-complexity `

--- a/docs/enforcement_matrix.md
+++ b/docs/enforcement_matrix.md
@@ -1,40 +1,41 @@
 # Enforcement Matrix
 
-Every required `NOT_IMPLEMENTED` row keeps full product incomplete. Existing rows preserve
-historical deterministic-gate delivery; they are not complete normative-clause coverage.
+This matrix maps enforcement responsibilities to milestones. Current product status, milestone
+evidence, authorized work, and remaining work are recorded only in the
+[Product Completion Contract](product_completion_contract.md).
 
-| Successor enforcement requirement | Milestone | Current state |
-|---|---:|---|
-| Complete normative-clause inventory and traceability validator | 1 | IMPLEMENTED |
-| Trusted semantic judgment channel | 2 | IMPLEMENTED |
-| Python and TypeScript touched-function complexity and narrow anti-gaming | 3 | IMPLEMENTED |
-| Exact-head responsibility-boundary enforcement | 4 | IMPLEMENTED |
-| Remaining principle-specific enforcement | 5–10 | NOT_IMPLEMENTED |
-| Full Python/frontend protected-merge qualification | 11 | NOT_IMPLEMENTED |
+| Successor enforcement requirement | Milestone |
+|---|---:|
+| Complete normative-clause inventory and traceability validator | 1 |
+| Trusted semantic judgment channel | 2 |
+| Python and TypeScript touched-function complexity and narrow anti-gaming | 3 |
+| Exact-head responsibility-boundary enforcement | 4 |
+| Remaining principle-specific enforcement | 5–10 |
+| Full Python/frontend protected-merge qualification | 11 |
 
-| Supportability requirement | Enforcement class | Milestone | Current state |
-|---|---|---:|---|
-| Immutable owner-authored standard integrity | DETERMINISTIC | 1 | IMPLEMENTED |
-| Git base/head changed-file identity | DETERMINISTIC | 1 | IMPLEMENTED |
-| Touched Python function and method binding | DETERMINISTIC | 1 | IMPLEMENTED |
-| McCabe/C901 maximum 10 for new and non-legacy touched functions | DETERMINISTIC | 1 | IMPLEMENTED |
-| Progressive tightening for touched legacy functions | DETERMINISTIC | 1 | IMPLEMENTED |
-| Deterministic JSON and derived Markdown evidence | DETERMINISTIC | 1 | IMPLEMENTED |
-| Product source lint, format, type, complexity, test, package, and import-boundary gates | DETERMINISTIC | 1 | IMPLEMENTED |
-| Approved external gate adapters | DETERMINISTIC | 2 | IMPLEMENTED |
-| Changed-file gate coverage proof | DETERMINISTIC | 2 | IMPLEMENTED |
-| Highest-risk-file gate coverage proof | DETERMINISTIC | 2 | IMPLEMENTED |
-| Threshold anti-weakening | DETERMINISTIC | 2 | IMPLEMENTED |
-| Gate-scope anti-narrowing | DETERMINISTIC | 2 | IMPLEMENTED |
-| Behavior and characterization proof | STRUCTURED_REVIEW_EVIDENCE | 3 | IMPLEMENTED |
-| Separation-of-concerns evidence | STRUCTURED_REVIEW_EVIDENCE | 3 | IMPLEMENTED |
-| Architecture and dependency-direction review evidence | STRUCTURED_REVIEW_EVIDENCE | 3 | IMPLEMENTED |
-| Responsibility-boundary reporting | STRUCTURED_REVIEW_EVIDENCE | 3 | IMPLEMENTED |
-| Incremental refactor evidence | STRUCTURED_REVIEW_EVIDENCE | 3 | IMPLEMENTED |
-| Review handoff and remaining-risk evidence | STRUCTURED_REVIEW_EVIDENCE | 3 | IMPLEMENTED |
-| Naming, cohesion, intended behavior, and reviewability judgment | HUMAN_REVIEW | 3 | IMPLEMENTED |
-| Organization required-workflow enforcement proof | DETERMINISTIC | 4 | IMPLEMENTED |
-| Temporary target-repository protected merge proof | DETERMINISTIC | 4 | IMPLEMENTED |
-| TWMN clean and defect canaries | DETERMINISTIC | 5 | IMPLEMENTED |
-| TWMN gate-weakening and scope-narrowing canaries | DETERMINISTIC | 5 | IMPLEMENTED |
-| Frontend framework gate execution in Python-only V1 | DETERMINISTIC | 1 | NOT_APPLICABLE_TO_PRODUCT |
+| Supportability requirement | Enforcement class | Milestone |
+|---|---|---:|
+| Immutable owner-authored standard integrity | DETERMINISTIC | 1 |
+| Git base/head changed-file identity | DETERMINISTIC | 1 |
+| Touched Python function and method binding | DETERMINISTIC | 1 |
+| McCabe/C901 maximum 10 for new and non-legacy touched functions | DETERMINISTIC | 1 |
+| Progressive tightening for touched legacy functions | DETERMINISTIC | 1 |
+| Deterministic JSON and derived Markdown evidence | DETERMINISTIC | 1 |
+| Product source lint, format, type, complexity, test, package, and import-boundary gates | DETERMINISTIC | 1 |
+| Approved external gate adapters | DETERMINISTIC | 2 |
+| Changed-file gate coverage proof | DETERMINISTIC | 2 |
+| Highest-risk-file gate coverage proof | DETERMINISTIC | 2 |
+| Threshold anti-weakening | DETERMINISTIC | 2 |
+| Gate-scope anti-narrowing | DETERMINISTIC | 2 |
+| Behavior and characterization proof | STRUCTURED_REVIEW_EVIDENCE | 3 |
+| Separation-of-concerns evidence | STRUCTURED_REVIEW_EVIDENCE | 3 |
+| Architecture and dependency-direction review evidence | STRUCTURED_REVIEW_EVIDENCE | 3 |
+| Responsibility-boundary reporting | STRUCTURED_REVIEW_EVIDENCE | 3 |
+| Incremental refactor evidence | STRUCTURED_REVIEW_EVIDENCE | 3 |
+| Review handoff and remaining-risk evidence | STRUCTURED_REVIEW_EVIDENCE | 3 |
+| Naming, cohesion, intended behavior, and reviewability judgment | HUMAN_REVIEW | 3 |
+| Organization required-workflow enforcement proof | DETERMINISTIC | 4 |
+| Temporary target-repository protected merge proof | DETERMINISTIC | 4 |
+| TWMN clean and defect canaries | DETERMINISTIC | 5 |
+| TWMN gate-weakening and scope-narrowing canaries | DETERMINISTIC | 5 |
+| Frontend framework gate execution in Python-only V1 | DETERMINISTIC | 1 |


### PR DESCRIPTION
## Scope

PR7 under #79. Resolves frozen root issue 24 without rewriting history.

- Removes mutable duplicate product-status claims from `README.md` and `docs/enforcement_matrix.md`.
- Makes `docs/product_completion_contract.md` the sole current-status source.
- Preserves static capability, enforcement-class, milestone-responsibility, adapter, and complexity-limit explanations.

## Validation

- Immutable Standard SHA-256: `81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2`.
- Changed files: `README.md`, `docs/enforcement_matrix.md` only.
- Mutable-status scan: no stale status labels remain in those files.
- Local completion-contract links resolve.
- Project #3 link resolves.
- `git diff --check`: pass.
- No pytest, per issue #79 PR7 directive.

## Exclusions

No product code, tests, packages, immutable Standard, frozen roadmap, completion ledger, TWMN, deployment, canary, or thread-closure changes.