### PR TITLE
S00: add concurrent exact-PR semantic worker

### DIFF
--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -10,6 +10,7 @@ responsibility_changes = [
 simplified_functions = [
     "GitHubApp.assert_current",
     "GitHubApp.pull",
+    "_ensemble_summary",
     "_evaluation_lock",
     "_parser",
     "_pull_lock_path",

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,19 +2,27 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "3e942e7a546537776eac538fb0a15c39cb28d687"
+base_sha = "377528d08fcc3a251512f3cff402be5d19751835"
 overall_result = "PASS"
 responsibility_changes = [
-    "Specialist prompts now require exhaustive acceptance, async-interleaving, and trust-boundary analysis, while exact diff citations accept the model's standard colon delimiter.",
+    "One exact pull worker owns its repository/PR lock, runs four specialists concurrently per round, preserves the round barrier, and rejects deterministic completion defects before model transport.",
 ]
 simplified_functions = [
-    "_boundary_evidence",
+    "GitHubApp.assert_current",
+    "GitHubApp.pull",
+    "_evaluation_lock",
+    "_parser",
+    "_pull_lock_path",
+    "_review",
+    "_review_attempt",
+    "_review_round",
+    "main",
 ]
 boundary_rationale = [
-    "semantic_contract owns fixed grader instructions; semantic_review alone validates exact evidence citations; the qualification harness owns oracle fixtures and matching.",
+    "semantic_cli owns exact-pull execution and concurrency; GitHubApp owns authenticated pull state; existing transport, evidence, parsing, replay, and check publication remain unchanged.",
 ]
 remaining_risks = [
-    "Two rounds materially reduce latent detection but cannot prove absence of every unknown defect; transport or parser failure still prevents PASS.",
+    "Throughput remains capped by gateway latency and future dispatcher capacity; transport or parser failure still prevents PASS.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-I", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -34,11 +42,21 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-convergent-oracle"
-text = "The fixed specialists explicitly trace acceptance actions, pending async navigation, stale completion, and untrusted external values, while diff-only evidence remains outside parser boundary claims."
-citations = ["src/supportability_gate/semantic_contract.py:23-23", "src/supportability_gate/semantic_contract.py:28-28", "src/supportability_gate/semantic_contract.py:38-38", "src/supportability_gate/semantic_contract.py:336-337"]
+id = "claim-concurrent-rounds"
+text = "Each round submits all four fixed specialist profiles concurrently, then collects every result in deterministic profile order before the next round starts."
+citations = ["src/supportability_gate/semantic_cli.py:183-212"]
 
 [[completion_report.claims]]
-id = "claim-exact-citation-delimiter"
-text = "Exact diff line citations accept either a space or colon-space delimiter without accepting numeric prefix collisions."
-citations = ["src/supportability_gate/semantic_review.py:265-266"]
+id = "claim-exact-pull-isolation"
+text = "Repository identity is case-normalized and combined with the pull number to select one stable per-PR lock."
+citations = ["src/supportability_gate/semantic_cli.py:150-153"]
+
+[[completion_report.claims]]
+id = "claim-fast-deterministic-preflight"
+text = "Deterministic completion-report defects publish action-required and return before any specialist request begins."
+citations = ["src/supportability_gate/semantic_cli.py:248-270"]
+
+[[completion_report.claims]]
+id = "claim-stale-pull-rejection"
+text = "Closed pulls and pull state changes are rejected before evaluation or trusted publication."
+citations = ["src/supportability_gate/github_app.py:216-248"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -60,4 +60,4 @@ citations = ["src/supportability_gate/semantic_cli.py:257-279"]
 [[completion_report.claims]]
 id = "claim-stale-pull-rejection"
 text = "Closed pulls and pull state changes are rejected before evaluation or trusted publication."
-citations = ["src/supportability_gate/github_app.py:216-252"]
+citations = ["src/supportability_gate/github_app.py:216-258"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -60,4 +60,4 @@ citations = ["src/supportability_gate/semantic_cli.py:257-279"]
 [[completion_report.claims]]
 id = "claim-stale-pull-rejection"
 text = "Closed pulls and pull state changes are rejected before evaluation or trusted publication."
-citations = ["src/supportability_gate/github_app.py:216-258"]
+citations = ["src/supportability_gate/github_app.py:216-257"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -44,19 +44,19 @@ gate_coverage = [
 [[completion_report.claims]]
 id = "claim-concurrent-rounds"
 text = "Each round submits all four fixed specialist profiles concurrently, then collects every result in deterministic profile order before the next round starts."
-citations = ["src/supportability_gate/semantic_cli.py:183-212"]
+citations = ["src/supportability_gate/semantic_cli.py:190-221"]
 
 [[completion_report.claims]]
 id = "claim-exact-pull-isolation"
 text = "Repository identity is case-normalized and combined with the pull number to select one stable per-PR lock."
-citations = ["src/supportability_gate/semantic_cli.py:150-153"]
+citations = ["src/supportability_gate/semantic_cli.py:157-160"]
 
 [[completion_report.claims]]
 id = "claim-fast-deterministic-preflight"
 text = "Deterministic completion-report defects publish action-required and return before any specialist request begins."
-citations = ["src/supportability_gate/semantic_cli.py:248-270"]
+citations = ["src/supportability_gate/semantic_cli.py:257-279"]
 
 [[completion_report.claims]]
 id = "claim-stale-pull-rejection"
 text = "Closed pulls and pull state changes are rejected before evaluation or trusted publication."
-citations = ["src/supportability_gate/github_app.py:216-248"]
+citations = ["src/supportability_gate/github_app.py:216-252"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,9 +100,9 @@ Stop condition:
 
 Before editing:
 
-1. Identify the single milestone marked `In progress` in the
-   [Supportability Standard Enforcement](https://github.com/orgs/mbh-solutions/projects/3)
-   project. Project #2 is historical and must not be changed.
+1. Identify the single slice marked `In progress` in the
+   [Repository-Isolated Semantic Review Runtime](https://github.com/orgs/mbh-solutions/projects/8)
+   project. Projects #2, #3, and #6 are historical and must not be changed.
 2. Read its milestone issue completely.
 3. State:
    - terminal capability;

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -216,7 +216,11 @@ class GitHubApp:
     def pull(self, repository: str, pull_number: int, token: str) -> dict[str, Any]:
         """Return current authenticated pull-request metadata for event reconciliation."""
         result = self._request("GET", f"/repos/{repository}/pulls/{pull_number}", token)
-        if not isinstance(result, dict) or result.get("number") != pull_number:
+        if (
+            not isinstance(result, dict)
+            or type(result.get("number")) is not int
+            or result["number"] != pull_number
+        ):
             raise SemanticReviewError("MALFORMED_PULL_REQUEST")
         if result.get("state") != "open":
             raise SemanticReviewError("STALE_EVIDENCE")
@@ -227,7 +231,8 @@ class GitHubApp:
         pull = self._request("GET", f"/repos/{packet.repository}/pulls/{pull_number}", token)
         if (
             not isinstance(pull, dict)
-            or pull.get("number") != pull_number
+            or type(pull.get("number")) is not int
+            or pull["number"] != pull_number
             or pull.get("state") != "open"
         ):
             raise SemanticReviewError("STALE_EVIDENCE")

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -225,7 +225,11 @@ class GitHubApp:
     def assert_current(self, packet: EvidencePacket, pull_number: int, token: str) -> None:
         """Reject evidence if pull-request authority, commits, or review state changed."""
         pull = self._request("GET", f"/repos/{packet.repository}/pulls/{pull_number}", token)
-        if not isinstance(pull, dict) or pull.get("state") != "open":
+        if (
+            not isinstance(pull, dict)
+            or pull.get("number") != pull_number
+            or pull.get("state") != "open"
+        ):
             raise SemanticReviewError("STALE_EVIDENCE")
         try:
             base_sha = pull["base"]["sha"]

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -218,11 +218,15 @@ class GitHubApp:
         result = self._request("GET", f"/repos/{repository}/pulls/{pull_number}", token)
         if not isinstance(result, dict) or result.get("number") != pull_number:
             raise SemanticReviewError("MALFORMED_PULL_REQUEST")
+        if result.get("state") != "open":
+            raise SemanticReviewError("STALE_EVIDENCE")
         return result
 
     def assert_current(self, packet: EvidencePacket, pull_number: int, token: str) -> None:
         """Reject evidence if pull-request authority, commits, or review state changed."""
         pull = self._request("GET", f"/repos/{packet.repository}/pulls/{pull_number}", token)
+        if not isinstance(pull, dict) or pull.get("state") != "open":
+            raise SemanticReviewError("STALE_EVIDENCE")
         try:
             base_sha = pull["base"]["sha"]
             head_sha = pull["head"]["sha"]

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -257,6 +257,17 @@ def _review(
         )
         else ()
     )
+    if preflight:
+        _complete_current_check(
+            app,
+            packet,
+            pull_number,
+            token,
+            check_id,
+            "action_required",
+            "PREFLIGHT_BLOCK\n" + "\n".join(preflight),
+        )
+        return False
     verdicts: list[SemanticVerdict] = []
     errors: list[tuple[str, int, str]] = []
     for round_number in ROUNDS:

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from pathlib import Path
 from typing import BinaryIO
@@ -64,6 +66,7 @@ def _verdict_summary(verdict: SemanticVerdict) -> str:
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="supportability-semantic-review")
     parser.add_argument("--repository", required=True)
+    parser.add_argument("--pull-number", required=True, type=int)
     parser.add_argument("--app-id", required=True, type=int)
     parser.add_argument("--installation-id", required=True, type=int)
     parser.add_argument("--private-key", required=True, type=Path)
@@ -135,13 +138,78 @@ def _unlock(handle: BinaryIO) -> None:
 
 @contextmanager
 def _evaluation_lock(path: Path) -> Iterator[None]:
-    """Give one scheduled process exclusive model and verdict ownership."""
+    """Give one pull-request worker exclusive verdict ownership."""
     with path.open("a+b") as handle:
         _lock(handle)
         try:
             yield
         finally:
             _unlock(handle)
+
+
+def _pull_lock_path(private_key: Path, repository: str, pull_number: int) -> Path:
+    """Return one stable, filesystem-safe lock path for an exact pull request."""
+    identity = hashlib.sha256(f"{repository}#{pull_number}".encode()).hexdigest()
+    return private_key.with_name(f"semantic-review-{identity}.lock")
+
+
+def _review_attempt(
+    packet: EvidencePacket,
+    profile_id: str,
+    round_number: int,
+    diagnostics_root: Path | None,
+    check_id: int,
+) -> SemanticVerdict:
+    """Run and parse one specialist attempt."""
+    response = (
+        request_response(
+            packet,
+            profile_id,
+            round_number,
+            diagnostics_root=diagnostics_root,
+            check_id=check_id,
+        )
+        if diagnostics_root is not None
+        else request_response(packet, profile_id, round_number)
+    )
+    return parse_response(
+        packet,
+        response.decoded() if isinstance(response, TransportResponse) else response,
+        profile_id,
+        round_number,
+    )
+
+
+def _review_round(
+    packet: EvidencePacket,
+    round_number: int,
+    diagnostics_root: Path | None,
+    check_id: int,
+) -> tuple[list[SemanticVerdict], list[tuple[str, int, str]]]:
+    """Run four specialists concurrently and retain deterministic profile order."""
+    with ThreadPoolExecutor(max_workers=len(PROFILE_IDS)) as executor:
+        attempts = [
+            (
+                profile_id,
+                executor.submit(
+                    _review_attempt,
+                    packet,
+                    profile_id,
+                    round_number,
+                    diagnostics_root,
+                    check_id,
+                ),
+            )
+            for profile_id in PROFILE_IDS
+        ]
+    verdicts: list[SemanticVerdict] = []
+    errors: list[tuple[str, int, str]] = []
+    for profile_id, attempt in attempts:
+        try:
+            verdicts.append(attempt.result())
+        except SemanticReviewError as error:
+            errors.append((profile_id, round_number, error.code))
+    return verdicts, errors
 
 
 def _review(
@@ -192,29 +260,11 @@ def _review(
     verdicts: list[SemanticVerdict] = []
     errors: list[tuple[str, int, str]] = []
     for round_number in ROUNDS:
-        for profile_id in PROFILE_IDS:
-            try:
-                response = (
-                    request_response(
-                        packet,
-                        profile_id,
-                        round_number,
-                        diagnostics_root=diagnostics_root,
-                        check_id=check_id,
-                    )
-                    if diagnostics_root is not None
-                    else request_response(packet, profile_id, round_number)
-                )
-                verdicts.append(
-                    parse_response(
-                        packet,
-                        response.decoded() if isinstance(response, TransportResponse) else response,
-                        profile_id,
-                        round_number,
-                    )
-                )
-            except SemanticReviewError as error:
-                errors.append((profile_id, round_number, error.code))
+        round_verdicts, round_errors = _review_round(
+            packet, round_number, diagnostics_root, check_id
+        )
+        verdicts.extend(round_verdicts)
+        errors.extend(round_errors)
     findings = tuple(
         dict.fromkeys((*preflight, *(finding for item in verdicts for finding in item.findings)))
     )
@@ -297,18 +347,21 @@ def reconcile_open_pulls(
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Review every currently open pull request once."""
+    """Review one exact pull request once."""
     arguments = _parser().parse_args(argv)
     try:
         private_key = arguments.private_key.read_bytes()
         app = GitHubApp(arguments.app_id, arguments.installation_id, private_key)
         token = app.installation_token()
-        lock_path = arguments.private_key.with_name("semantic-review.lock")
+        pull = app.pull(arguments.repository, arguments.pull_number, token)
+        lock_path = _pull_lock_path(
+            arguments.private_key, arguments.repository, arguments.pull_number
+        )
         diagnostics_root = arguments.private_key.with_name("semantic-review-diagnostics")
         with _evaluation_lock(lock_path):
-            results = reconcile_open_pulls(app, arguments.repository, token, diagnostics_root)
+            result = _review(app, arguments.repository, token, pull, diagnostics_root)
     except (OSError, SemanticReviewError):
         print("TECHNICAL_FAILURE")
         return 2
-    print("PASS" if all(results) else "BLOCK")
-    return 0 if all(results) else 1
+    print("PASS" if result else "BLOCK")
+    return 0 if result else 1

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -34,16 +34,23 @@ def _ensemble_summary(
     """Render bounded aggregate identities and the unsuppressed finding union."""
     lines = ["PASS" if passed else "BLOCK"]
     lines.extend(f"finding: {finding}" for finding in findings)
-    lines.extend(
-        f"response: {getattr(item, 'profile_id', 'profile')} "
-        f"round {getattr(item, 'round', '?')} | {item.response_sha256} | "
-        f"{item.returned_model} {item.reasoning_effort} | {item.parser_result}"
+    profile_order = {profile_id: index for index, profile_id in enumerate(PROFILE_IDS)}
+    attempts = [
+        (
+            (item.round, profile_order[item.profile_id]),
+            f"response: {item.profile_id} round {item.round} | {item.response_sha256} | "
+            f"{item.returned_model} {item.reasoning_effort} | {item.parser_result}",
+        )
         for item in verdicts
-    )
-    lines.extend(
-        f"attempt failure: {profile_id} round {round_number} | {code}"
+    ]
+    attempts.extend(
+        (
+            (round_number, profile_order[profile_id]),
+            f"attempt failure: {profile_id} round {round_number} | {code}",
+        )
         for profile_id, round_number, code in errors
     )
+    lines.extend(summary for _, summary in sorted(attempts))
     return "\n".join(lines)
 
 
@@ -209,6 +216,8 @@ def _review_round(
             verdicts.append(attempt.result())
         except SemanticReviewError as error:
             errors.append((profile_id, round_number, error.code))
+        except Exception:
+            errors.append((profile_id, round_number, "UNEXPECTED_ATTEMPT_FAILURE"))
     return verdicts, errors
 
 

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -149,7 +149,7 @@ def _evaluation_lock(path: Path) -> Iterator[None]:
 
 def _pull_lock_path(private_key: Path, repository: str, pull_number: int) -> Path:
     """Return one stable, filesystem-safe lock path for an exact pull request."""
-    identity = hashlib.sha256(f"{repository}#{pull_number}".encode()).hexdigest()
+    identity = hashlib.sha256(f"{repository.lower()}#{pull_number}".encode()).hexdigest()
     return private_key.with_name(f"semantic-review-{identity}.lock")
 
 

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -537,7 +537,25 @@ def test_semantic_source_collection_has_no_total_line_ceiling(
 
 def test_stale_pull_evidence_blocks_before_publication() -> None:
     packet = EvidencePacket("mbh-solutions/supportability-gate", "a" * 40, "b" * 40, 42, {})
-    current = {"base": {"sha": "c" * 40}, "head": {"sha": "b" * 40}, "state": "open"}
+    current = {
+        "base": {"sha": "c" * 40},
+        "head": {"sha": "b" * 40},
+        "number": 3,
+        "state": "open",
+    }
+    app = GitHubApp(42, 7, b"unused", opener=lambda *args, **kwargs: _Reply(current))
+    with pytest.raises(SemanticReviewError, match="STALE_EVIDENCE"):
+        app.assert_current(packet, 3, "token")
+
+
+def test_wrong_pull_number_blocks_before_publication() -> None:
+    packet = EvidencePacket("mbh-solutions/supportability-gate", "a" * 40, "b" * 40, 42, {})
+    current = {
+        "base": {"sha": "a" * 40},
+        "head": {"sha": "b" * 40},
+        "number": 4,
+        "state": "open",
+    }
     app = GitHubApp(42, 7, b"unused", opener=lambda *args, **kwargs: _Reply(current))
     with pytest.raises(SemanticReviewError, match="STALE_EVIDENCE"):
         app.assert_current(packet, 3, "token")
@@ -558,7 +576,12 @@ def test_stale_review_state_blocks_before_publication(monkeypatch: pytest.Monkey
         42,
         {"review_state": captured},
     )
-    current = {"base": {"sha": "a" * 40}, "head": {"sha": "b" * 40}, "state": "open"}
+    current = {
+        "base": {"sha": "a" * 40},
+        "head": {"sha": "b" * 40},
+        "number": 3,
+        "state": "open",
+    }
     app = GitHubApp(42, 7, b"unused", opener=lambda *args, **kwargs: _Reply(current))
     monkeypatch.setattr(app, "issue_comments", lambda *args: ())
     monkeypatch.setattr(app, "_review_state", lambda *args: {**captured, "threads": [{}]})
@@ -632,7 +655,12 @@ def test_authority_edit_invalidates_evaluation(monkeypatch: pytest.MonkeyPatch) 
         42,
         {"authority": authority, "review_state": {"threads": []}},
     )
-    current = {"base": {"sha": "a" * 40}, "head": {"sha": "b" * 40}, "state": "open"}
+    current = {
+        "base": {"sha": "a" * 40},
+        "head": {"sha": "b" * 40},
+        "number": 18,
+        "state": "open",
+    }
     app = GitHubApp(42, 7, b"unused", opener=lambda *args, **kwargs: _Reply(current))
     monkeypatch.setattr(app, "_authority", lambda *args: {**authority, "edited": True})
 

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -510,6 +510,22 @@ def test_closed_exact_pull_blocks_before_evaluation() -> None:
         app.pull("mbh-solutions/supportability-gate", 3, "token")
 
 
+def test_boolean_pull_number_cannot_impersonate_integer_identity() -> None:
+    current = {
+        "base": {"sha": "a" * 40},
+        "head": {"sha": "b" * 40},
+        "number": True,
+        "state": "open",
+    }
+    packet = EvidencePacket("mbh-solutions/supportability-gate", "a" * 40, "b" * 40, 42, {})
+    app = GitHubApp(42, 7, b"unused", opener=lambda *args, **kwargs: _Reply(current))
+
+    with pytest.raises(SemanticReviewError, match="MALFORMED_PULL_REQUEST"):
+        app.pull("mbh-solutions/supportability-gate", 1, "token")
+    with pytest.raises(SemanticReviewError, match="STALE_EVIDENCE"):
+        app.assert_current(packet, 1, "token")
+
+
 def test_semantic_source_collection_has_no_total_line_ceiling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -499,6 +499,17 @@ def test_open_pull_truncation_blocks() -> None:
         app.open_pulls("mbh-solutions/supportability-gate", "token")
 
 
+def test_closed_exact_pull_blocks_before_evaluation() -> None:
+    app = GitHubApp(
+        42,
+        7,
+        b"unused",
+        opener=lambda *args, **kwargs: _Reply({"number": 3, "state": "closed"}),
+    )
+    with pytest.raises(SemanticReviewError, match="STALE_EVIDENCE"):
+        app.pull("mbh-solutions/supportability-gate", 3, "token")
+
+
 def test_semantic_source_collection_has_no_total_line_ceiling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -526,7 +537,7 @@ def test_semantic_source_collection_has_no_total_line_ceiling(
 
 def test_stale_pull_evidence_blocks_before_publication() -> None:
     packet = EvidencePacket("mbh-solutions/supportability-gate", "a" * 40, "b" * 40, 42, {})
-    current = {"base": {"sha": "c" * 40}, "head": {"sha": "b" * 40}}
+    current = {"base": {"sha": "c" * 40}, "head": {"sha": "b" * 40}, "state": "open"}
     app = GitHubApp(42, 7, b"unused", opener=lambda *args, **kwargs: _Reply(current))
     with pytest.raises(SemanticReviewError, match="STALE_EVIDENCE"):
         app.assert_current(packet, 3, "token")
@@ -547,7 +558,7 @@ def test_stale_review_state_blocks_before_publication(monkeypatch: pytest.Monkey
         42,
         {"review_state": captured},
     )
-    current = {"base": {"sha": "a" * 40}, "head": {"sha": "b" * 40}}
+    current = {"base": {"sha": "a" * 40}, "head": {"sha": "b" * 40}, "state": "open"}
     app = GitHubApp(42, 7, b"unused", opener=lambda *args, **kwargs: _Reply(current))
     monkeypatch.setattr(app, "issue_comments", lambda *args: ())
     monkeypatch.setattr(app, "_review_state", lambda *args: {**captured, "threads": [{}]})
@@ -621,7 +632,7 @@ def test_authority_edit_invalidates_evaluation(monkeypatch: pytest.MonkeyPatch) 
         42,
         {"authority": authority, "review_state": {"threads": []}},
     )
-    current = {"base": {"sha": "a" * 40}, "head": {"sha": "b" * 40}}
+    current = {"base": {"sha": "a" * 40}, "head": {"sha": "b" * 40}, "state": "open"}
     app = GitHubApp(42, 7, b"unused", opener=lambda *args, **kwargs: _Reply(current))
     monkeypatch.setattr(app, "_authority", lambda *args: {**authority, "edited": True})
 

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -204,6 +204,7 @@ def test_pull_lock_path_is_exact_and_repository_isolated(tmp_path: Path) -> None
     first = semantic_cli._pull_lock_path(private_key, "owner/first", 7)
 
     assert first == semantic_cli._pull_lock_path(private_key, "owner/first", 7)
+    assert first == semantic_cli._pull_lock_path(private_key, "Owner/First", 7)
     assert first != semantic_cli._pull_lock_path(private_key, "owner/second", 7)
     assert first != semantic_cli._pull_lock_path(private_key, "owner/first", 8)
     assert first.parent == tmp_path

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -191,12 +191,67 @@ def test_new_event_invalidates_without_concurrent_model_evaluation() -> None:
     assert app.pending == [packet.sha256]
 
 
-def test_only_one_scheduled_evaluator_can_hold_the_runtime_lock(tmp_path: Path) -> None:
+def test_only_one_exact_pull_worker_can_hold_its_lock(tmp_path: Path) -> None:
     lock = tmp_path / "semantic-review.lock"
     with semantic_cli._evaluation_lock(lock):
         with pytest.raises(SemanticReviewError, match="EVALUATION_IN_PROGRESS"):
             with semantic_cli._evaluation_lock(lock):
                 pytest.fail("concurrent evaluator acquired the runtime lock")
+
+
+def test_pull_lock_path_is_exact_and_repository_isolated(tmp_path: Path) -> None:
+    private_key = tmp_path / "key.pem"
+    first = semantic_cli._pull_lock_path(private_key, "owner/first", 7)
+
+    assert first == semantic_cli._pull_lock_path(private_key, "owner/first", 7)
+    assert first != semantic_cli._pull_lock_path(private_key, "owner/second", 7)
+    assert first != semantic_cli._pull_lock_path(private_key, "owner/first", 8)
+    assert first.parent == tmp_path
+
+
+def test_main_reviews_only_the_requested_pull(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    private_key = tmp_path / "key.pem"
+    private_key.write_bytes(b"key")
+    observed: list[object] = []
+
+    class App:
+        def installation_token(self) -> str:
+            return "token"
+
+        def pull(self, repository: str, pull_number: int, token: str) -> dict[str, object]:
+            observed.append((repository, pull_number, token))
+            return {"number": pull_number}
+
+    monkeypatch.setattr(semantic_cli, "GitHubApp", lambda *args: App())
+
+    def review(*args: object) -> bool:
+        observed.append(args[3])
+        return True
+
+    monkeypatch.setattr(semantic_cli, "_review", review)
+
+    assert (
+        semantic_cli.main(
+            [
+                "--repository",
+                "owner/repository",
+                "--pull-number",
+                "17",
+                "--app-id",
+                "42",
+                "--installation-id",
+                "7",
+                "--private-key",
+                str(private_key),
+            ]
+        )
+        == 0
+    )
+    assert observed == [("owner/repository", 17, "token"), {"number": 17}]
+    assert capsys.readouterr().out == "PASS\n"
+    assert semantic_cli._pull_lock_path(private_key, "owner/repository", 17).exists()
 
 
 def test_same_head_change_becomes_pending_before_fresh_evaluation(

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -255,6 +257,52 @@ def test_main_reviews_only_the_requested_pull(
     assert observed == [("owner/repository", 17, "token"), {"number": 17}]
     assert capsys.readouterr().out == "PASS\n"
     assert semantic_cli._pull_lock_path(private_key, "owner/repository", 17).exists()
+
+
+def test_duplicate_exact_main_invocation_runs_one_ensemble(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    private_key = tmp_path / "key.pem"
+    private_key.write_bytes(b"private")
+    entered, release = threading.Event(), threading.Event()
+    reviews = 0
+
+    class App:
+        def installation_token(self) -> str:
+            return "token"
+
+        def pull(self, *args: object) -> dict[str, object]:
+            return {"number": 17}
+
+    def review(*args: object) -> bool:
+        nonlocal reviews
+        reviews += 1
+        entered.set()
+        assert release.wait(timeout=2)
+        return True
+
+    arguments = [
+        "--repository",
+        "owner/repository",
+        "--pull-number",
+        "17",
+        "--app-id",
+        "42",
+        "--installation-id",
+        "7",
+        "--private-key",
+        str(private_key),
+    ]
+    monkeypatch.setattr(semantic_cli, "GitHubApp", lambda *args: App())
+    monkeypatch.setattr(semantic_cli, "_review", review)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(semantic_cli.main, arguments)
+        assert entered.wait(timeout=1)
+        assert semantic_cli.main(arguments) == 2
+        release.set()
+        assert first.result(timeout=1) == 0
+    assert reviews == 1
 
 
 def test_same_head_change_becomes_pending_before_fresh_evaluation(

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -53,6 +53,8 @@ def _pass_verdict() -> object:
             "dependency_direction": "preserved",
             "architecture_citations": (),
             "findings": (),
+            "profile_id": "contract-correctness",
+            "round": 1,
             "returned_model": "model",
             "reasoning_effort": "medium",
             "response_sha256": "c" * 64,

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -554,7 +554,10 @@ def test_production_review_missing_completion_evidence_blocks_before_graders(
     assert "MALFORMED_COMPLETION_REPORT" in app.published[0][4]
 
 
-@pytest.mark.parametrize("code", ["TIMEOUT", "INCOMPLETE_RESPONSE", "REFUSAL", "MODEL_DRIFT"])
+@pytest.mark.parametrize(
+    "code",
+    ["TIMEOUT", "INCOMPLETE_RESPONSE", "REFUSAL", "MODEL_DRIFT", "UNEXPECTED_ATTEMPT_FAILURE"],
+)
 def test_technical_model_failure_runs_all_graders_without_trusted_completion(
     monkeypatch: pytest.MonkeyPatch,
     code: str,
@@ -591,12 +594,14 @@ def test_technical_model_failure_runs_all_graders_without_trusted_completion(
         calls += 1
         if code == "TIMEOUT":
             raise SemanticReviewError(code)
+        if code == "UNEXPECTED_ATTEMPT_FAILURE" and args[1] == PROFILE_IDS[0]:
+            raise RuntimeError("untrusted attempt failure")
         response = _response(_m10_packet(), profile_id=str(args[1]), round_number=int(args[2]))
         if code == "INCOMPLETE_RESPONSE":
             response["status"] = "incomplete"
         elif code == "REFUSAL":
             response["output"][0]["content"][0] = {"type": "refusal", "refusal": "no"}  # type: ignore[index]
-        else:
+        elif code == "MODEL_DRIFT":
             response["model"] = "other"
         return response
 
@@ -610,6 +615,18 @@ def test_technical_model_failure_runs_all_graders_without_trusted_completion(
     assert len(app.completed) == 1
     assert app.completed[0][3] == "action_required"
     assert code in str(app.completed[0][4])
+    if code == "UNEXPECTED_ATTEMPT_FAILURE":
+        attempts = [
+            line.split(" |", 1)[0]
+            for line in str(app.completed[0][4]).splitlines()
+            if line.startswith(("response:", "attempt failure:"))
+        ]
+        assert attempts == [
+            f"{('attempt failure' if profile == PROFILE_IDS[0] else 'response')}: "
+            f"{profile} round {round_number}"
+            for round_number in (1, 2)
+            for profile in PROFILE_IDS
+        ]
 
 
 def test_deterministic_response_failure_runs_all_without_trusted_completion(

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -463,7 +463,7 @@ def test_ensemble_never_suppresses_and_byte_deduplicates_findings(
 def test_each_round_runs_four_profiles_concurrently_with_a_round_barrier(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    packet = _packet({"completion_sources": [], "pull_request": 67})
+    packet = _m10_packet()
     active = {1: 0, 2: 0}
     maximum = {1: 0, 2: 0}
     completed = {1: 0, 2: 0}
@@ -510,7 +510,7 @@ def test_each_round_runs_four_profiles_concurrently_with_a_round_barrier(
     assert completed == {1: 4, 2: 4}
 
 
-def test_production_review_missing_completion_evidence_still_runs_all_graders(
+def test_production_review_missing_completion_evidence_blocks_before_graders(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     packet = _packet({"pull_request": 3})
@@ -549,7 +549,8 @@ def test_production_review_missing_completion_evidence_still_runs_all_graders(
     assert not semantic_cli._review(  # type: ignore[arg-type]
         app, "mbh-solutions/supportability-gate", "token", {}
     )
-    assert calls == 8
+    assert calls == 0
+    assert app.published[0][3] == "action_required"
     assert "MALFORMED_COMPLETION_REPORT" in app.published[0][4]
 
 

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -4,6 +4,8 @@ import copy
 import hashlib
 import io
 import json
+import threading
+import time
 import urllib.error
 from pathlib import Path
 
@@ -413,6 +415,56 @@ def test_ensemble_never_suppresses_and_byte_deduplicates_findings(
     assert calls == 8
     assert str(app.completed[0][4]).count(f"finding: {finding}") == 1
     assert str(app.completed[0][4]).count("response:") == 8
+
+
+def test_each_round_runs_four_profiles_concurrently_with_a_round_barrier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packet = _packet({"completion_sources": [], "pull_request": 67})
+    active = {1: 0, 2: 0}
+    maximum = {1: 0, 2: 0}
+    completed = {1: 0, 2: 0}
+    lock = threading.Lock()
+    barriers = {1: threading.Barrier(4), 2: threading.Barrier(4)}
+
+    def respond(*args: object) -> object:
+        profile_id = str(args[1])
+        round_number = int(args[2])
+        with lock:
+            assert round_number == 1 or completed[1] == 4
+            active[round_number] += 1
+            maximum[round_number] = max(maximum[round_number], active[round_number])
+        barriers[round_number].wait(timeout=2)
+        time.sleep(0.01)
+        with lock:
+            active[round_number] -= 1
+            completed[round_number] += 1
+        return _response(packet, profile_id=profile_id, round_number=round_number)
+
+    class App:
+        def evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def assert_current(self, *args: object) -> None:
+            pass
+
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def replay_result(self, *args: object) -> None:
+            return None
+
+        def start_check(self, *args: object) -> int:
+            return 99
+
+        def complete_check(self, *args: object) -> None:
+            pass
+
+    monkeypatch.setattr(semantic_cli, "request_response", respond)
+
+    semantic_cli._review(App(), packet.repository, "token", {})  # type: ignore[arg-type]
+    assert maximum == {1: 4, 2: 4}
+    assert completed == {1: 4, 2: 4}
 
 
 def test_production_review_missing_completion_evidence_still_runs_all_graders(

--- a/tests/test_semantic_review.py
+++ b/tests/test_semantic_review.py
@@ -299,6 +299,49 @@ def test_m10_deterministic_contradiction_blocks_even_if_model_claims_pass() -> N
     assert "CONTRADICTED_COMPLETION_RESULT" in verdict.findings
 
 
+def test_deterministic_completion_defect_blocks_before_model_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packet = _m10_packet()
+    evidence = packet.evidence
+    evidence["completion_report"]["overall_result"] = "BLOCK"  # type: ignore[index]
+    packet = EvidencePacket(
+        packet.repository, packet.base_sha, packet.head_sha, packet.app_id, evidence
+    )
+
+    class App:
+        completed: list[tuple[object, ...]] = []
+
+        def evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def m10_evidence_packet(self, *args: object) -> EvidencePacket:
+            return packet
+
+        def replay_result(self, *args: object) -> None:
+            return None
+
+        def assert_current(self, *args: object) -> None:
+            return None
+
+        def start_check(self, *args: object) -> int:
+            return 99
+
+        def complete_check(self, *args: object) -> None:
+            self.completed.append(args)
+
+    monkeypatch.setattr(
+        semantic_cli,
+        "request_response",
+        lambda *args: pytest.fail("deterministic defect reached model transport"),
+    )
+    app = App()
+
+    assert not semantic_cli._review(app, packet.repository, "token", {})  # type: ignore[arg-type]
+    assert app.completed[0][3] == "action_required"
+    assert "CONTRADICTED_COMPLETION_RESULT" in str(app.completed[0][4])
+
+
 def test_nonproduction_review_skips_completion_preflight(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Closes #118

## Change

- Require one exact pull number per semantic worker.
- Replace machine-wide production lock selection with repository/PR-keyed lock files.
- Run four fixed specialist profiles concurrently inside each round.
- Preserve the round barrier, deterministic aggregate order, all errors/findings, replay, and exact-head checks.
- Point repository active-work contract to Project #8.
- Leave all three installed scheduled tasks and production runtime unchanged.

## Capacity evidence

- Existing loopback gateway accepted four overlapping baseline requests.
- Two simulated PR groups reached eight overlapping requests.
- Observed transport responses were HTTP 200 with no 429, timeout, auth failure, or gateway outage.
- One response failed strict evidence binding and remained technical/fail-closed, matching existing retryable behavior.

## Verification

- Focused semantic/review-event suite: 84 passed.
- Required source proof: Ruff lint/format/C901, strict mypy, import contracts, 324 passed with 2 skipped, compileall.
- Wheel SHA-256: `bd568c84039f8d5f08ab0bb09d636ad635497f8434cbdac1624f4ea05197c8b1`.
- Exact locked fresh Python 3.12 install and `supportability-gate --help`: passed.
- Immutable Standard tamper test and exact hash: passed.
- Generated build/cache/temp artifacts removed.

## Runtime boundary clarification

S00 changes source and proves the candidate exact-pull worker, but does not install that candidate into any scheduled task. The three unchanged tasks continue running the previously installed reconciliation runtime. S01 adds the dispatcher. S02 atomically installs the merged dispatcher/worker wheel and replaces the legacy task invocations, so no installed production invocation ever runs the new worker without --pull-number.