### PR TITLE
Bound semantic check output

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,32 +2,23 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "644037bcae8ce334fddf811c1925089e58a427f0"
+base_sha = "d58e41e9898f66b810929f6de68a59b87626d1d9"
 overall_result = "PASS"
 responsibility_changes = [
-    "Responses transport preserves exact received bytes and records each attempt before semantic parsing.",
-    "Semantic CLI publishes only safe diagnostic identity when deterministic parsing rejects a response.",
+    "GitHubApp bounds completed semantic-check summaries by UTF-8 bytes while retaining exact evidence bindings and a deterministic full-summary digest.",
+    "Semantic CLI renders actionable findings and parser identity before exhaustive boundary and architecture detail.",
 ]
 simplified_functions = [
-    "TransportResponse.__getitem__",
-    "TransportResponse.decoded",
-    "_review",
-    "main",
-    "reconcile_open_pulls",
-    "request_response",
-    "_atomic_write",
-    "_attempt_content",
-    "_restricted_directory",
-    "_utc_now",
-    "complete_attempt",
-    "quarantine_response",
-    "start_attempt",
+    "GitHubApp.complete_check",
+    "GitHubApp.publish_check",
+    "_check_summary",
+    "_verdict_summary",
 ]
 boundary_rationale = [
-    "semantic_diagnostics owns restricted atomic local persistence, responses_transport owns HTTP-attempt lifecycle, and semantic_cli owns GitHub publication.",
+    "GitHubApp owns final check-payload safety and evidence binding; semantic_cli owns verdict presentation order without changing parsing or model contracts.",
 ]
 remaining_risks = [
-    "Diagnostic storage failure remains a fail-closed technical failure; retained diagnostics are intentionally not pruned by this repair.",
+    "Exhaustive boundary and architecture detail can be truncated, while findings, parser identity, full-summary SHA-256, response SHA-256, and evidence bindings remain visible.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-I", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -47,16 +38,16 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-exact-response-quarantine"
-text = "Production semantic review atomically quarantines each received response as exact bytes before decoding or semantic parsing."
-citations = ["src/supportability_gate/semantic_cli.py:190-198", "src/supportability_gate/semantic_cli.py:290-300", "src/supportability_gate/responses_transport.py:105-121", "src/supportability_gate/semantic_diagnostics.py:120-126"]
+id = "claim-bounded-check-output"
+text = "Completed semantic checks use one shared UTF-8 byte boundary that preserves exact packet bindings and identifies any omitted detail by full-summary SHA-256."
+citations = ["src/supportability_gate/github_app.py:134-150", "src/supportability_gate/github_app.py:1023-1052", "src/supportability_gate/github_app.py:1098-1129"]
 
 [[completion_report.claims]]
-id = "claim-attempt-lifecycle"
-text = "Each production model call records its check-bound transport attempt and terminal result."
-citations = ["src/supportability_gate/responses_transport.py:88-120", "src/supportability_gate/semantic_diagnostics.py:83-117", "src/supportability_gate/semantic_cli.py:290-300"]
+id = "claim-actionable-verdict-order"
+text = "Semantic verdict summaries place findings and parser identity before exhaustive ownership and architecture evidence."
+citations = ["src/supportability_gate/semantic_cli.py:24-48"]
 
 [[completion_report.claims]]
-id = "claim-safe-parser-diagnostic"
-text = "A deterministic parser rejection publishes only its error code, response SHA-256, and relative diagnostic filename."
-citations = ["src/supportability_gate/semantic_cli.py:195-217"]
+id = "claim-safe-oversized-finding"
+text = "Invalid surrogate code points are escaped before sizing, and an oversized single finding retains its actionable prefix inside the bounded payload."
+citations = ["src/supportability_gate/github_app.py:134-150", "tests/test_github_app.py:1187-1216"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -50,4 +50,4 @@ citations = ["src/supportability_gate/semantic_cli.py:24-48"]
 [[completion_report.claims]]
 id = "claim-safe-oversized-finding"
 text = "Invalid surrogate code points are escaped before sizing, and an oversized single finding retains its actionable prefix inside the bounded payload."
-citations = ["src/supportability_gate/github_app.py:134-150", "tests/test_github_app.py:1187-1216"]
+citations = ["src/supportability_gate/github_app.py:134-150"]

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -132,6 +132,7 @@ def _decoded_response(body: bytes) -> Any:
 
 
 def _check_summary(packet: EvidencePacket, summary: str) -> str:
+    summary = summary.encode("utf-8", errors="backslashreplace").decode()
     suffix = (
         f"\n\nEvidence SHA-256: `{packet.sha256}`\n"
         f"Instruction SHA-256: `{packet.instruction_sha256}`\n"
@@ -146,8 +147,6 @@ def _check_summary(packet: EvidencePacket, summary: str) -> str:
     )
     budget = MAX_CHECK_SUMMARY_BYTES - len((marker + suffix).encode())
     prefix = summary.encode()[:budget].decode("utf-8", errors="ignore")
-    if "\n" in prefix:
-        prefix = prefix.rsplit("\n", 1)[0]
     return prefix.rstrip() + marker + suffix
 
 

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -50,6 +50,7 @@ HUNK_PATTERN = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 SourceBoundary = dict[str, int | str]
 HANDOFF_WORKFLOW_PATH = ".github/workflows/organization-required.yml"
 MAX_HANDOFF_BYTES = 5_000_000
+MAX_CHECK_SUMMARY_BYTES = 65_535
 REVIEW_THREADS_QUERY = """
 query($owner:String!,$name:String!,$number:Int!,$cursor:String){
   repository(owner:$owner,name:$name){pullRequest(number:$number){
@@ -128,6 +129,26 @@ def _decoded_response(body: bytes) -> Any:
         return json.loads(body)
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
         raise SemanticReviewError("GITHUB_MALFORMED_RESPONSE") from error
+
+
+def _check_summary(packet: EvidencePacket, summary: str) -> str:
+    suffix = (
+        f"\n\nEvidence SHA-256: `{packet.sha256}`\n"
+        f"Instruction SHA-256: `{packet.instruction_sha256}`\n"
+        f"Base: `{packet.base_sha}`\nHead: `{packet.head_sha}`"
+    )
+    full = summary + suffix
+    if len(full.encode()) <= MAX_CHECK_SUMMARY_BYTES:
+        return full
+    marker = (
+        "\n\nGitHub output truncated; full summary SHA-256: "
+        f"`{hashlib.sha256(summary.encode()).hexdigest()}`"
+    )
+    budget = MAX_CHECK_SUMMARY_BYTES - len((marker + suffix).encode())
+    prefix = summary.encode()[:budget].decode("utf-8", errors="ignore")
+    if "\n" in prefix:
+        prefix = prefix.rsplit("\n", 1)[0]
+    return prefix.rstrip() + marker + suffix
 
 
 @dataclass
@@ -1020,11 +1041,7 @@ class GitHubApp:
                 "conclusion": conclusion,
                 "output": {
                     "title": CHECK_NAME,
-                    "summary": (
-                        f"{summary}\n\nEvidence SHA-256: `{packet.sha256}`\n"
-                        f"Instruction SHA-256: `{packet.instruction_sha256}`\n"
-                        f"Base: `{packet.base_sha}`\nHead: `{packet.head_sha}`"
-                    ),
+                    "summary": _check_summary(packet, summary),
                 },
             },
         )
@@ -1097,11 +1114,7 @@ class GitHubApp:
                 "conclusion": conclusion,
                 "output": {
                     "title": CHECK_NAME,
-                    "summary": (
-                        f"{summary}\n\nEvidence SHA-256: `{packet.sha256}`\n"
-                        f"Instruction SHA-256: `{packet.instruction_sha256}`\n"
-                        f"Base: `{packet.base_sha}`\nHead: `{packet.head_sha}`"
-                    ),
+                    "summary": _check_summary(packet, summary),
                 },
             },
         )

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -24,24 +24,24 @@ from supportability_gate.semantic_review import parse_response
 def _verdict_summary(verdict: SemanticVerdict) -> str:
     """Render resolvable ownership evidence for the GitHub check summary."""
     lines = [verdict.verdict]
+    lines.extend(f"finding: {finding}" for finding in verdict.findings)
+    lines.extend(
+        (
+            f"dependency direction: {verdict.dependency_direction}",
+            f"model: {verdict.returned_model} ({verdict.reasoning_effort})",
+            f"response SHA-256: {verdict.response_sha256}",
+            f"terminal status: {verdict.terminal_status}",
+            f"parser result: {verdict.parser_result}",
+        )
+    )
     for item in verdict.boundaries:
         lines.append(
             f"{item.path}:{item.start_line}-{item.end_line} {item.kind} {item.name} | "
             f"{item.basis} | owns: {item.owns} | does not own: {item.does_not_own} | "
             f"evidence lines: {','.join(str(line) for line in item.evidence_lines)}"
         )
-    lines.append(f"dependency direction: {verdict.dependency_direction}")
     lines.extend(
         f"architecture citation: {citation}" for citation in verdict.architecture_citations
-    )
-    lines.extend(f"finding: {finding}" for finding in verdict.findings)
-    lines.extend(
-        (
-            f"model: {verdict.returned_model} ({verdict.reasoning_effort})",
-            f"response SHA-256: {verdict.response_sha256}",
-            f"terminal status: {verdict.terminal_status}",
-            f"parser result: {verdict.parser_result}",
-        )
     )
     if not verdict.reviewed_paths:
         lines.append("No changed Python or frontend boundary.")

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -14,7 +14,13 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 
 import supportability_gate.github_app as github_app_module
 from supportability_gate.function_changes import ResponsibilitySpan, responsibility_spans
-from supportability_gate.github_app import CHECK_NAME, REVIEWED_SUFFIXES, GitHubApp, app_jwt
+from supportability_gate.github_app import (
+    CHECK_NAME,
+    MAX_CHECK_SUMMARY_BYTES,
+    REVIEWED_SUFFIXES,
+    GitHubApp,
+    app_jwt,
+)
 from supportability_gate.semantic_contract import EvidencePacket, SemanticReviewError
 
 CONTRACT = b"""schema_version = "1.0"
@@ -1176,6 +1182,37 @@ def test_pending_check_is_completed_with_same_evidence_binding() -> None:
     assert packet.instruction_sha256 in pending["output"]["summary"]
     assert requests[2].method == "PATCH"
     assert packet.instruction_sha256 in json.loads(requests[2].data)["output"]["summary"]
+
+
+def test_oversized_valid_block_summary_is_bounded_with_action_and_identity() -> None:
+    packet = EvidencePacket("mbh-solutions/supportability-gate", "a" * 40, "b" * 40, 42, {})
+    requests: list[Any] = []
+    prefix = "BLOCK\nfinding: src/a.py:1-2 unsupported completion claim\n"
+    summary = prefix + "boundary evidence\n" * ((69_197 - len(prefix)) // 18)
+    summary += "x" * (69_197 - len(summary))
+
+    def open_request(request: Any, **kwargs: object) -> _Reply:
+        requests.append(request)
+        return _Reply(
+            {
+                "app": {"id": 42},
+                "external_id": packet.sha256,
+                "head_sha": packet.head_sha,
+                "id": 99,
+            }
+        )
+
+    GitHubApp(42, 7, b"unused", opener=open_request).complete_check(
+        packet, "token", 99, "failure", summary
+    )
+
+    published = json.loads(requests[0].data)["output"]["summary"]
+    assert len(summary) == 69_197
+    assert len(published.encode()) <= MAX_CHECK_SUMMARY_BYTES
+    assert published.startswith(prefix)
+    assert "GitHub output truncated; full summary SHA-256" in published
+    assert hashlib.sha256(summary.encode()).hexdigest() in published
+    assert packet.sha256 in published
 
 
 def test_existing_pending_check_is_reused_idempotently() -> None:

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -1184,12 +1184,12 @@ def test_pending_check_is_completed_with_same_evidence_binding() -> None:
     assert packet.instruction_sha256 in json.loads(requests[2].data)["output"]["summary"]
 
 
-def test_oversized_valid_block_summary_is_bounded_with_action_and_identity() -> None:
+def test_oversized_valid_block_summary_is_safe_bounded_and_actionable() -> None:
     packet = EvidencePacket("mbh-solutions/supportability-gate", "a" * 40, "b" * 40, 42, {})
     requests: list[Any] = []
-    prefix = "BLOCK\nfinding: src/a.py:1-2 unsupported completion claim\n"
-    summary = prefix + "boundary evidence\n" * ((69_197 - len(prefix)) // 18)
-    summary += "x" * (69_197 - len(summary))
+    prefix = "BLOCK\nfinding: src/a.py:1-2 unsupported completion claim \ud800"
+    summary = prefix + "x" * (69_197 - len(prefix))
+    safe_summary = summary.encode("utf-8", errors="backslashreplace").decode()
 
     def open_request(request: Any, **kwargs: object) -> _Reply:
         requests.append(request)
@@ -1209,9 +1209,10 @@ def test_oversized_valid_block_summary_is_bounded_with_action_and_identity() -> 
     published = json.loads(requests[0].data)["output"]["summary"]
     assert len(summary) == 69_197
     assert len(published.encode()) <= MAX_CHECK_SUMMARY_BYTES
-    assert published.startswith(prefix)
+    assert published.startswith(prefix.replace("\ud800", "\\ud800"))
+    assert "x" * 100 in published
     assert "GitHub output truncated; full summary SHA-256" in published
-    assert hashlib.sha256(summary.encode()).hexdigest() in published
+    assert hashlib.sha256(safe_summary.encode()).hexdigest() in published
     assert packet.sha256 in published
 
 

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -221,7 +221,7 @@ def test_clean_fixture_passes_and_is_deterministic() -> None:
     assert first == second
     assert first.verdict == "PASS"
     assert first.architecture_citations == ()
-    assert _verdict_summary(first).startswith("PASS\nsrc/sample.py:1-2 function parse_input")
+    assert _verdict_summary(first).startswith("PASS\ndependency direction:")
 
 
 def test_exact_m10_packet_binds_response_model_status_hash_and_parser_result() -> None:


### PR DESCRIPTION
Fixes #97.

## What changed

- bound final GitHub check summaries to 65,535 UTF-8 bytes while preserving evidence bindings
- retain deterministic full-summary SHA-256 when output is truncated
- render verdict findings and parser identity before exhaustive boundary/citation detail
- add the 69,197-character BLOCK regression

## Root cause

A valid parsed BLOCK rendered 69,197 characters. GitHub rejected the check update, leaving the check in progress.

## Validation

- focused regression: 1 passed
- directly relevant suites: 106 passed
- full suite: 309 passed, 2 skipped
- Ruff lint/format/C901, strict Mypy, import contracts: passed
- wheel build, exact-lock fresh install, installed CLI help: passed
- immutable Standard hash: 81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2

Issue #95 remains open until versioned deployment and one automatic exact-head TWMN PR #62 runtime proof.