### PR TITLE
Reconstruct historical semantic qualification evidence

### DIFF
--- a/tests/qualify_convergent_reviewer.py
+++ b/tests/qualify_convergent_reviewer.py
@@ -53,6 +53,10 @@ def _historical_packet(
     app: GitHubApp, token: str, pull_number: int, head_sha: str
 ) -> EvidencePacket:
     pull = dict(app.pull(REPOSITORY, pull_number, token))
+    run = app._handoff_runs(REPOSITORY, head_sha, token)[0]
+    artifact = app._handoff_artifact(REPOSITORY, run, token)
+    files = app._artifact_json(app._artifact_bytes(REPOSITORY, artifact["id"], token))
+    pull["base"] = {**pull["base"], "sha": files["complexity-result.json"]["base_sha"]}
     pull["head"] = {**pull["head"], "sha": head_sha}
     packet = app.evidence_packet(REPOSITORY, pull, token)
     return app.m10_evidence_packet(REPOSITORY, pull, token, packet)


### PR DESCRIPTION
References #109.\n\nUses each historical head's authenticated Supportability artifact to recover its exact comparison base before assembling semantic-review.v2 evidence. This fixes qualification-only reconstruction; it does not change production review behavior.