### PR TITLE
Remove semantic review source-line ceiling

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,31 +2,22 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "a8a8ddb15cdaa0a60eb972128433dc478d80d5bd"
+base_sha = "639e45dd490cfd1509a18bcec101b759e48ad523"
 overall_result = "PASS"
 responsibility_changes = [
-    "quality_profile and quality_runner isolate trusted Python module tools from target-controlled import paths while retaining generated source-discovery configuration.",
-    "GitHubApp searches successful exact-head handoff runs newest-first and binds the first artifact matching the packet's current base and head SHAs.",
-    "handoff_policy validates report and authoritative command rows independently and preserves authenticated failures as deterministic blocks.",
-    "refactor_policy collapses duplicate spans to their single bounded target identity.",
+    "GitHubApp retains every resolved production source line instead of rejecting evidence above a fixed total line count.",
+    "GitHubApp validates and coalesces completion citation intervals before line expansion so work is bounded by the fetched blob.",
 ]
 simplified_functions = [
-    "GitHubApp._handoff_evidence",
-    "GitHubApp._handoff_runs",
-    "GitHubApp.m10_evidence_packet",
-    "_command_blocks",
-    "_commands",
-    "_result_blocks",
-    "_target_identities",
-    "_write_python_configs",
-    "command_plans",
-    "fixed_environment",
+    "GitHubApp._completion_source",
+    "GitHubApp._completion_sources",
+    "GitHubApp._source_evidence",
 ]
 boundary_rationale = [
-    "Command isolation remains in the fixed quality profile and runner; artifact identity remains in GitHub evidence collection; semantic fail-closed decisions remain in handoff policy.",
+    "Evidence collection and citation normalization remain in GitHubApp; measured complete packets fit the existing model transport, so no partitioning or progress infrastructure was added.",
 ]
 remaining_risks = [
-    "Quality and handoff evidence still depend on authenticated GitHub workflow availability; missing, stale, malformed, unexecuted, or failed evidence blocks.",
+    "Very large complete packets still depend on model transport latency and the scheduled-task runtime; transport or timeout failures remain deterministic blocks.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-I", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -46,21 +37,11 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-trusted-python-tools"
-text = "Every Python module quality tool uses isolated mode, the fixed target environment omits PYTHONPATH, and generated pytest and mypy configuration supplies intended source discovery."
-citations = ["src/supportability_gate/quality_profile.py:14-118", "src/supportability_gate/quality_runner.py:24-36", "src/supportability_gate/quality_runner.py:125-136"]
+id = "claim-complete-source-collection"
+text = "Resolved production evidence is collected without a fixed total reviewed-line ceiling."
+citations = ["src/supportability_gate/github_app.py:486-530", "src/supportability_gate/github_app.py:762-787"]
 
 [[completion_report.claims]]
-id = "claim-base-head-handoff-binding"
-text = "Handoff collection searches successful exact-head runs newest-first and accepts only an authenticated result whose base and head identities match the current packet."
-citations = ["src/supportability_gate/github_app.py:278-303", "src/supportability_gate/github_app.py:313-339", "src/supportability_gate/github_app.py:429-458"]
-
-[[completion_report.claims]]
-id = "claim-fail-closed-handoff-results"
-text = "Report and authoritative command rows use separate strict shapes and failure codes, while authoritative non-PASS, unexecuted, and nonzero results always produce deterministic blocks."
-citations = ["src/supportability_gate/handoff_policy.py:24-32", "src/supportability_gate/handoff_policy.py:143-230", "src/supportability_gate/handoff_policy.py:273-289"]
-
-[[completion_report.claims]]
-id = "claim-unique-refactor-targets"
-text = "Repeated spans for the same changed responsibility collapse to one exact authorization target."
-citations = ["src/supportability_gate/refactor_policy.py:367-396"]
+id = "claim-bounded-citation-expansion"
+text = "Completion citation intervals are deduplicated, validated against the fetched blob, and coalesced before expansion."
+citations = ["src/supportability_gate/github_app.py:532-567"]

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -521,14 +521,12 @@ class GitHubApp:
         allowed = (changed_paths & deleted_paths) - reviewed_paths
         requested: dict[str, list[tuple[int, int]]] = {}
         for path, start, end in completion_citations(report):
-            if path in allowed and end - start < 2_500:
+            if path in allowed:
                 requested.setdefault(path, []).append((start, end))
-        used = sum(len(source["lines"]) for source in sources)
         for path, ranges in sorted(requested.items()):
             source = self._completion_source(repository, head_sha, path, ranges, token)
-            if source is not None and used + len(source["lines"]) <= 2_500:
+            if source is not None:
                 sources.append(source)
-                used += len(source["lines"])
         return sources
 
     def _completion_source(
@@ -785,7 +783,6 @@ class GitHubApp:
             if removed is not None:
                 deleted.append(removed)
         sources = [sources_by_path[path] for path in sorted(sources_by_path)]
-        self._validate_review_size(sources)
         return sources, deleted
 
     def _deletion_evidence(
@@ -861,10 +858,6 @@ class GitHubApp:
                 for root in production_paths
             )
         )
-
-    def _validate_review_size(self, sources: list[dict[str, Any]]) -> None:
-        if sum(len(source["lines"]) for source in sources) > 2_500:
-            raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
 
     def _source_candidates(self, files: tuple[dict[str, Any], ...]) -> tuple[dict[str, Any], ...]:
         candidates: list[dict[str, Any]] = []

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -548,14 +548,15 @@ class GitHubApp:
             raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
         content = self._blob_content(repository, blob_sha, token)
         lines = content.splitlines()
-        selected = sorted(
-            {
-                number
-                for start, end in ranges
-                if 1 <= start <= end <= len(lines)
-                for number in range(start, end + 1)
-            }
-        )
+        merged: list[tuple[int, int]] = []
+        for start, end in sorted(set(ranges)):
+            if not 1 <= start <= end <= len(lines):
+                continue
+            if merged and start <= merged[-1][1] + 1:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+            else:
+                merged.append((start, end))
+        selected = [number for start, end in merged for number in range(start, end + 1)]
         if not selected:
             return None
         return {

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -12,6 +12,7 @@ import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
+import supportability_gate.github_app as github_app_module
 from supportability_gate.function_changes import ResponsibilitySpan, responsibility_spans
 from supportability_gate.github_app import CHECK_NAME, REVIEWED_SUFFIXES, GitHubApp, app_jwt
 from supportability_gate.semantic_contract import EvidencePacket, SemanticReviewError
@@ -895,6 +896,43 @@ def test_completion_sources_include_large_valid_citation() -> None:
 
     assert len(sources) == 1
     assert len(sources[0]["lines"]) == 2_501
+
+
+def test_completion_source_coalesces_duplicate_ranges_before_expansion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    head = b"value = 1\n" * 2_501
+    head_blob = _blob_sha(head)
+    app = GitHubApp(
+        42,
+        7,
+        b"unused",
+        opener=lambda request, **kwargs: (
+            _Reply({"sha": head_blob})
+            if "/contents/" in request.full_url
+            else _Reply(_blob_payload(head))
+        ),
+    )
+    calls: list[tuple[int, int]] = []
+    builtin_range = range
+
+    def counted_range(start: int, end: int) -> range:
+        calls.append((start, end))
+        return builtin_range(start, end)
+
+    monkeypatch.setattr(github_app_module, "range", counted_range, raising=False)
+
+    source = app._completion_source(
+        "mbh-solutions/supportability-gate",
+        "b" * 40,
+        "src/a.py",
+        [(1, 2_500), (2, 2_501)] * 5_000,
+        "token",
+    )
+
+    assert source is not None
+    assert len(source["lines"]) == 2_501
+    assert calls == [(1, 2_502)]
 
 
 def test_mixed_source_change_reviews_head_and_identifies_deleted_base_responsibilities() -> None:

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -475,11 +475,29 @@ def test_open_pull_truncation_blocks() -> None:
         app.open_pulls("mbh-solutions/supportability-gate", "token")
 
 
-def test_semantic_source_limit_accepts_m9_packet_but_remains_bounded() -> None:
+def test_semantic_source_collection_has_no_total_line_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     app = GitHubApp(42, 7, b"unused")
-    app._validate_review_size([{"lines": [None] * 2_228}])
-    with pytest.raises(SemanticReviewError, match="INCOMPLETE_GITHUB_EVIDENCE"):
-        app._validate_review_size([{"lines": [None] * 2_501}])
+    files = (
+        {"filename": "src/a.py", "status": "modified"},
+        {"filename": "src/b.py", "status": "modified"},
+    )
+    monkeypatch.setattr(app, "_production_paths", lambda *args: ("src",))
+    monkeypatch.setattr(
+        app,
+        "_reviewed_source",
+        lambda repository, item, token: {
+            "lines": [None] * 2_003,
+            "path": item["filename"],
+        },
+    )
+    monkeypatch.setattr(app, "_deletion_evidence", lambda *args: (None, None))
+
+    sources, deleted = app._source_evidence("owner/repo", "a" * 40, files, "token")
+
+    assert sum(len(source["lines"]) for source in sources) == 4_006
+    assert deleted == []
 
 
 def test_stale_pull_evidence_blocks_before_publication() -> None:
@@ -806,11 +824,6 @@ def test_completion_sources_reject_unbounded_paths_and_ranges() -> None:
             [{"path": "src/a.txt", "status": "modified"}],
         ),
         (
-            {"claims": [{"citations": ["src/a.py:1-2501"], "id": "claim", "text": "too large"}]},
-            [{"path": "src/a.py"}],
-            [{"path": "src/a.py", "status": "modified"}],
-        ),
-        (
             {"claims": [{"citations": ["not-a-citation"], "id": "claim", "text": "bad"}]},
             [{"path": "src/a.py"}],
             [{"path": "src/a.py", "status": "modified"}],
@@ -854,6 +867,34 @@ def test_completion_sources_reject_unbounded_paths_and_ranges() -> None:
         )
         == []
     )
