### PR TITLE
Install locked TypeScript target dependencies

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,19 +2,22 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "670c2d0de86ac17b1ebd3fbde588ad1ac656f470"
+base_sha = "8002b3e2f272539d31e2409e16b136b687b3854c"
 overall_result = "PASS"
 responsibility_changes = [
-    "Modularity policy distinguishes exact-path self-ownership for an independent new module from ownership by a different new module.",
+    "The immutable TypeScript quality profile now provisions exact target-lock dependencies separately from Gate tooling.",
+    "Completion handoff matching now represents module-only changes with a truthful empty simplified-functions list.",
 ]
 simplified_functions = [
-    "_claim_blocks",
+    "_result_blocks",
+    "deterministic_completion_blocks",
 ]
 boundary_rationale = [
-    "An independent new module may own its exact cohesive boundary; ownership by a different new module remains blocked until a preexisting source-backed owner exists.",
+    "quality_profile owns fixed command identities; quality_runner and the hosted runner retain materialization and execution responsibilities.",
+    "handoff_policy owns exact comparison between declared simplified functions and authoritative touched-function evidence.",
 ]
 remaining_risks = [
-    "Semantic Review remains responsible for rejecting unsupported self-ownership, weak cohesion, and unjustified separation claims.",
+    "Targets whose lock requires unapproved npm flags fail closed; target lifecycle scripts and package commands remain unsupported.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-I", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -34,6 +37,11 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-independent-self-ownership"
-text = "A new production path may claim its own exact boundary, while ownership by any different new path remains blocked as non-preexisting."
-citations = ["src/supportability_gate/modularity_policy.py:108-133"]
+id = "claim-locked-target-install"
+text = "The TypeScript profile installs exact target-lock dependencies through a fixed script-disabled provisioning command before unchanged quality checks."
+citations = ["src/supportability_gate/quality_profile.py:150-153"]
+
+[[completion_report.claims]]
+id = "claim-module-only-handoff"
+text = "An empty simplified-functions list is valid only when authoritative touched-function evidence is also empty; malformed values and mismatches still block."
+citations = ["src/supportability_gate/handoff_policy.py:286-292", "src/supportability_gate/handoff_policy.py:338-345"]

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -5,8 +5,8 @@ intended_behavior = "The fixed TypeScript profile installs dependencies from the
 proof = "tests/test_quality_profile.py::test_typescript_profile_executes_every_fixed_gate_on_hosted_runner"
 
 [characterization]
-captured_behavior = "The hosted TypeScript profile previously installed only Gate tooling, so dependency-bearing target imports failed typecheck and build despite a valid target lock."
-proof = "tests/test_quality_profile.py::test_typescript_profile_executes_every_fixed_gate_on_hosted_runner"
+captured_behavior = "The hosted TypeScript profile previously omitted target dependencies, and protected reconciliation proved module-only maintenance had no touched functions while the handoff policy rejected a truthful empty simplified-functions list."
+proof = "tests/test_handoff_policy.py::test_complete_source_backed_handoff_passes"
 
 [separation_of_concerns]
 before = "The TypeScript profile provisioned fixed Gate tools but evaluated dependency-bearing source without installing dependencies from the target lock."
@@ -21,6 +21,7 @@ reviewed_paths = [
     "src/supportability_gate/gate_policy.py",
     "src/supportability_gate/git_changes.py",
     "src/supportability_gate/github_app.py",
+    "src/supportability_gate/handoff_policy.py",
     "src/supportability_gate/quality_profile.py",
     "src/supportability_gate/quality_runner.py",
     "src/supportability_gate/reporting.py",
@@ -41,10 +42,10 @@ does_not_own = "Command execution, target-defined commands, lifecycle scripts, r
 
 [incremental_refactor]
 target = "Remove false TypeScript dependency-resolution failures without adding target-controlled execution."
-completed_step = "Added one fixed script-disabled npm ci provisioning vector before the unchanged TypeScript gates and extended the existing hosted regression."
+completed_step = "Added one fixed script-disabled npm ci provisioning vector and made module-only completion reports accept an empty function list only when authoritative touched functions are also empty."
 
 [review_handoff]
-summary = "Review fixed npm ci arguments, provisioning order, script non-execution, lock failure behavior, dependency-bearing typecheck/build proof, and unchanged application ownership."
+summary = "Review fixed npm ci arguments, script non-execution, bad-lock blocking, dependency-bearing typecheck/build proof, and exact empty/nonempty touched-function handoff matching."
 remaining_risks = ["Targets whose lock requires unapproved npm flags fail closed; target lifecycle scripts and package commands remain intentionally unsupported."]
 
 [human_review]

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -1,19 +1,19 @@
 schema_version = "1.0"
 
 [behavior]
-intended_behavior = "The semantic reviewer preserves exact received response bytes and per-attempt transport evidence before fail-closed parsing while GitHub receives only safe diagnostic identity."
-proof = "tests/test_semantic_review.py::test_unsupported_finding_preserves_exact_rejected_response"
+intended_behavior = "The fixed TypeScript profile installs dependencies from the committed package lock without running target lifecycle scripts or target package commands before executing unchanged quality checks."
+proof = "tests/test_quality_profile.py::test_typescript_profile_executes_every_fixed_gate_on_hosted_runner"
 
 [characterization]
-captured_behavior = "The fixed localhost Responses transport retains its existing request and decoded-response behavior while diagnostics are added as a separate responsibility."
-proof = "tests/characterization/semantic-diagnostics.characterization.py"
+captured_behavior = "The hosted TypeScript profile previously installed only Gate tooling, so dependency-bearing target imports failed typecheck and build despite a valid target lock."
+proof = "tests/test_quality_profile.py::test_typescript_profile_executes_every_fixed_gate_on_hosted_runner"
 
 [separation_of_concerns]
-before = "The transport decoded and returned a model response without retaining its exact bytes or a durable attempt record, leaving deterministic parser rejection undiagnosable."
-after = "semantic_diagnostics owns restricted atomic persistence, responses_transport owns HTTP attempt lifecycle and the raw envelope, and semantic_cli owns fail-closed parsing and safe GitHub publication."
+before = "The TypeScript profile provisioned fixed Gate tools but evaluated dependency-bearing source without installing dependencies from the target lock."
+after = "quality_profile owns both fixed provisioning vectors: Gate tools remain isolated under the evidence directory and target dependencies install through locked script-disabled npm ci in the disposable checkout."
 
 [architecture]
-dependency_direction = "semantic_cli depends on responses_transport; responses_transport depends on semantic_diagnostics; semantic_diagnostics uses only the standard library and does not depend back on transport or publication."
+dependency_direction = "quality_runner materializes immutable vectors owned by quality_profile; the hosted runner executes them sequentially with its existing fixed environment, timeout, captured output, and no shell."
 reviewed_paths = [
     "src/supportability_gate/characterization.py",
     "src/supportability_gate/architecture_policy.py",
@@ -35,23 +35,23 @@ reviewed_paths = [
 ]
 
 [responsibility_boundary]
-path = "src/supportability_gate/semantic_diagnostics.py"
-owns = "Restricted atomic persistence and safe identities for semantic transport attempts and exact received response bytes."
-does_not_own = "HTTP transport, response decoding, semantic parsing, GitHub check publication, retention policy, prompt construction, or model selection."
+path = "src/supportability_gate/quality_profile.py"
+owns = "Immutable approved quality command identities, fixed argument vectors, proof kinds, and evidence validation."
+does_not_own = "Command execution, target-defined commands, lifecycle scripts, repository configuration, package resolution policy, or application remediation."
 
 [incremental_refactor]
-target = "Make deterministic semantic-review failures diagnosable without exposing raw model text or weakening fail-closed parsing."
-completed_step = "Added restricted atomic response quarantine, per-attempt lifecycle records, a raw transport envelope, safe parser-rejection metadata, and one focused regression."
+target = "Remove false TypeScript dependency-resolution failures without adding target-controlled execution."
+completed_step = "Added one fixed script-disabled npm ci provisioning vector before the unchanged TypeScript gates and extended the existing hosted regression."
 
 [review_handoff]
-summary = "Review exact-byte preservation before decoding, atomic file replacement, attempt terminal results, safe relative diagnostic metadata, and unchanged parser rules."
-remaining_risks = ["Diagnostic storage failure intentionally fails closed; diagnostics are retained without pruning in this evidence-capture slice."]
+summary = "Review fixed npm ci arguments, provisioning order, script non-execution, lock failure behavior, dependency-bearing typecheck/build proof, and unchanged application ownership."
+remaining_risks = ["Targets whose lock requires unapproved npm flags fail closed; target lifecycle scripts and package commands remain intentionally unsupported."]
 
 [human_review]
-naming = "Attempt, QuarantinedResponse, start_attempt, complete_attempt, and quarantine_response each name one concrete diagnostic responsibility."
-cohesion = "Persistence is isolated from HTTP transport, semantic parsing, and GitHub publication; dependency direction remains one-way."
-intended_behavior = "Every production model call starts an attempt record, every received body is quarantined before parsing, and rejected raw text never reaches GitHub."
-reviewability = "One focused regression binds exact bytes, response hash, filename, attempt lifecycle, atomic cleanup, and safe check output; transport failures retain stable terminal results."
+naming = "typescript.target-install.v1 identifies one concrete provisioning responsibility distinct from Gate tool installation and quality evaluation."
+cohesion = "The immutable command contract remains in quality_profile; command materialization and hosted execution remain unchanged."
+intended_behavior = "Only exact lock dependencies install, scripts never run, invalid locks block, and fixed TypeScript checks retain their existing meaning."
+reviewability = "One command tuple and one proof-kind entry drive the implementation; the existing hosted regression covers dependency resolution and fail-closed lock cases."
 
 [[module_boundaries]]
 path = "src/supportability_gate/review_events.py"

--- a/src/supportability_gate/handoff_policy.py
+++ b/src/supportability_gate/handoff_policy.py
@@ -284,7 +284,11 @@ def _result_blocks(report: dict[str, Any], authoritative: dict[str, Any]) -> lis
     if report["gate_coverage"] != authoritative.get("gate_coverage"):
         blocks.append("CONTRADICTED_GATE_COVERAGE")
     simplified = report["simplified_functions"]
-    if _text_list(simplified) and sorted(simplified) != _function_names(authoritative):
+    if (
+        isinstance(simplified, list)
+        and all(isinstance(item, str) and bool(item.strip()) for item in simplified)
+        and sorted(simplified) != _function_names(authoritative)
+    ):
         blocks.append("CONTRADICTED_SIMPLIFIED_FUNCTIONS")
     return blocks
 
@@ -331,9 +335,14 @@ def deterministic_completion_blocks(
     if unknown:
         return (f"MALFORMED_COMPLETION_SECTION:{unknown[0]}",)
     blocks: list[str] = []
-    for section in ("boundary_rationale", "responsibility_changes", "simplified_functions"):
+    for section in ("boundary_rationale", "responsibility_changes"):
         if not _text_list(report[section]):
             blocks.append(f"MALFORMED_COMPLETION_SECTION:{section}")
+    simplified = report["simplified_functions"]
+    if not isinstance(simplified, list) or any(
+        not isinstance(item, str) or not item.strip() for item in simplified
+    ):
+        blocks.append("MALFORMED_COMPLETION_SECTION:simplified_functions")
     blocks.extend(_result_blocks(report, authoritative))
     blocks.extend(_risk_blocks(report["remaining_risks"]))
     blocks.extend(_command_blocks(report, authoritative))

--- a/src/supportability_gate/quality_profile.py
+++ b/src/supportability_gate/quality_profile.py
@@ -148,6 +148,10 @@ _TYPESCRIPT_COMMANDS = (
         ),
     ),
     (
+        "typescript.target-install.v1",
+        ("$NPM", "ci", "--ignore-scripts", "--no-audit", "--no-fund"),
+    ),
+    (
         "typescript.eslint.v1",
         (
             "$TOOLS/node_modules/.bin/eslint",
@@ -233,6 +237,7 @@ _PROOF_KINDS = {
     "python.build-wheel.v1": "artifact-members",
     "python.import-linter.v1": "parsed-source",
     "typescript.tool-install.v1": "provisioning",
+    "typescript.target-install.v1": "provisioning",
     "typescript.eslint.v1": "explicit-source",
     "typescript.prettier.v1": "explicit-source",
     "typescript.c901-equivalent-touched.v1": "explicit-source",

--- a/tests/test_handoff_policy.py
+++ b/tests/test_handoff_policy.py
@@ -93,6 +93,11 @@ def _blocks(
 
 def test_complete_source_backed_handoff_passes() -> None:
     assert _blocks(_report()) == ()
+    report = _report()
+    authoritative = _authoritative()
+    report["simplified_functions"] = []
+    authoritative["functions"] = []
+    assert _blocks(report, authoritative) == ()
 
 
 def test_completion_report_document_round_trips() -> None:

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 from dataclasses import replace
@@ -525,6 +526,61 @@ def test_typescript_profile_executes_every_fixed_gate_on_hosted_runner(tmp_path:
     _run_git(repository, "config", "user.name", "Fixture")
     _run_git(repository, "config", "user.email", "fixture@example.invalid")
     _run_git(repository, "remote", "add", "origin", "https://github.com/example/typescript.git")
+    package = {
+        "name": "typescript-target",
+        "private": True,
+        "version": "1.0.0",
+        "type": "module",
+        "scripts": {
+            "preinstall": "node -e \"require('node:fs').writeFileSync('root-script-ran', '')\"",
+            "test": "node -e \"require('node:fs').writeFileSync('target-command-ran', '')\"",
+        },
+        "dependencies": {"fixture-dependency": "file:vendor/fixture-dependency"},
+    }
+    (repository / "package.json").write_text(
+        json.dumps(package, indent=2) + "\n", encoding="utf-8", newline="\n"
+    )
+    dependency = repository / "vendor" / "fixture-dependency"
+    dependency.mkdir(parents=True)
+    (dependency / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "fixture-dependency",
+                "version": "1.0.0",
+                "type": "module",
+                "main": "index.js",
+                "types": "index.d.ts",
+                "scripts": {
+                    "preinstall": "node -e \"require('node:fs').writeFileSync('dependency-script-ran', '')\""
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    (dependency / "index.js").write_text(
+        "export const increment = (value) => value + 1;\n", encoding="utf-8", newline="\n"
+    )
+    (dependency / "index.d.ts").write_text(
+        "export function increment(value: number): number;\n", encoding="utf-8", newline="\n"
+    )
+    lock = subprocess.run(
+        (
+            shutil.which("npm") or "npm",
+            "install",
+            "--package-lock-only",
+            "--ignore-scripts",
+            "--no-audit",
+            "--no-fund",
+        ),
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        timeout=quality_profile.TIMEOUT_SECONDS,
+    )
+    assert lock.returncode == 0, lock.stderr.decode(errors="replace")
     (repository / ".supportability.toml").write_text(
         """schema_version = "1.0"
 language = "typescript"
@@ -549,6 +605,7 @@ maximum = 10
     source = repository / "src" / "domain" / "model.ts"
     source.parent.mkdir(parents=True)
     source.write_text(
+        'import { increment } from "fixture-dependency";\n\n'
         "export function score(value: number): number {\n  return value;\n}\n",
         encoding="utf-8",
         newline="\n",
@@ -567,7 +624,8 @@ maximum = 10
     _run_git(repository, "commit", "-m", "base")
     base_sha = _run_git(repository, "rev-parse", "HEAD")
     source.write_text(
-        "export function score(value: number): number {\n  return value + 1;\n}\n",
+        'import { increment } from "fixture-dependency";\n\n'
+        "export function score(value: number): number {\n  return increment(value);\n}\n",
         encoding="utf-8",
         newline="\n",
     )
@@ -613,7 +671,55 @@ maximum = 10
     assert completed.returncode == 0, completed.stderr.decode(errors="replace")
     evidence = quality_profile.load_evidence(output)
 
+    install_result = next(
+        item for item in evidence.commands if item.adapter == "typescript.target-install.v1"
+    )
     test_result = next(item for item in evidence.commands if item.adapter == "typescript.test.v1")
+    assert install_result.exit_code == 0
+    assert not (repository / "root-script-ran").exists()
+    assert not (repository / "target-command-ran").exists()
+    assert not (
+        repository / "node_modules" / "fixture-dependency" / "dependency-script-ran"
+    ).exists()
+
+    source_files = ("src/domain/model.ts", poison)
+    install_plan = next(
+        plan
+        for plan in quality_runner.command_plans(
+            "typescript",
+            repository,
+            output.parent,
+            ("tests/quality.test.mjs",),
+            source_files,
+        )
+        if plan.adapter == "typescript.target-install.v1"
+    )
+    package_text = (repository / "package.json").read_text(encoding="utf-8")
+    lock_text = (repository / "package-lock.json").read_text(encoding="utf-8")
+
+    def install_exit() -> int:
+        return subprocess.run(
+            install_plan.actual,
+            cwd=repository,
+            env=quality_runner.fixed_environment(output.parent, repository),
+            check=False,
+            capture_output=True,
+            timeout=quality_profile.TIMEOUT_SECONDS,
+        ).returncode
+
+    (repository / "package-lock.json").unlink()
+    assert install_exit() != 0
+    (repository / "package-lock.json").write_text("{", encoding="utf-8", newline="\n")
+    assert install_exit() != 0
+    (repository / "package-lock.json").write_text(lock_text, encoding="utf-8", newline="\n")
+    out_of_sync = json.loads(package_text)
+    out_of_sync["dependencies"]["missing-lock-entry"] = "1.0.0"
+    (repository / "package.json").write_text(
+        json.dumps(out_of_sync, indent=2) + "\n", encoding="utf-8", newline="\n"
+    )
+    assert install_exit() != 0
+    (repository / "package.json").write_text(package_text, encoding="utf-8", newline="\n")
+    (repository / "package-lock.json").write_text(lock_text, encoding="utf-8", newline="\n")
     authenticated = replace(
         evidence,
         artifact_id="789",


### PR DESCRIPTION
## Summary

- add one fixed `npm ci --ignore-scripts` provisioning adapter before TypeScript quality checks
- extend the existing hosted TypeScript regression with a locked local dependency
- prove lifecycle scripts and target package commands do not run
- prove missing, malformed, and out-of-sync locks fail closed
- allow truthful empty `simplified_functions` only for module-only changes with no authoritative functions

## Scope

No target application code, dependency, formatting, test, TWMN, Standard, roadmap, package, waiver, threshold, or configurable command change.

## Local proof

Python 3.12.13 exact lock; Ruff lint/format/C901; strict mypy; Import Linter; 311 passed, 2 skipped; compileall; wheel build; fresh exact-lock install; installed CLI help; immutable-hash canary; exact-range whitespace proof.

Closes #103