### PR TITLE
Align v0.2.0 runtime version identity

### DIFF
--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -2,6 +2,7 @@
   "scenarios": [
     {
       "covers": [
+        "src/supportability_gate/__init__.py",
         "src/supportability_gate/characterization.py",
         "src/supportability_gate/cli.py",
         "src/supportability_gate/complexity_metrics.py",

--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -2,7 +2,6 @@
   "scenarios": [
     {
       "covers": [
-        "src/supportability_gate/__init__.py",
         "src/supportability_gate/characterization.py",
         "src/supportability_gate/cli.py",
         "src/supportability_gate/complexity_metrics.py",
@@ -87,6 +86,13 @@
         "src/supportability_gate/modularity_policy.py"
       ],
       "id": "architecture-modularity-baseline",
+      "kind": "regression"
+    },
+    {
+      "covers": [
+        "src/supportability_gate/__init__.py"
+      ],
+      "id": "package-version",
       "kind": "regression"
     }
   ],

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -36,4 +36,4 @@ gate_coverage = [
 [[completion_report.claims]]
 id = "claim-version-identity"
 text = "Package CLI and deterministic tool evidence share the 0.2.0 package version constant."
-citations = ["src/supportability_gate/__init__.py:1-3", "src/supportability_gate/complexity_metrics.py:19-24", "src/supportability_gate/complexity_metrics.py:295-306"]
+citations = ["src/supportability_gate/__init__.py:3-3", "src/supportability_gate/complexity_metrics.py:22-22", "src/supportability_gate/complexity_metrics.py:302-302"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,45 +2,19 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "9f597afc7f9b1fc585c59f6a6e969e5e474e7d22"
+base_sha = "5d90481c05553011ea4f23f0401e1a3408db6a68"
 overall_result = "PASS"
 responsibility_changes = [
-    "GitHub evidence now binds the complete validated comparison diff and authenticated PR plus closing-issue authority, with freshness revalidation.",
-    "The semantic contract now fixes four profiles across two rounds and binds every profile, round, instruction, evidence, model, effort, and response identity.",
-    "The orchestrator runs all eight calls, retains every trusted finding, byte-deduplicates only identical findings, and requires eight clean trusted PASS results.",
-    "Diagnostics and live qualification record eight attempts and cover historical PR 18, poison, and clean convergence cases.",
+    "The installed package and deterministic evidence now report the same 0.2.0 version as the wheel metadata.",
 ]
 simplified_functions = [
-    "GitHubApp._authority",
-    "GitHubApp._authority_issue",
-    "GitHubApp.assert_current",
-    "GitHubApp.evidence_packet",
-    "GitHubApp.replay_result",
-    "_attempt_content",
-    "_authority_finding_prefixes",
-    "_boundary_evidence",
-    "_diff_finding_prefixes",
-    "_ensemble_summary",
-    "_request",
-    "_response_data",
-    "_review",
-    "_trusted_verdict",
-    "_validate_bindings",
-    "_verdict_summary",
-    "parse_response",
-    "profile_instruction",
-    "profile_instruction_sha256",
-    "request_payload",
-    "request_response",
-    "result_schema",
-    "start_attempt",
+    "tool_versions",
 ]
 boundary_rationale = [
-    "GitHubApp remains the authenticated authority and comparison owner; semantic_contract owns immutable request/result schema; semantic_review validates one response; semantic_cli owns ensemble execution.",
-    "Existing transport and diagnostics modules receive only the fixed profile and round bindings needed for one attempt; no new production module or dependency is introduced.",
+    "The package root owns the release version; complexity_metrics reads that existing constant instead of retaining a duplicate report value.",
 ]
 remaining_risks = [
-    "Two clean rounds materially reduce latent detection but cannot mathematically prove absence of every unknown defect.",
+    "A future release still requires updating pyproject metadata and the package version constant together.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-I", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -60,16 +34,6 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-full-authority-evidence"
-text = "The production packet contains the complete validated GitHub comparison diff and authenticated PR and closing-issue authority, and authority edits invalidate currentness."
-citations = ["src/supportability_gate/github_app.py:223-244", "src/supportability_gate/github_app.py:279-309", "src/supportability_gate/github_app.py:631-696"]
-
-[[completion_report.claims]]
-id = "claim-eight-fixed-attempts"
-text = "The orchestrator executes the four fixed profiles in each of two rounds, does not stop on a failed response, and passes only eight trusted clean verdicts."
-citations = ["src/supportability_gate/semantic_cli.py:147-236", "src/supportability_gate/semantic_contract.py:21-34"]
-
-[[completion_report.claims]]
-id = "claim-attempt-identities"
-text = "Each response binds profile, round, profile instruction SHA, common evidence SHA, fixed model and effort, and response SHA; each diagnostic attempt records profile, round, evidence, and response identity."
-citations = ["src/supportability_gate/semantic_contract.py:149-169", "src/supportability_gate/semantic_diagnostics.py:18-111", "src/supportability_gate/semantic_review.py:388-463"]
+id = "claim-version-identity"
+text = "Package CLI and deterministic tool evidence share the 0.2.0 package version constant."
+citations = ["src/supportability_gate/__init__.py:1-3", "src/supportability_gate/complexity_metrics.py:19-24", "src/supportability_gate/complexity_metrics.py:295-306"]

--- a/src/supportability_gate/__init__.py
+++ b/src/supportability_gate/__init__.py
@@ -1,3 +1,3 @@
 """Supportability gate package."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/supportability_gate/complexity_metrics.py
+++ b/src/supportability_gate/complexity_metrics.py
@@ -19,6 +19,7 @@ from typing import Any
 from mccabe import PathGraphingAstVisitor  # type: ignore[import-untyped]
 from tree_sitter import Node
 
+from supportability_gate import __version__
 from supportability_gate.function_changes import FunctionDefinition, FunctionSpan
 
 RUFF_TIMEOUT_SECONDS = 60
@@ -298,7 +299,7 @@ def tool_versions() -> dict[str, str]:
         "mccabe": importlib.metadata.version("mccabe"),
         "python": platform.python_version(),
         "ruff": importlib.metadata.version("ruff"),
-        "supportability_gate": "0.1.0",
+        "supportability_gate": __version__,
         "tree_sitter": importlib.metadata.version("tree-sitter"),
         "tree_sitter_typescript": importlib.metadata.version("tree-sitter-typescript"),
     }

--- a/tests/characterization/package-version.characterization.py
+++ b/tests/characterization/package-version.characterization.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+
+from supportability_gate import __version__
+
+
+def main() -> None:
+    print(
+        json.dumps(
+            {
+                "behavior": {"version_is_string": isinstance(__version__, str)},
+                "scenario": "package-version",
+                "schema_version": "1.0",
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/characterization/package-version.golden.json
+++ b/tests/characterization/package-version.golden.json
@@ -1,0 +1,3 @@
+{
+  "version_is_string": true
+}

--- a/tests/test_evaluate_complexity.py
+++ b/tests/test_evaluate_complexity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -21,7 +22,9 @@ from supportability_gate import (
 
 
 def test_reported_package_version_matches_distribution_version() -> None:
-    assert complexity_metrics.tool_versions()["supportability_gate"] == __version__ == "0.2.0"
+    metadata = tomllib.loads((Path(__file__).parents[1] / "pyproject.toml").read_text("utf-8"))
+    assert complexity_metrics.tool_versions()["supportability_gate"] == __version__
+    assert __version__ == metadata["project"]["version"]
 
 
 WORKFLOW_SHA = "f" * 40

--- a/tests/test_evaluate_complexity.py
+++ b/tests/test_evaluate_complexity.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from supportability_gate import (
+    __version__,
     cli,
     complexity_metrics,
     complexity_policy,
@@ -17,6 +18,11 @@ from supportability_gate import (
     quality_profile,
     reporting,
 )
+
+
+def test_reported_package_version_matches_distribution_version() -> None:
+    assert complexity_metrics.tool_versions()["supportability_gate"] == __version__ == "0.2.0"
+
 
 WORKFLOW_SHA = "f" * 40
 


### PR DESCRIPTION
References #109. Does not close the maintenance issue.

The merged v0.2.0 wheel exposed two retained v0.1.0 source constants during fresh-runtime verification. This minimal correction makes the package root authoritative and reuses it in deterministic tool evidence.

Proof: focused Ruff, strict mypy, version regression, CLI --version all pass. No runtime/task cutover occurred.