+
+
+def test_completion_sources_include_large_valid_citation() -> None:
+    head = b"value = 1\n" * 2_501
+    head_blob = _blob_sha(head)
+    app = GitHubApp(
+        42,
+        7,
+        b"unused",
+        opener=lambda request, **kwargs: (
+            _Reply({"sha": head_blob})
+            if "/contents/" in request.full_url
+            else _Reply(_blob_payload(head))
+        ),
+    )
+
+    sources = app._completion_sources(
+        "mbh-solutions/supportability-gate",
+        "b" * 40,
+        {"claims": [{"citations": ["src/a.py:1-2501"], "id": "claim", "text": "large"}]},
+        [],
+        [{"path": "src/a.py"}],
+        [{"path": "src/a.py", "status": "modified"}],
+        "token",
+    )
+
+    assert len(sources) == 1
+    assert len(sources[0]["lines"]) == 2_501
 
 
 def test_mixed_source_change_reviews_head_and_identifies_deleted_base_responsibilities() -> None:


### PR DESCRIPTION
## Summary

- remove the fixed 2,500-line ceiling from reviewed source collection
- include all valid completion-report citation lines instead of silently dropping large citations or packets
- retain existing GitHub payload, blob-integrity, exact-head, review-state, transport, timeout, parser, replay, and publication failure boundaries

References #92. Does not close it; production runtime and exact-head proof remain required.

## Root-cause evidence

- installed TWMN reviewer: `INCOMPLETE_GITHUB_EVIDENCE` / scheduler exit `2`
- exact PR #62 packet: 13 sources, 125 boundaries, 4,004 reviewed lines
- full M10 evidence: 768,200 canonical bytes
- exact `gpt-5.6-sol` diagnostic: 212,716 input tokens; completed in 440.5 seconds inside existing 480-second transport and 10-minute task boundaries; parser returned substantive `BLOCK` with four findings

This proves model transport accepts the complete packet. Sharding/persistence is not required by observed capacity and is intentionally not added.

## Validation

- focused new checks: `2 passed`
- directly relevant suite: `45 passed`
- exact-lock source proof: Ruff lint/format/C901, strict mypy, two import contracts, `306 passed, 2 skipped`, compileall
- wheel SHA-256: `271140c55b313ea8f68e2830a02b69cf2affee9d4fdb6602797fd9bfa8a9c826`
- fresh Python 3.12 exact-lock install and installed `supportability-gate --help`: PASS
- immutable-standard tamper test: PASS
- exact base/head diff whitespace: PASS
- no package, configuration, threshold, exclusion, waiver, command, environment, or gate-scope change
