### PR TITLE
Preserve semantic reviewer diagnostics

### DIFF
--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -23,7 +23,8 @@
     },
     {
       "covers": [
-        "src/supportability_gate/responses_transport.py"
+        "src/supportability_gate/responses_transport.py",
+        "src/supportability_gate/semantic_diagnostics.py"
       ],
       "id": "semantic-transport",
       "kind": "regression"

--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -23,10 +23,16 @@
     },
     {
       "covers": [
-        "src/supportability_gate/responses_transport.py",
-        "src/supportability_gate/semantic_diagnostics.py"
+        "src/supportability_gate/responses_transport.py"
       ],
       "id": "semantic-transport",
+      "kind": "regression"
+    },
+    {
+      "covers": [
+        "src/supportability_gate/semantic_diagnostics.py"
+      ],
+      "id": "semantic-diagnostics",
       "kind": "regression"
     },
     {

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -42,12 +42,12 @@ gate_coverage = [
 [[completion_report.claims]]
 id = "claim-exact-response-quarantine"
 text = "Every received response is atomically quarantined as exact bytes before decoding or semantic parsing."
-citations = ["src/supportability_gate/responses_transport.py:98-114", "src/supportability_gate/semantic_cli.py:190-198", "src/supportability_gate/semantic_diagnostics.py:120-126"]
+citations = ["src/supportability_gate/responses_transport.py:105-121", "src/supportability_gate/semantic_cli.py:190-198", "src/supportability_gate/semantic_diagnostics.py:120-126"]
 
 [[completion_report.claims]]
 id = "claim-attempt-lifecycle"
 text = "Each production model call records its check-bound transport attempt and terminal result."
-citations = ["src/supportability_gate/responses_transport.py:81-113", "src/supportability_gate/semantic_diagnostics.py:83-117", "src/supportability_gate/semantic_cli.py:290-300"]
+citations = ["src/supportability_gate/responses_transport.py:88-120", "src/supportability_gate/semantic_diagnostics.py:83-117", "src/supportability_gate/semantic_cli.py:290-300"]
 
 [[completion_report.claims]]
 id = "claim-safe-parser-diagnostic"

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -9,12 +9,19 @@ responsibility_changes = [
     "Semantic CLI publishes only safe diagnostic identity when deterministic parsing rejects a response.",
 ]
 simplified_functions = [
+    "TransportResponse.__getitem__",
     "TransportResponse.decoded",
+    "_review",
+    "main",
+    "reconcile_open_pulls",
     "request_response",
-    "start_attempt",
+    "_atomic_write",
+    "_attempt_content",
+    "_restricted_directory",
+    "_utc_now",
     "complete_attempt",
     "quarantine_response",
-    "_review",
+    "start_attempt",
 ]
 boundary_rationale = [
     "semantic_diagnostics owns restricted atomic local persistence, responses_transport owns HTTP-attempt lifecycle, and semantic_cli owns GitHub publication.",

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -48,8 +48,8 @@ gate_coverage = [
 
 [[completion_report.claims]]
 id = "claim-exact-response-quarantine"
-text = "Every received response is atomically quarantined as exact bytes before decoding or semantic parsing."
-citations = ["src/supportability_gate/responses_transport.py:105-121", "src/supportability_gate/semantic_cli.py:190-198", "src/supportability_gate/semantic_diagnostics.py:120-126"]
+text = "Production semantic review atomically quarantines each received response as exact bytes before decoding or semantic parsing."
+citations = ["src/supportability_gate/semantic_cli.py:190-198", "src/supportability_gate/semantic_cli.py:290-300", "src/supportability_gate/responses_transport.py:105-121", "src/supportability_gate/semantic_diagnostics.py:120-126"]
 
 [[completion_report.claims]]
 id = "claim-attempt-lifecycle"

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,22 +2,25 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "639e45dd490cfd1509a18bcec101b759e48ad523"
+base_sha = "644037bcae8ce334fddf811c1925089e58a427f0"
 overall_result = "PASS"
 responsibility_changes = [
-    "GitHubApp retains every resolved production source line instead of rejecting evidence above a fixed total line count.",
-    "GitHubApp validates and coalesces completion citation intervals before line expansion so work is bounded by the fetched blob.",
+    "Responses transport preserves exact received bytes and records each attempt before semantic parsing.",
+    "Semantic CLI publishes only safe diagnostic identity when deterministic parsing rejects a response.",
 ]
 simplified_functions = [
-    "GitHubApp._completion_source",
-    "GitHubApp._completion_sources",
-    "GitHubApp._source_evidence",
+    "TransportResponse.decoded",
+    "request_response",
+    "start_attempt",
+    "complete_attempt",
+    "quarantine_response",
+    "_review",
 ]
 boundary_rationale = [
-    "Evidence collection and citation normalization remain in GitHubApp; measured complete packets fit the existing model transport, so no partitioning or progress infrastructure was added.",
+    "semantic_diagnostics owns restricted atomic local persistence, responses_transport owns HTTP-attempt lifecycle, and semantic_cli owns GitHub publication.",
 ]
 remaining_risks = [
-    "Very large complete packets still depend on model transport latency and the scheduled-task runtime; transport or timeout failures remain deterministic blocks.",
+    "Diagnostic storage failure remains a fail-closed technical failure; retained diagnostics are intentionally not pruned by this repair.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-I", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -37,11 +40,16 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-complete-source-collection"
-text = "Resolved production evidence is collected without a fixed total reviewed-line ceiling."
-citations = ["src/supportability_gate/github_app.py:486-530", "src/supportability_gate/github_app.py:762-787"]
+id = "claim-exact-response-quarantine"
+text = "Every received response is atomically quarantined as exact bytes before decoding or semantic parsing."
+citations = ["src/supportability_gate/responses_transport.py:98-114", "src/supportability_gate/semantic_cli.py:190-198", "src/supportability_gate/semantic_diagnostics.py:120-126"]
 
 [[completion_report.claims]]
-id = "claim-bounded-citation-expansion"
-text = "Completion citation intervals are deduplicated, validated against the fetched blob, and coalesced before expansion."
-citations = ["src/supportability_gate/github_app.py:532-567"]
+id = "claim-attempt-lifecycle"
+text = "Each production model call records its check-bound transport attempt and terminal result."
+citations = ["src/supportability_gate/responses_transport.py:81-113", "src/supportability_gate/semantic_diagnostics.py:83-117", "src/supportability_gate/semantic_cli.py:290-300"]
+
+[[completion_report.claims]]
+id = "claim-safe-parser-diagnostic"
+text = "A deterministic parser rejection publishes only its error code, response SHA-256, and relative diagnostic filename."
+citations = ["src/supportability_gate/semantic_cli.py:195-217"]

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -1,19 +1,19 @@
 schema_version = "1.0"
 
 [behavior]
-intended_behavior = "Milestones 1-8 remain enforced while fixed Python and TypeScript quality profiles execute only on GitHub-hosted runners and bind exact command, result, coverage, threshold, exclusion, and commit evidence."
-proof = "tests/test_quality_profile.py"
+intended_behavior = "The semantic reviewer preserves exact received response bytes and per-attempt transport evidence before fail-closed parsing while GitHub receives only safe diagnostic identity."
+proof = "tests/test_semantic_review.py::test_unsupported_finding_preserves_exact_rejected_response"
 
 [characterization]
-captured_behavior = "The pre-change 192-test suite and existing Python and TypeScript characterization scenarios remain the immutable runnable base for Milestone 9."
-proof = "tests/test_quality_profile.py"
+captured_behavior = "The fixed localhost Responses transport retains its existing request and decoded-response behavior while diagnostics are added as a separate responsibility."
+proof = "tests/characterization/semantic-diagnostics.characterization.py"
 
 [separation_of_concerns]
-before = "Declared gate adapters proved configured coverage but did not prove every stack-native command actually executed successfully in an isolated hosted job."
-after = "The quality-profile module defines the immutable approved command contract and verifies its exact-head attestation, the quality-runner module materializes no-shell plans from that contract and independently defines their fixed tool configuration, and a disposable hosted job alone executes them."
+before = "The transport decoded and returned a model response without retaining its exact bytes or a durable attempt record, leaving deterministic parser rejection undiagnosable."
+after = "semantic_diagnostics owns restricted atomic persistence, responses_transport owns HTTP attempt lifecycle and the raw envelope, and semantic_cli owns fail-closed parsing and safe GitHub publication."
 
 [architecture]
-dependency_direction = "The organization workflow captures behavior, runs the fixed hosted quality profile, then the existing CLI verifies its immutable attestation before complexity, architecture, modularity, reporting, and semantic-review paths complete."
+dependency_direction = "semantic_cli depends on responses_transport; responses_transport depends on semantic_diagnostics; semantic_diagnostics uses only the standard library and does not depend back on transport or publication."
 reviewed_paths = [
     "src/supportability_gate/characterization.py",
     "src/supportability_gate/architecture_policy.py",
@@ -25,31 +25,33 @@ reviewed_paths = [
     "src/supportability_gate/quality_runner.py",
     "src/supportability_gate/reporting.py",
     "src/supportability_gate/refactor_policy.py",
+    "src/supportability_gate/responses_transport.py",
     "src/supportability_gate/review_events.py",
     "src/supportability_gate/review_state.py",
     "src/supportability_gate/semantic_cli.py",
     "src/supportability_gate/semantic_contract.py",
+    "src/supportability_gate/semantic_diagnostics.py",
     "src/supportability_gate/semantic_review.py",
 ]
 
 [responsibility_boundary]
-path = "src/supportability_gate/quality_profile.py"
-owns = "The immutable approved quality-profile contract plus API-read artifact metadata, exact result, identity, coverage, and anti-weakening verification."
-does_not_own = "Concrete command-plan materialization, generated tool configuration, target execution, characterization capture, refactor authorization, semantic transport, check publication, or waivers."
+path = "src/supportability_gate/semantic_diagnostics.py"
+owns = "Restricted atomic persistence and safe identities for semantic transport attempts and exact received response bytes."
+does_not_own = "HTTP transport, response decoding, semantic parsing, GitHub check publication, retention policy, prompt construction, or model selection."
 
 [incremental_refactor]
-target = "Require one complete fixed stack-native quality profile and exact attestation before the existing evaluator can pass."
-completed_step = "Added one immutable quality-profile contract and verifier, one concrete plan materializer, and one disposable hosted execution job; no shell, waiver, exclusion, or repository-controlled command path."
+target = "Make deterministic semantic-review failures diagnosable without exposing raw model text or weakening fail-closed parsing."
+completed_step = "Added restricted atomic response quarantine, per-attempt lifecycle records, a raw transport envelope, safe parser-rejection metadata, and one focused regression."
 
 [review_handoff]
-summary = "Review hosted-only execution, immutable command vectors, finite timeouts, captured result hashes, exact identity binding, complete changed/high-risk coverage, anti-weakening, deterministic evidence, and unchanged downstream gates."
-remaining_risks = ["Missing, malformed, unexecuted, failed, uncovered, excluded, weakened, narrowed, moved-outside-scope, or non-hosted quality evidence intentionally fails the required workflow closed."]
+summary = "Review exact-byte preservation before decoding, atomic file replacement, attempt terminal results, safe relative diagnostic metadata, and unchanged parser rules."
+remaining_risks = ["Diagnostic storage failure intentionally fails closed; diagnostics are retained without pruning in this evidence-capture slice."]
 
 [human_review]
-naming = "Quality-profile names directly describe fixed commands, hosted execution, attestation identity, coverage, and anti-weakening."
-cohesion = "The quality-profile module owns approved policy specification and verification; the quality-runner module owns concrete plan and tool-config materialization; the disposable hosted job owns execution."
-intended_behavior = "Existing enforcement remains; Python and TypeScript quality claims now block every missing, failed, unexecuted, uncovered, excluded, weakened, narrowed, moved, malformed, stale, or non-hosted condition."
-reviewability = "Focused fixtures cover both fixed profiles, all required failure classes, exact identities and vectors, workstation refusal, and byte-identical evidence."
+naming = "Attempt, QuarantinedResponse, start_attempt, complete_attempt, and quarantine_response each name one concrete diagnostic responsibility."
+cohesion = "Persistence is isolated from HTTP transport, semantic parsing, and GitHub publication; dependency direction remains one-way."
+intended_behavior = "Every production model call starts an attempt record, every received body is quarantined before parsing, and rejected raw text never reaches GitHub."
+reviewability = "One focused regression binds exact bytes, response hash, filename, attempt lifecycle, atomic cleanup, and safe check output; transport failures retain stable terminal results."
 
 [[module_boundaries]]
 path = "src/supportability_gate/review_events.py"
@@ -98,3 +100,9 @@ path = "src/supportability_gate/handoff_policy.py"
 owner_path = "src/supportability_gate/handoff_policy.py"
 basis = "responsibility"
 justification = "Owns completion-report parsing and exact evidence cross-checking without GitHub transport, target execution, or semantic model judgment."
+
+[[module_boundaries]]
+path = "src/supportability_gate/semantic_diagnostics.py"
+owner_path = "src/supportability_gate/responses_transport.py"
+basis = "responsibility"
+justification = "Owns restricted atomic local persistence for semantic transport attempts and exact response bytes, while the preexisting responses_transport boundary owns HTTP request and response handling and invokes diagnostics without taking persistence ownership."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ type = "layers"
 layers = [
     "supportability_gate.semantic_cli",
     "supportability_gate.github_app | supportability_gate.responses_transport",
+    "supportability_gate.semantic_diagnostics",
     "supportability_gate.review_events | supportability_gate.review_state",
     "supportability_gate.architecture_policy",
     "supportability_gate.semantic_review | supportability_gate.function_changes",

--- a/src/supportability_gate/responses_transport.py
+++ b/src/supportability_gate/responses_transport.py
@@ -7,6 +7,8 @@ import socket
 import urllib.error
 import urllib.request
 from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from supportability_gate.semantic_contract import (
@@ -14,9 +16,27 @@ from supportability_gate.semantic_contract import (
     SemanticReviewError,
     request_payload,
 )
+from supportability_gate.semantic_diagnostics import (
+    QuarantinedResponse,
+    complete_attempt,
+    quarantine_response,
+    start_attempt,
+)
 
 ENDPOINT = "http://127.0.0.1:8317/v1/responses"
 LOCAL_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({})).open
+
+
+@dataclass(frozen=True)
+class TransportResponse:
+    """Exact received bytes plus their safe diagnostic identity."""
+
+    body: bytes
+    diagnostic: QuarantinedResponse | None
+
+    def decoded(self) -> object:
+        """Decode the quarantined transport body for semantic parsing."""
+        return _decoded_response(self.body)
 
 
 def _request(packet: EvidencePacket) -> urllib.request.Request:
@@ -54,6 +74,41 @@ def request_response(
     *,
     timeout_seconds: float = 480.0,
     opener: Callable[..., Any] = LOCAL_OPENER,
-) -> object:
-    """Return one decoded response from the fixed localhost transport."""
-    return _decoded_response(_response_bytes(_request(packet), timeout_seconds, opener))
+    diagnostics_root: Path | None = None,
+    check_id: int | None = None,
+) -> TransportResponse:
+    """Return exact response bytes after recording the transport attempt."""
+    if (diagnostics_root is None) != (check_id is None):
+        raise ValueError("diagnostics_root and check_id must be supplied together")
+    attempt = (
+        start_attempt(diagnostics_root, packet.sha256, check_id)
+        if diagnostics_root is not None and check_id is not None
+        else None
+    )
+    try:
+        body = _response_bytes(_request(packet), timeout_seconds, opener)
+    except SemanticReviewError as error:
+        if attempt is not None:
+            result = {
+                "TIMEOUT": "TIMEOUT",
+                "PROXY_OUTAGE": "PROXY_OUTAGE",
+            }.get(error.code, "HTTP_FAILURE")
+            complete_attempt(attempt, result, error_code=error.code)
+        raise
+    try:
+        diagnostic = (
+            quarantine_response(diagnostics_root, packet.sha256, body)
+            if diagnostics_root is not None
+            else None
+        )
+    except OSError as error:
+        if attempt is not None:
+            complete_attempt(
+                attempt,
+                "RESPONSE_RECEIVED",
+                error_code="DIAGNOSTIC_PERSISTENCE_FAILURE",
+            )
+        raise SemanticReviewError("DIAGNOSTIC_PERSISTENCE_FAILURE") from error
+    if attempt is not None:
+        complete_attempt(attempt, "RESPONSE_RECEIVED", response=diagnostic)
+    return TransportResponse(body, diagnostic)

--- a/src/supportability_gate/responses_transport.py
+++ b/src/supportability_gate/responses_transport.py
@@ -38,6 +38,13 @@ class TransportResponse:
         """Decode the quarantined transport body for semantic parsing."""
         return _decoded_response(self.body)
 
+    def __getitem__(self, key: str) -> object:
+        """Keep existing decoded field access while retaining exact bytes."""
+        decoded = self.decoded()
+        if not isinstance(decoded, dict):
+            raise TypeError("response is not an object")
+        return decoded[key]
+
 
 def _request(packet: EvidencePacket) -> urllib.request.Request:
     return urllib.request.Request(

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -11,7 +11,7 @@ from typing import BinaryIO
 
 from supportability_gate.github_app import GitHubApp
 from supportability_gate.handoff_policy import deterministic_completion_blocks
-from supportability_gate.responses_transport import request_response
+from supportability_gate.responses_transport import TransportResponse, request_response
 from supportability_gate.review_events import ReviewEvent, parse_review_event
 from supportability_gate.semantic_contract import (
     EvidencePacket,
@@ -131,7 +131,13 @@ def _evaluation_lock(path: Path) -> Iterator[None]:
             _unlock(handle)
 
 
-def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]) -> bool:
+def _review(
+    app: GitHubApp,
+    repository: str,
+    token: str,
+    pull: dict[str, object],
+    diagnostics_root: Path | None = None,
+) -> bool:
     packet = app.evidence_packet(repository, pull, token)
     evidence = packet.evidence
     review_blocks = unresolved_review_blocks(evidence)
@@ -181,12 +187,24 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
             "BLOCK\n" + "\n".join(preflight),
         )
         return False
-    response = request_response(packet)
+    response = (
+        request_response(packet, diagnostics_root=diagnostics_root, check_id=check_id)
+        if diagnostics_root is not None
+        else request_response(packet)
+    )
     try:
-        verdict = parse_response(packet, response)
+        verdict = parse_response(
+            packet, response.decoded() if isinstance(response, TransportResponse) else response
+        )
     except SemanticReviewError as error:
         if error.code in {"INCOMPLETE_RESPONSE", "MODEL_DRIFT", "REFUSAL"}:
             raise
+        diagnostic = response.diagnostic if isinstance(response, TransportResponse) else None
+        details = f"TECHNICAL_FAILURE\n{error.code}"
+        if diagnostic is not None:
+            details += (
+                f"\nresponse SHA-256: {diagnostic.sha256}\ndiagnostic file: {diagnostic.filename}"
+            )
         _complete_current_check(
             app,
             packet,
@@ -194,7 +212,7 @@ def _review(app: GitHubApp, repository: str, token: str, pull: dict[str, object]
             token,
             check_id,
             "failure",
-            f"TECHNICAL_FAILURE\n{error.code}",
+            details,
         )
         return False
     if verdict.verdict == "PASS":
@@ -256,10 +274,16 @@ def handle_review_event(
     return process_review_event(app, token, event)
 
 
-def reconcile_open_pulls(app: GitHubApp, repository: str, token: str) -> tuple[bool, ...]:
+def reconcile_open_pulls(
+    app: GitHubApp,
+    repository: str,
+    token: str,
+    diagnostics_root: Path | None = None,
+) -> tuple[bool, ...]:
     """Re-evaluate every current open pull request as lost-event recovery."""
     return tuple(
-        _review(app, repository, token, pull) for pull in app.open_pulls(repository, token)
+        _review(app, repository, token, pull, diagnostics_root)
+        for pull in app.open_pulls(repository, token)
     )
 
 
@@ -271,8 +295,9 @@ def main(argv: list[str] | None = None) -> int:
         app = GitHubApp(arguments.app_id, arguments.installation_id, private_key)
         token = app.installation_token()
         lock_path = arguments.private_key.with_name("semantic-review.lock")
+        diagnostics_root = arguments.private_key.with_name("semantic-review-diagnostics")
         with _evaluation_lock(lock_path):
-            results = reconcile_open_pulls(app, arguments.repository, token)
+            results = reconcile_open_pulls(app, arguments.repository, token, diagnostics_root)
     except (OSError, SemanticReviewError):
         print("TECHNICAL_FAILURE")
         return 2

--- a/src/supportability_gate/semantic_diagnostics.py
+++ b/src/supportability_gate/semantic_diagnostics.py
@@ -1,0 +1,126 @@
+"""Persist restricted semantic-review transport diagnostics."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Attempt:
+    """One model transport attempt awaiting its terminal result."""
+
+    path: Path
+    evidence_sha256: str
+    check_id: int
+    started_at: str
+    started_monotonic_ns: int
+
+
+@dataclass(frozen=True)
+class QuarantinedResponse:
+    """Safe identity of an exact quarantined response."""
+
+    sha256: str
+    filename: str
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _restricted_directory(path: Path) -> None:
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(path, 0o700)
+
+
+def _atomic_write(path: Path, content: bytes) -> None:
+    _restricted_directory(path.parent)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{time.time_ns()}.tmp")
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _attempt_content(
+    attempt: Attempt,
+    *,
+    result: str,
+    ended_at: str | None = None,
+    duration_ms: int | None = None,
+    error_code: str | None = None,
+    response: QuarantinedResponse | None = None,
+) -> bytes:
+    return json.dumps(
+        {
+            "check_id": attempt.check_id,
+            "duration_ms": duration_ms,
+            "ended_at": ended_at,
+            "error_code": error_code,
+            "evidence_sha256": attempt.evidence_sha256,
+            "response_file": response.filename if response else None,
+            "response_sha256": response.sha256 if response else None,
+            "result": result,
+            "started_at": attempt.started_at,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+
+
+def start_attempt(root: Path, evidence_sha256: str, check_id: int) -> Attempt:
+    """Persist an in-progress record before starting model transport."""
+    _restricted_directory(root)
+    start_ns = time.time_ns()
+    attempt = Attempt(
+        root / "attempts" / f"{evidence_sha256}-{check_id}-{start_ns}-{os.getpid()}.json",
+        evidence_sha256,
+        check_id,
+        _utc_now(),
+        time.monotonic_ns(),
+    )
+    _atomic_write(attempt.path, _attempt_content(attempt, result="IN_PROGRESS"))
+    return attempt
+
+
+def complete_attempt(
+    attempt: Attempt,
+    result: str,
+    *,
+    error_code: str | None = None,
+    response: QuarantinedResponse | None = None,
+) -> None:
+    """Atomically replace an attempt with its terminal transport result."""
+    duration_ms = (time.monotonic_ns() - attempt.started_monotonic_ns) // 1_000_000
+    _atomic_write(
+        attempt.path,
+        _attempt_content(
+            attempt,
+            result=result,
+            ended_at=_utc_now(),
+            duration_ms=duration_ms,
+            error_code=error_code,
+            response=response,
+        ),
+    )
+
+
+def quarantine_response(root: Path, evidence_sha256: str, body: bytes) -> QuarantinedResponse:
+    """Atomically preserve exact response bytes before any decoding or parsing."""
+    _restricted_directory(root)
+    response_sha256 = hashlib.sha256(body).hexdigest()
+    filename = f"responses/{evidence_sha256}-{response_sha256}.response"
+    _atomic_write(root / filename, body)
+    return QuarantinedResponse(response_sha256, filename)

--- a/tests/characterization/semantic-diagnostics.characterization.py
+++ b/tests/characterization/semantic-diagnostics.characterization.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import urllib.request
+from pathlib import Path
+
+from supportability_gate import responses_transport
+from supportability_gate.semantic_contract import EvidencePacket
+
+BODY = b'{"error":null,"model":"gpt-5.6-sol","output":[],"status":"completed"}'
+
+
+class Reply:
+    def __enter__(self) -> Reply:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return BODY
+
+
+def main() -> None:
+    packet = EvidencePacket("owner/repository", "a" * 40, "b" * 40, 42, {"diff": ""})
+
+    def open_request(_request: urllib.request.Request, *, timeout: float) -> Reply:
+        assert timeout == 1.0
+        return Reply()
+
+    with tempfile.TemporaryDirectory() as directory:
+        arguments = (
+            {"diagnostics_root": Path(directory), "check_id": 7}
+            if hasattr(responses_transport, "TransportResponse")
+            else {}
+        )
+        response = responses_transport.request_response(
+            packet,
+            timeout_seconds=1.0,
+            opener=open_request,
+            **arguments,
+        )
+        if arguments:
+            assert response.body == BODY
+            diagnostic = response.diagnostic
+            assert diagnostic is not None
+            assert (Path(directory) / diagnostic.filename).read_bytes() == BODY
+            attempts = list((Path(directory) / "attempts").glob("*.json"))
+            assert len(attempts) == 1
+            attempt = json.loads(attempts[0].read_text())
+            assert attempt["result"] == "RESPONSE_RECEIVED"
+            assert attempt["response_sha256"] == hashlib.sha256(BODY).hexdigest()
+        status = response["status"]
+
+    print(
+        json.dumps(
+            {
+                "behavior": {
+                    "response_sha256": hashlib.sha256(BODY).hexdigest(),
+                    "status": status,
+                },
+                "scenario": "semantic-diagnostics",
+                "schema_version": "1.0",
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/characterization/semantic-diagnostics.golden.json
+++ b/tests/characterization/semantic-diagnostics.golden.json
@@ -1,0 +1,4 @@
+{
+  "response_sha256": "54ee03b51653219f6d2e2f372043364360ae78bd2f2b2e920a4d80eee8b04d24",
+  "status": "completed"
+}

--- a/tests/characterization/semantic-transport.characterization.py
+++ b/tests/characterization/semantic-transport.characterization.py
@@ -39,8 +39,7 @@ def main() -> None:
         timeout_seconds=1.0,
         opener=open_request,
     )
-    decoded = response if isinstance(response, dict) else response.decoded()
-    observed["response_status"] = decoded["status"]
+    observed["response_status"] = response["status"]
     print(
         json.dumps(
             {"behavior": observed, "scenario": "semantic-transport", "schema_version": "1.0"},

--- a/tests/characterization/semantic-transport.characterization.py
+++ b/tests/characterization/semantic-transport.characterization.py
@@ -39,7 +39,8 @@ def main() -> None:
         timeout_seconds=1.0,
         opener=open_request,
     )
-    observed["response_status"] = response.decoded()["status"]
+    decoded = response if isinstance(response, dict) else response.decoded()
+    observed["response_status"] = decoded["status"]
     print(
         json.dumps(
             {"behavior": observed, "scenario": "semantic-transport", "schema_version": "1.0"},

--- a/tests/characterization/semantic-transport.characterization.py
+++ b/tests/characterization/semantic-transport.characterization.py
@@ -39,7 +39,7 @@ def main() -> None:
         timeout_seconds=1.0,
         opener=open_request,
     )
-    observed["response_status"] = response["status"]
+    observed["response_status"] = response.decoded()["status"]
     print(
         json.dumps(
             {"behavior": observed, "scenario": "semantic-transport", "schema_version": "1.0"},

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -5,6 +5,7 @@ import hashlib
 import io
 import json
 import urllib.error
+from pathlib import Path
 
 import pytest
 
@@ -467,6 +468,69 @@ def test_deterministic_response_failure_completes_once_without_recalling_model(
     assert app.completed[0][3:] == ("failure", "TECHNICAL_FAILURE\nMALFORMED_SCHEMA")
 
 
+def test_unsupported_finding_preserves_exact_rejected_response(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    packet = _m10_packet()
+    rejected = _response(packet, "BLOCK", ["missing exact boundary prefix"])
+    reply = _Reply(rejected)
+
+    class App:
+        completed: list[tuple[object, ...]] = []
+
+        def evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def replay_result(self, *args: object) -> None:
+            return None
+
+        def assert_current(self, *args: object) -> None:
+            return None
+
+        def start_check(self, *args: object) -> int:
+            return 92455702993
+
+        def complete_check(self, *args: object) -> None:
+            self.completed.append(args)
+
+    def transport(current: EvidencePacket, **kwargs: object) -> object:
+        return request_response(
+            current,
+            opener=lambda *args, **opener_kwargs: reply,
+            diagnostics_root=kwargs["diagnostics_root"],  # type: ignore[arg-type]
+            check_id=kwargs["check_id"],  # type: ignore[arg-type]
+        )
+
+    monkeypatch.setattr(semantic_cli, "request_response", transport)
+    app = App()
+
+    assert not semantic_cli._review(  # type: ignore[arg-type]
+        app, packet.repository, "token", {}, tmp_path
+    )
+
+    response_sha256 = hashlib.sha256(reply.body).hexdigest()
+    filename = f"responses/{packet.sha256}-{response_sha256}.response"
+    assert (tmp_path / filename).read_bytes() == reply.body
+    attempts = list((tmp_path / "attempts").glob("*.json"))
+    assert len(attempts) == 1
+    attempt = json.loads(attempts[0].read_text())
+    assert attempt["result"] == "RESPONSE_RECEIVED"
+    assert attempt["response_sha256"] == response_sha256
+    assert attempt["response_file"] == filename
+    assert not list(tmp_path.rglob("*.tmp"))
+    summary = app.completed[0][4]
+    assert summary == (
+        "TECHNICAL_FAILURE\nUNSUPPORTED_FINDING"
+        f"\nresponse SHA-256: {response_sha256}"
+        f"\ndiagnostic file: {filename}"
+    )
+    assert "missing exact boundary prefix" not in summary
+    assert str(tmp_path) not in summary
+
+
 def test_evidence_packet_is_immutable_after_construction() -> None:
     evidence = {"diff": "+safe", "reviewed_sources": []}
     packet = EvidencePacket("mbh-solutions/supportability-gate", "a" * 40, "b" * 40, 42, evidence)
@@ -727,19 +791,33 @@ def test_untrusted_or_unavailable_model_results_block(defect: str, code: str) ->
 
 
 @pytest.mark.parametrize(
-    ("error", "code"),
+    ("error", "code", "result"),
     [
-        (urllib.error.HTTPError("x", 401, "", {}, io.BytesIO()), "AUTHENTICATION_FAILURE"),
-        (urllib.error.URLError("offline"), "PROXY_OUTAGE"),
-        (TimeoutError(), "TIMEOUT"),
+        (
+            urllib.error.HTTPError("x", 401, "", {}, io.BytesIO()),
+            "AUTHENTICATION_FAILURE",
+            "HTTP_FAILURE",
+        ),
+        (urllib.error.URLError("offline"), "PROXY_OUTAGE", "PROXY_OUTAGE"),
+        (TimeoutError(), "TIMEOUT", "TIMEOUT"),
     ],
 )
-def test_transport_failures_block(error: Exception, code: str) -> None:
+def test_transport_failures_block(tmp_path: Path, error: Exception, code: str, result: str) -> None:
     def fail(*args: object, **kwargs: object) -> object:
         raise error
 
     with pytest.raises(SemanticReviewError, match=code):
-        request_response(_packet(), opener=fail)
+        request_response(_packet(), opener=fail, diagnostics_root=tmp_path, check_id=92455702993)
+    records = list((tmp_path / "attempts").glob("*.json"))
+    assert len(records) == 1
+    record = json.loads(records[0].read_text())
+    assert (record["result"], record["error_code"], record["check_id"]) == (
+        result,
+        code,
+        92455702993,
+    )
+    assert record["ended_at"] is not None
+    assert isinstance(record["duration_ms"], int)
 
 
 def test_transport_uses_fixed_480_second_default() -> None:
@@ -870,7 +948,10 @@ def test_bound_vague_helper_verdict_blocks_python_and_typescript(diff: str) -> N
 def test_live_shape_from_transport_passes() -> None:
     packet = _packet()
     verdict = parse_response(
-        packet, request_response(packet, opener=lambda *args, **kwargs: _Reply(_response(packet)))
+        packet,
+        request_response(
+            packet, opener=lambda *args, **kwargs: _Reply(_response(packet))
+        ).decoded(),
     )
     assert verdict.verdict == "PASS"
 


### PR DESCRIPTION
## Summary

- atomically quarantine exact semantic model response bytes before decoding/parsing
- persist restricted per-attempt transport lifecycle records with safe response identity
- publish only error code, response SHA-256, and relative diagnostic filename on parser rejection
- keep the parser, prompt, schema, model, effort, and fail-closed behavior unchanged

References #95

## Proof

- focused regression: 1 passed
- relevant semantic/event suite exposed one test-double compatibility defect; fixed at the shared call boundary
- final Python 3.12 exact-lock proof: Ruff lint/format/C901 PASS; strict Mypy PASS; both import contracts PASS; 308 passed, 2 skipped; compileall PASS
- immutable Standard tamper test: PASS
- wheel build and fresh exact-lock install: PASS
- installed supportability-gate --help: PASS
- immutable Standard SHA-256: 81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2