### PR TITLE
Canary: missing remaining-gap enforcement

### DIFF
--- a/src/supportability_gate/complexity_policy.py
+++ b/src/supportability_gate/complexity_policy.py
@@ -77,7 +77,7 @@ def validate_reporting(decisions: tuple[FunctionDecision, ...], maximum: int) ->
             or decision.remaining_debt != max(0, decision.head.complexity - maximum)
             or decision.next_target != maximum
         ):
-            raise ComplexityPolicyError("INCOMPLETE_REMAINING_GAP")
+            return
 
 
 def _decide_one(


### PR DESCRIPTION
Issue #79 source-only canary. Deliberately removes the INCOMPLETE_REMAINING_GAP enforcement path; must remain unmerged.