### PR TITLE
Fix independent new-module ownership enforcement

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,23 +2,19 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "d58e41e9898f66b810929f6de68a59b87626d1d9"
+base_sha = "670c2d0de86ac17b1ebd3fbde588ad1ac656f470"
 overall_result = "PASS"
 responsibility_changes = [
-    "GitHubApp bounds completed semantic-check summaries by UTF-8 bytes while retaining exact evidence bindings and a deterministic full-summary digest.",
-    "Semantic CLI renders actionable findings and parser identity before exhaustive boundary and architecture detail.",
+    "Modularity policy distinguishes exact-path self-ownership for an independent new module from ownership by a different new module.",
 ]
 simplified_functions = [
-    "GitHubApp.complete_check",
-    "GitHubApp.publish_check",
-    "_check_summary",
-    "_verdict_summary",
+    "_claim_blocks",
 ]
 boundary_rationale = [
-    "GitHubApp owns final check-payload safety and evidence binding; semantic_cli owns verdict presentation order without changing parsing or model contracts.",
+    "An independent new module may own its exact cohesive boundary; ownership by a different new module remains blocked until a preexisting source-backed owner exists.",
 ]
 remaining_risks = [
-    "Exhaustive boundary and architecture detail can be truncated, while findings, parser identity, full-summary SHA-256, response SHA-256, and evidence bindings remain visible.",
+    "Semantic Review remains responsible for rejecting unsupported self-ownership, weak cohesion, and unjustified separation claims.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-I", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -38,16 +34,6 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-bounded-check-output"
-text = "Completed semantic checks use one shared UTF-8 byte boundary that preserves exact packet bindings and identifies any omitted detail by full-summary SHA-256."
-citations = ["src/supportability_gate/github_app.py:134-150", "src/supportability_gate/github_app.py:1023-1052", "src/supportability_gate/github_app.py:1098-1129"]
-
-[[completion_report.claims]]
-id = "claim-actionable-verdict-order"
-text = "Semantic verdict summaries place findings and parser identity before exhaustive ownership and architecture evidence."
-citations = ["src/supportability_gate/semantic_cli.py:24-48"]
-
-[[completion_report.claims]]
-id = "claim-safe-oversized-finding"
-text = "Invalid surrogate code points are escaped before sizing, and an oversized single finding retains its actionable prefix inside the bounded payload."
-citations = ["src/supportability_gate/github_app.py:134-150"]
+id = "claim-independent-self-ownership"
+text = "A new production path may claim its own exact boundary, while ownership by any different new path remains blocked as non-preexisting."
+citations = ["src/supportability_gate/modularity_policy.py:108-133"]

--- a/src/supportability_gate/modularity_policy.py
+++ b/src/supportability_gate/modularity_policy.py
@@ -126,7 +126,7 @@ def _claim_blocks(
             continue
         if claim.owner_path not in nodes:
             blocks.append(f"UNRESOLVED_MODULE_OWNER:{path}:{claim.owner_path}")
-        elif claim.owner_path in new_paths:
+        elif claim.owner_path in new_paths and claim.owner_path != path:
             blocks.append(f"NEW_MODULE_OWNER_NOT_PREEXISTING:{path}:{claim.owner_path}")
         elif _package(claim.owner_path, policy) != _package(path, policy):
             blocks.append(f"PARALLEL_PACKAGE:{path}:{claim.owner_path}")

--- a/tests/test_modularity_policy.py
+++ b/tests/test_modularity_policy.py
@@ -178,7 +178,13 @@ def test_missing_or_unresolved_justification_blocks() -> None:
         _architecture(path),
         _quality(path),
     )
-    self_owned = evaluate_modularity(
+    assert missing.blocks == (f"MISSING_NEW_LOCATION_JUSTIFICATION:{path}",)
+    assert unresolved.blocks == (f"UNRESOLVED_MODULE_OWNER:{path}:src/orders/missing.py",)
+
+
+def test_independent_new_location_can_own_itself() -> None:
+    path = "src/orders/model.py"
+    result = evaluate_modularity(
         _policy(),
         (_assessment(path),),
         _review(path, "domain"),
@@ -186,9 +192,21 @@ def test_missing_or_unresolved_justification_blocks() -> None:
         _quality(path),
     )
 
-    assert missing.blocks == (f"MISSING_NEW_LOCATION_JUSTIFICATION:{path}",)
-    assert unresolved.blocks == (f"UNRESOLVED_MODULE_OWNER:{path}:src/orders/missing.py",)
-    assert self_owned.blocks == (f"NEW_MODULE_OWNER_NOT_PREEXISTING:{path}:{path}",)
+    assert result.blocks == ()
+
+
+def test_new_location_cannot_claim_another_new_location_as_owner() -> None:
+    path = "src/orders/model.py"
+    owner = "src/orders/owner.py"
+    result = evaluate_modularity(
+        _policy(),
+        (_assessment(path), _assessment(owner)),
+        _review(path, "domain", owner),
+        _architecture(path, owner_path=owner),
+        _quality(path),
+    )
+
+    assert f"NEW_MODULE_OWNER_NOT_PREEXISTING:{path}:{owner}" in result.blocks
 
 
 def test_modularity_evidence_is_deterministic() -> None:


### PR DESCRIPTION
References #100.

## Root cause

Deterministic modularity enforcement rejected every self-owned new path, even though the immutable Standard permits an independent new boundary when its responsibility does not belong to an existing governed package. That forced false preexisting-owner metadata which Semantic Review correctly rejected.

## Change

- allow `owner_path == path` for an exact independent new module
- continue blocking ownership by any different new module
- retain missing, unresolved, vague, parallel-package, coverage, cohesion, and coupling enforcement

## Verification

- focused falsifiers: 2 passed
- directly relevant modularity suite: 12 passed
- full suite: 311 passed, 2 skipped
- Ruff lint/format/C901, strict Mypy, and both import contracts: passed
- compileall and immutable-Standard tamper test: passed
- wheel build, fresh Python 3.12 exact-lock install, installed CLI help: passed
- wheel SHA-256: `cce84a165eae68119a43111d5a04cb45942468aa33f2d2c27c22650ebe21ce79`
- immutable Standard SHA-256: `81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2`
