### PR TITLE
S01: add installation-wide semantic dispatcher

### DIFF
--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -37,6 +37,13 @@
     },
     {
       "covers": [
+        "src/supportability_gate/semantic_dispatch.py"
+      ],
+      "id": "semantic-dispatch",
+      "kind": "regression"
+    },
+    {
+      "covers": [
         "src/supportability_gate/quality_profile.py",
         "src/supportability_gate/reporting.py"
       ],

--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -37,7 +37,8 @@
     },
     {
       "covers": [
-        "src/supportability_gate/semantic_dispatch.py"
+        "src/supportability_gate/semantic_dispatch.py",
+        "src/supportability_gate/semantic_lease.py"
       ],
       "id": "semantic-dispatch",
       "kind": "regression"

--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -38,7 +38,8 @@
     {
       "covers": [
         "src/supportability_gate/semantic_dispatch.py",
-        "src/supportability_gate/semantic_lease.py"
+        "src/supportability_gate/semantic_lease.py",
+        "src/supportability_gate/semantic_result.py"
       ],
       "id": "semantic-dispatch",
       "kind": "regression"

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -5,7 +5,7 @@ architecture_judgment = "PASS"
 base_sha = "d6c17ce518a1e2e3b4ff5a7642ee5b6b266ec660"
 overall_result = "PASS"
 responsibility_changes = [
-    "semantic_dispatch owns App-selected repository discovery, exact-head eligibility, fair queueing, isolated trusted worker launch, and bounded process monitoring; the existing exact-pull worker retains evidence, review, replay, and check publication.",
+    "semantic_dispatch owns App-selected repository discovery, exact-head eligibility, fair queueing, isolated trusted worker launch, bounded process monitoring, and publication-lease revocation; the existing exact-pull worker validates that lease before check publication.",
 ]
 simplified_functions = [
     "Candidate.key",
@@ -14,10 +14,13 @@ simplified_functions = [
     "GitHubApp.installation_repositories",
     "GitHubApp.open_pulls",
     "_candidate",
+    "_finish_worker",
     "_parser",
     "_parser",
     "_shadow",
     "_report_worker",
+    "_require_lease",
+    "_revoke_worker",
     "_terminate_worker",
     "_worker_arguments",
     "discover_candidates",
@@ -60,7 +63,7 @@ citations = ["src/supportability_gate/semantic_contract.py:20-22", "src/supporta
 [[completion_report.claims]]
 id = "claim-exact-head-readiness"
 text = "A pull becomes eligible only after one successful exact-head organization-required workflow artifact exists."
-citations = ["src/supportability_gate/github_app.py:401-430", "src/supportability_gate/github_app.py:432-447", "src/supportability_gate/semantic_dispatch.py:90-105"]
+citations = ["src/supportability_gate/github_app.py:401-430", "src/supportability_gate/github_app.py:432-447", "src/supportability_gate/semantic_dispatch.py:91-106"]
 
 [[completion_report.claims]]
 id = "claim-open-pull-pagination"
@@ -70,14 +73,14 @@ citations = ["src/supportability_gate/github_app.py:247-255"]
 [[completion_report.claims]]
 id = "claim-fair-bounded-workers"
 text = "Candidates rotate repository-round-robin after each served pull, duplicate active keys are suppressed, and no more than two fixed worker slots launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:108-133", "src/supportability_gate/semantic_dispatch.py:181-199"]
+citations = ["src/supportability_gate/semantic_dispatch.py:109-134", "src/supportability_gate/semantic_dispatch.py:196-215"]
 
 [[completion_report.claims]]
 id = "claim-safe-process-boundary"
-text = "Each worker uses isolated Python, a trusted working directory, a fixed shell-free argument vector, and captured output; timeout cleanup requests termination and fails closed after two bounded waits when the OS does not confirm exit."
-citations = ["src/supportability_gate/semantic_dispatch.py:136-178", "src/supportability_gate/semantic_dispatch.py:202-262", "src/supportability_gate/semantic_dispatch.py:285-318"]
+text = "Each worker uses isolated Python, an absolute key path, a trusted working directory, captured output, and a publication lease. An unconfirmed exit revokes that lease, gives every sibling one bounded termination sequence, and returns a technical failure; a revoked worker cannot publish a verdict."
+citations = ["src/supportability_gate/semantic_cli.py:102-120", "src/supportability_gate/semantic_dispatch.py:137-194", "src/supportability_gate/semantic_dispatch.py:217-302", "src/supportability_gate/semantic_dispatch.py:324-357"]
 
 [[completion_report.claims]]
 id = "claim-shadow-no-publish"
 text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:265-282", "src/supportability_gate/semantic_dispatch.py:285-318"]
+citations = ["src/supportability_gate/semantic_dispatch.py:304-321", "src/supportability_gate/semantic_dispatch.py:324-357"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -12,6 +12,7 @@ simplified_functions = [
     "GitHubApp._handoff_runs",
     "GitHubApp.handoff_ready",
     "GitHubApp.installation_repositories",
+    "GitHubApp.open_pulls",
     "_candidate",
     "_parser",
     "_parser",
@@ -57,7 +58,12 @@ citations = ["src/supportability_gate/github_app.py:207-241"]
 [[completion_report.claims]]
 id = "claim-exact-head-readiness"
 text = "A pull becomes eligible only after one successful exact-head organization-required workflow artifact exists."
-citations = ["src/supportability_gate/github_app.py:396-425", "src/supportability_gate/github_app.py:427-442", "src/supportability_gate/semantic_dispatch.py:83-98"]
+citations = ["src/supportability_gate/github_app.py:397-426", "src/supportability_gate/github_app.py:428-443", "src/supportability_gate/semantic_dispatch.py:83-98"]
+
+[[completion_report.claims]]
+id = "claim-open-pull-pagination"
+text = "Every selected repository's open pulls are fully paginated and duplicate pull identities fail closed before queueing."
+citations = ["src/supportability_gate/github_app.py:243-251"]
 
 [[completion_report.claims]]
 id = "claim-fair-bounded-workers"
@@ -67,9 +73,9 @@ citations = ["src/supportability_gate/semantic_dispatch.py:101-126", "src/suppor
 [[completion_report.claims]]
 id = "claim-safe-process-boundary"
 text = "Each worker uses a fixed shell-free argument vector with captured output and is killed after the fixed finite timeout."
-citations = ["src/supportability_gate/semantic_dispatch.py:129-169", "src/supportability_gate/semantic_dispatch.py:193-233"]
+citations = ["src/supportability_gate/semantic_dispatch.py:129-169", "src/supportability_gate/semantic_dispatch.py:193-238"]
 
 [[completion_report.claims]]
 id = "claim-shadow-no-publish"
 text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:236-253", "src/supportability_gate/semantic_dispatch.py:256-283"]
+citations = ["src/supportability_gate/semantic_dispatch.py:241-258", "src/supportability_gate/semantic_dispatch.py:261-292"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -59,14 +59,14 @@ citations = ["src/supportability_gate/github_app.py:419-434", "src/supportabilit
 [[completion_report.claims]]
 id = "claim-fair-bounded-workers"
 text = "Candidates are ordered repository-round-robin with oldest pulls first, then deduplicated and launched only into two fixed worker slots."
-citations = ["src/supportability_gate/semantic_dispatch.py:90-106", "src/supportability_gate/semantic_dispatch.py:143-156"]
+citations = ["src/supportability_gate/semantic_dispatch.py:90-115", "src/supportability_gate/semantic_dispatch.py:152-167"]
 
 [[completion_report.claims]]
 id = "claim-safe-process-boundary"
 text = "Each worker uses a fixed shell-free argument vector with captured output and is killed after the fixed finite timeout."
-citations = ["src/supportability_gate/semantic_dispatch.py:109-140", "src/supportability_gate/semantic_dispatch.py:159-183"]
+citations = ["src/supportability_gate/semantic_dispatch.py:118-149", "src/supportability_gate/semantic_dispatch.py:170-194"]
 
 [[completion_report.claims]]
 id = "claim-shadow-no-publish"
 text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:186-203", "src/supportability_gate/semantic_dispatch.py:206-226"]
+citations = ["src/supportability_gate/semantic_dispatch.py:197-214", "src/supportability_gate/semantic_dispatch.py:217-244"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -5,7 +5,7 @@ architecture_judgment = "PASS"
 base_sha = "d6c17ce518a1e2e3b4ff5a7642ee5b6b266ec660"
 overall_result = "PASS"
 responsibility_changes = [
-    "semantic_dispatch owns App-selected repository discovery, exact-generation replay suppression, fair queueing, isolated trusted worker launch, bounded process monitoring, and final check publication after confirmed worker exit; exact-pull workers can only write bounded deferred results.",
+    "semantic_dispatch owns App-selected repository discovery, exact-generation replay suppression, fair queueing, isolated trusted worker launch, and bounded process monitoring; semantic_result owns deferred-result validation and final check publication after confirmed successful worker exit.",
 ]
 simplified_functions = [
     "Candidate.key",
@@ -35,14 +35,14 @@ simplified_functions = [
     "launch_worker",
     "main",
     "main",
-    "_publish_worker_result",
+    "publish_worker_result",
     "pull_lock_path",
     "reap_workers",
     "run_dispatch_loop",
     "unresolved_review_blocks",
 ]
 boundary_rationale = [
-    "semantic_cli and semantic_dispatch share the focused semantic_lease exact-pull identity; workers write bounded deferred results and the dispatcher alone validates and publishes them under that lock after confirmed exit.",
+    "semantic_cli and semantic_result share the focused semantic_lease exact-pull identity; workers write bounded deferred results, while semantic_result validates and publishes them under that lock only after the dispatcher confirms a successful exit.",
 ]
 remaining_risks = [
     "Production remains on legacy per-repository tasks until separately authorized S02 cutover; dispatcher throughput is intentionally capped at two active pull workers.",
@@ -72,7 +72,7 @@ citations = ["src/supportability_gate/semantic_contract.py:20-22", "src/supporta
 [[completion_report.claims]]
 id = "claim-exact-head-readiness"
 text = "A pull becomes eligible only after one successful exact-head organization-required workflow artifact exists."
-citations = ["src/supportability_gate/github_app.py:401-430", "src/supportability_gate/github_app.py:432-447", "src/supportability_gate/semantic_dispatch.py:97-117"]
+citations = ["src/supportability_gate/github_app.py:401-433", "src/supportability_gate/github_app.py:435-450", "src/supportability_gate/semantic_dispatch.py:97-117"]
 
 [[completion_report.claims]]
 id = "claim-exact-generation-deduplication"
@@ -91,10 +91,10 @@ citations = ["src/supportability_gate/semantic_dispatch.py:120-145", "src/suppor
 
 [[completion_report.claims]]
 id = "claim-safe-process-boundary"
-text = "Each worker uses isolated Python, an absolute key path, a trusted working directory, and captured output. Workers size-bound deferred results but cannot complete checks; only the dispatcher validates the exact evidence digest, reacquires the exact-pull lock, reasserts current state, and publishes after confirmed process exit. A timed-out or unconfirmed surviving worker therefore has no final-check publication path."
-citations = ["src/supportability_gate/semantic_cli.py:97-133", "src/supportability_gate/semantic_lease.py:47-63", "src/supportability_gate/semantic_dispatch.py:148-215", "src/supportability_gate/semantic_dispatch.py:280-354", "src/supportability_gate/semantic_dispatch.py:377-410"]
+text = "Each worker uses isolated Python, an absolute key path, a trusted working directory, and captured output. Workers size-bound deferred results but cannot complete checks; the dispatcher rejects timeout and nonzero exits, then semantic_result validates the exact evidence digest, reacquires the exact-pull lock, reasserts current state, and publishes. A timed-out, failed, or unconfirmed surviving worker therefore has no final-check publication path."
+citations = ["src/supportability_gate/semantic_cli.py:97-133", "src/supportability_gate/semantic_lease.py:47-63", "src/supportability_gate/semantic_dispatch.py:148-215", "src/supportability_gate/semantic_dispatch.py:239-328", "src/supportability_gate/semantic_result.py:18-52"]
 
 [[completion_report.claims]]
 id = "claim-shadow-no-publish"
 text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:357-374", "src/supportability_gate/semantic_dispatch.py:377-410"]
+citations = ["src/supportability_gate/semantic_dispatch.py:331-348", "src/supportability_gate/semantic_dispatch.py:351-384"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -73,7 +73,7 @@ citations = ["src/supportability_gate/github_app.py:401-430", "src/supportabilit
 
 [[completion_report.claims]]
 id = "claim-exact-generation-deduplication"
-text = "Discovery excludes a completed current evidence generation, while changed head, authority, or review state produces a different generation eligible for review."
+text = "Discovery excludes a completed exact evidence generation before worker launch."
 citations = ["src/supportability_gate/semantic_dispatch.py:92-112"]
 
 [[completion_report.claims]]
@@ -84,14 +84,14 @@ citations = ["src/supportability_gate/github_app.py:247-255"]
 [[completion_report.claims]]
 id = "claim-fair-bounded-workers"
 text = "Candidates rotate repository-round-robin after each served pull, duplicate active keys are suppressed, and no more than two fixed worker slots launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:110-135", "src/supportability_gate/semantic_dispatch.py:197-215"]
+citations = ["src/supportability_gate/semantic_dispatch.py:115-140", "src/supportability_gate/semantic_dispatch.py:206-224"]
 
 [[completion_report.claims]]
 id = "claim-safe-process-boundary"
-text = "Each worker uses isolated Python, an absolute key path, a trusted working directory, captured output, and a writable credential-directory publication lease. An unconfirmed exit attempts lease revocation, gives every process one bounded termination sequence even when revocation fails, and returns a technical failure; a revoked worker cannot publish a verdict."
-citations = ["src/supportability_gate/semantic_cli.py:101-114", "src/supportability_gate/semantic_lease.py:60-95", "src/supportability_gate/semantic_dispatch.py:143-203", "src/supportability_gate/semantic_dispatch.py:227-317", "src/supportability_gate/semantic_dispatch.py:340-373"]
+text = "Each worker uses isolated Python, an absolute key path, a trusted working directory, captured output, and a writable credential-directory publication lease. An unconfirmed exit independently marks future publication revoked before one bounded termination sequence, so even a surviving process cannot reacquire publication authority."
+citations = ["src/supportability_gate/semantic_cli.py:101-114", "src/supportability_gate/semantic_lease.py:59-80", "src/supportability_gate/semantic_dispatch.py:143-203", "src/supportability_gate/semantic_dispatch.py:227-320", "src/supportability_gate/semantic_dispatch.py:343-376"]
 
 [[completion_report.claims]]
 id = "claim-shadow-no-publish"
 text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:320-337", "src/supportability_gate/semantic_dispatch.py:340-373"]
+citations = ["src/supportability_gate/semantic_dispatch.py:321-338", "src/supportability_gate/semantic_dispatch.py:341-374"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -5,7 +5,7 @@ architecture_judgment = "PASS"
 base_sha = "d6c17ce518a1e2e3b4ff5a7642ee5b6b266ec660"
 overall_result = "PASS"
 responsibility_changes = [
-    "semantic_dispatch owns App-selected repository discovery, exact-head eligibility, fair queueing, isolated trusted worker launch, bounded process monitoring, and publication-lease revocation; the existing exact-pull worker validates that lease before check publication.",
+    "semantic_dispatch owns App-selected repository discovery, exact-generation replay suppression, fair queueing, isolated trusted worker launch, bounded process monitoring, and publication-lease revocation; the existing exact-pull worker validates that lease before check publication.",
 ]
 simplified_functions = [
     "Candidate.key",
@@ -69,7 +69,12 @@ citations = ["src/supportability_gate/semantic_contract.py:20-22", "src/supporta
 [[completion_report.claims]]
 id = "claim-exact-head-readiness"
 text = "A pull becomes eligible only after one successful exact-head organization-required workflow artifact exists."
-citations = ["src/supportability_gate/github_app.py:401-430", "src/supportability_gate/github_app.py:432-447", "src/supportability_gate/semantic_dispatch.py:92-107"]
+citations = ["src/supportability_gate/github_app.py:401-430", "src/supportability_gate/github_app.py:432-447", "src/supportability_gate/semantic_dispatch.py:92-112"]
+
+[[completion_report.claims]]
+id = "claim-exact-generation-deduplication"
+text = "Discovery excludes a completed current evidence generation, while changed head, authority, or review state produces a different generation eligible for review."
+citations = ["src/supportability_gate/semantic_dispatch.py:92-112"]
 
 [[completion_report.claims]]
 id = "claim-open-pull-pagination"
@@ -83,10 +88,10 @@ citations = ["src/supportability_gate/semantic_dispatch.py:110-135", "src/suppor
 
 [[completion_report.claims]]
 id = "claim-safe-process-boundary"
-text = "Each worker uses isolated Python, an absolute key path, a trusted working directory, captured output, and a publication lease. An unconfirmed exit revokes that lease, gives every sibling one bounded termination sequence, and returns a technical failure; a revoked worker cannot publish a verdict."
-citations = ["src/supportability_gate/semantic_cli.py:101-114", "src/supportability_gate/semantic_lease.py:60-95", "src/supportability_gate/semantic_dispatch.py:138-194", "src/supportability_gate/semantic_dispatch.py:218-305", "src/supportability_gate/semantic_dispatch.py:328-361"]
+text = "Each worker uses isolated Python, an absolute key path, a trusted working directory, captured output, and a writable credential-directory publication lease. An unconfirmed exit attempts lease revocation, gives every process one bounded termination sequence even when revocation fails, and returns a technical failure; a revoked worker cannot publish a verdict."
+citations = ["src/supportability_gate/semantic_cli.py:101-114", "src/supportability_gate/semantic_lease.py:60-95", "src/supportability_gate/semantic_dispatch.py:143-203", "src/supportability_gate/semantic_dispatch.py:227-317", "src/supportability_gate/semantic_dispatch.py:340-373"]
 
 [[completion_report.claims]]
 id = "claim-shadow-no-publish"
 text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:308-325", "src/supportability_gate/semantic_dispatch.py:328-361"]
+citations = ["src/supportability_gate/semantic_dispatch.py:320-337", "src/supportability_gate/semantic_dispatch.py:340-373"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -2,28 +2,32 @@ schema_version = "1.0"
 
 [completion_report]
 architecture_judgment = "PASS"
-base_sha = "377528d08fcc3a251512f3cff402be5d19751835"
+base_sha = "d6c17ce518a1e2e3b4ff5a7642ee5b6b266ec660"
 overall_result = "PASS"
 responsibility_changes = [
-    "One exact pull worker owns its repository/PR lock, runs four specialists concurrently per round, preserves the round barrier, and rejects deterministic completion defects before model transport.",
+    "semantic_dispatch owns App-selected repository discovery, exact-head eligibility, fair queueing, fixed worker launch, and bounded process monitoring; the existing exact-pull worker retains evidence, review, replay, and check publication.",
 ]
 simplified_functions = [
-    "GitHubApp.assert_current",
-    "GitHubApp.pull",
-    "_ensemble_summary",
-    "_evaluation_lock",
+    "Candidate.key",
+    "GitHubApp.handoff_ready",
+    "GitHubApp.installation_repositories",
+    "_candidate",
     "_parser",
-    "_pull_lock_path",
-    "_review",
-    "_review_attempt",
-    "_review_round",
+    "_run",
+    "_shadow",
+    "_worker_arguments",
+    "discover_candidates",
+    "fair_order",
+    "fill_slots",
+    "launch_worker",
     "main",
+    "reap_workers",
 ]
 boundary_rationale = [
-    "semantic_cli owns exact-pull execution and concurrency; GitHubApp owns authenticated pull state; existing transport, evidence, parsing, replay, and check publication remain unchanged.",
+    "semantic_dispatch depends on GitHubApp and launches semantic_cli by fixed module argument vector; neither GitHubApp nor the exact-pull worker depends on dispatcher orchestration.",
 ]
 remaining_risks = [
-    "Throughput remains capped by gateway latency and future dispatcher capacity; transport or parser failure still prevents PASS.",
+    "Production remains on legacy per-repository tasks until separately authorized S02 cutover; dispatcher throughput is intentionally capped at two active pull workers.",
 ]
 validation_results = [
     { adapter = "python.ruff-lint.v1", arguments = ["$PYTHON", "-I", "-m", "ruff", "check", "$SOURCE_FILES", "$TEST_FILES", "--select", "E4,E7,E9,F,I,UP", "--line-length", "100", "--target-version", "py312", "--isolated", "--no-cache"], exit_code = 0 },
@@ -43,21 +47,26 @@ gate_coverage = [
 ]
 
 [[completion_report.claims]]
-id = "claim-concurrent-rounds"
-text = "Each round submits all four fixed specialist profiles concurrently, then collects every result in deterministic profile order before the next round starts."
-citations = ["src/supportability_gate/semantic_cli.py:190-221"]
+id = "claim-app-selected-pagination"
+text = "Repository discovery paginates until the authenticated installation total is complete and rejects malformed or incomplete pages."
+citations = ["src/supportability_gate/github_app.py:207-237"]
 
 [[completion_report.claims]]
-id = "claim-exact-pull-isolation"
-text = "Repository identity is case-normalized and combined with the pull number to select one stable per-PR lock."
-citations = ["src/supportability_gate/semantic_cli.py:157-160"]
+id = "claim-exact-head-readiness"
+text = "A pull becomes eligible only after one successful exact-head organization-required workflow artifact exists."
+citations = ["src/supportability_gate/github_app.py:419-434", "src/supportability_gate/semantic_dispatch.py:72-87"]
 
 [[completion_report.claims]]
-id = "claim-fast-deterministic-preflight"
-text = "Deterministic completion-report defects publish action-required and return before any specialist request begins."
-citations = ["src/supportability_gate/semantic_cli.py:257-279"]
+id = "claim-fair-bounded-workers"
+text = "Candidates are ordered repository-round-robin with oldest pulls first, then deduplicated and launched only into two fixed worker slots."
+citations = ["src/supportability_gate/semantic_dispatch.py:90-106", "src/supportability_gate/semantic_dispatch.py:143-156"]
 
 [[completion_report.claims]]
-id = "claim-stale-pull-rejection"
-text = "Closed pulls and pull state changes are rejected before evaluation or trusted publication."
-citations = ["src/supportability_gate/github_app.py:216-257"]
+id = "claim-safe-process-boundary"
+text = "Each worker uses a fixed shell-free argument vector with captured output and is killed after the fixed finite timeout."
+citations = ["src/supportability_gate/semantic_dispatch.py:109-140", "src/supportability_gate/semantic_dispatch.py:159-183"]
+
+[[completion_report.claims]]
+id = "claim-shadow-no-publish"
+text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
+citations = ["src/supportability_gate/semantic_dispatch.py:186-203", "src/supportability_gate/semantic_dispatch.py:206-226"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -17,6 +17,7 @@ simplified_functions = [
     "_parser",
     "_parser",
     "_shadow",
+    "_terminate_worker",
     "_worker_arguments",
     "discover_candidates",
     "fair_order",
@@ -73,9 +74,9 @@ citations = ["src/supportability_gate/semantic_dispatch.py:101-126", "src/suppor
 [[completion_report.claims]]
 id = "claim-safe-process-boundary"
 text = "Each worker uses a fixed shell-free argument vector with captured output and is killed after the fixed finite timeout."
-citations = ["src/supportability_gate/semantic_dispatch.py:129-169", "src/supportability_gate/semantic_dispatch.py:193-238"]
+citations = ["src/supportability_gate/semantic_dispatch.py:129-169", "src/supportability_gate/semantic_dispatch.py:193-242"]
 
 [[completion_report.claims]]
 id = "claim-shadow-no-publish"
 text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:241-258", "src/supportability_gate/semantic_dispatch.py:261-292"]
+citations = ["src/supportability_gate/semantic_dispatch.py:245-262", "src/supportability_gate/semantic_dispatch.py:265-296"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -5,7 +5,7 @@ architecture_judgment = "PASS"
 base_sha = "d6c17ce518a1e2e3b4ff5a7642ee5b6b266ec660"
 overall_result = "PASS"
 responsibility_changes = [
-    "semantic_dispatch owns App-selected repository discovery, exact-head eligibility, fair queueing, fixed worker launch, and bounded process monitoring; the existing exact-pull worker retains evidence, review, replay, and check publication.",
+    "semantic_dispatch owns App-selected repository discovery, exact-head eligibility, fair queueing, isolated trusted worker launch, and bounded process monitoring; the existing exact-pull worker retains evidence, review, replay, and check publication.",
 ]
 simplified_functions = [
     "Candidate.key",
@@ -55,29 +55,29 @@ gate_coverage = [
 [[completion_report.claims]]
 id = "claim-app-selected-pagination"
 text = "Repository discovery paginates until the authenticated installation total is complete and rejects malformed or incomplete pages."
-citations = ["src/supportability_gate/github_app.py:207-241"]
+citations = ["src/supportability_gate/semantic_contract.py:20-22", "src/supportability_gate/github_app.py:208-245"]
 
 [[completion_report.claims]]
 id = "claim-exact-head-readiness"
 text = "A pull becomes eligible only after one successful exact-head organization-required workflow artifact exists."
-citations = ["src/supportability_gate/github_app.py:397-426", "src/supportability_gate/github_app.py:428-443", "src/supportability_gate/semantic_dispatch.py:83-98"]
+citations = ["src/supportability_gate/github_app.py:401-430", "src/supportability_gate/github_app.py:432-447", "src/supportability_gate/semantic_dispatch.py:90-105"]
 
 [[completion_report.claims]]
 id = "claim-open-pull-pagination"
 text = "Every selected repository's open pulls are fully paginated and duplicate pull identities fail closed before queueing."
-citations = ["src/supportability_gate/github_app.py:243-251"]
+citations = ["src/supportability_gate/github_app.py:247-255"]
 
 [[completion_report.claims]]
 id = "claim-fair-bounded-workers"
 text = "Candidates rotate repository-round-robin after each served pull, duplicate active keys are suppressed, and no more than two fixed worker slots launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:101-126", "src/supportability_gate/semantic_dispatch.py:172-190"]
+citations = ["src/supportability_gate/semantic_dispatch.py:108-133", "src/supportability_gate/semantic_dispatch.py:181-199"]
 
 [[completion_report.claims]]
 id = "claim-safe-process-boundary"
-text = "Each worker uses a fixed shell-free argument vector with captured output; timeout cleanup requests termination and fails closed after two bounded waits when the OS does not confirm exit."
-citations = ["src/supportability_gate/semantic_dispatch.py:129-169", "src/supportability_gate/semantic_dispatch.py:193-247", "src/supportability_gate/semantic_dispatch.py:270-298"]
+text = "Each worker uses isolated Python, a trusted working directory, a fixed shell-free argument vector, and captured output; timeout cleanup requests termination and fails closed after two bounded waits when the OS does not confirm exit."
+citations = ["src/supportability_gate/semantic_dispatch.py:136-178", "src/supportability_gate/semantic_dispatch.py:202-262", "src/supportability_gate/semantic_dispatch.py:285-318"]
 
 [[completion_report.claims]]
 id = "claim-shadow-no-publish"
 text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:250-267", "src/supportability_gate/semantic_dispatch.py:270-298"]
+citations = ["src/supportability_gate/semantic_dispatch.py:265-282", "src/supportability_gate/semantic_dispatch.py:285-318"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -15,6 +15,7 @@ simplified_functions = [
     "GitHubApp.open_pulls",
     "_candidate",
     "_complete_current_check",
+    "_conclude_current_check",
     "_evaluation_lock",
     "_finish_worker",
     "_lock",
@@ -26,6 +27,7 @@ simplified_functions = [
     "_terminate_worker",
     "_unlock",
     "_worker_arguments",
+    "_write_deferred_result",
     "discover_candidates",
     "exclusive_lease",
     "fair_order",
@@ -34,12 +36,13 @@ simplified_functions = [
     "main",
     "main",
     "_publish_worker_result",
+    "pull_lock_path",
     "reap_workers",
     "run_dispatch_loop",
     "unresolved_review_blocks",
 ]
 boundary_rationale = [
-    "semantic_cli depends on the focused semantic_lease primitive for exact-pull exclusion and writes deferred results; semantic_dispatch alone validates and publishes them after confirmed worker exit.",
+    "semantic_cli and semantic_dispatch share the focused semantic_lease exact-pull identity; workers write bounded deferred results and the dispatcher alone validates and publishes them under that lock after confirmed exit.",
 ]
 remaining_risks = [
     "Production remains on legacy per-repository tasks until separately authorized S02 cutover; dispatcher throughput is intentionally capped at two active pull workers.",
@@ -69,12 +72,12 @@ citations = ["src/supportability_gate/semantic_contract.py:20-22", "src/supporta
 [[completion_report.claims]]
 id = "claim-exact-head-readiness"
 text = "A pull becomes eligible only after one successful exact-head organization-required workflow artifact exists."
-citations = ["src/supportability_gate/github_app.py:401-430", "src/supportability_gate/github_app.py:432-447", "src/supportability_gate/semantic_dispatch.py:95-115"]
+citations = ["src/supportability_gate/github_app.py:401-430", "src/supportability_gate/github_app.py:432-447", "src/supportability_gate/semantic_dispatch.py:97-117"]
 
 [[completion_report.claims]]
 id = "claim-exact-generation-deduplication"
 text = "Discovery excludes a completed exact evidence generation before worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:95-115"]
+citations = ["src/supportability_gate/semantic_dispatch.py:97-117"]
 
 [[completion_report.claims]]
 id = "claim-open-pull-pagination"
@@ -84,14 +87,14 @@ citations = ["src/supportability_gate/github_app.py:247-255"]
 [[completion_report.claims]]
 id = "claim-fair-bounded-workers"
 text = "Candidates rotate repository-round-robin after each served pull, duplicate active keys are suppressed, and no more than two fixed worker slots launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:118-143", "src/supportability_gate/semantic_dispatch.py:208-226"]
+citations = ["src/supportability_gate/semantic_dispatch.py:120-145", "src/supportability_gate/semantic_dispatch.py:218-236"]
 
 [[completion_report.claims]]
 id = "claim-safe-process-boundary"
-text = "Each worker uses isolated Python, an absolute key path, a trusted working directory, and captured output. Workers write bounded deferred results but cannot complete checks; only the dispatcher validates the exact evidence digest, reasserts current state, and publishes after confirmed process exit. A timed-out or unconfirmed surviving worker therefore has no final-check publication path."
-citations = ["src/supportability_gate/semantic_cli.py:86-112", "src/supportability_gate/semantic_dispatch.py:146-205", "src/supportability_gate/semantic_dispatch.py:229-336", "src/supportability_gate/semantic_dispatch.py:359-392"]
+text = "Each worker uses isolated Python, an absolute key path, a trusted working directory, and captured output. Workers size-bound deferred results but cannot complete checks; only the dispatcher validates the exact evidence digest, reacquires the exact-pull lock, reasserts current state, and publishes after confirmed process exit. A timed-out or unconfirmed surviving worker therefore has no final-check publication path."
+citations = ["src/supportability_gate/semantic_cli.py:97-133", "src/supportability_gate/semantic_lease.py:47-63", "src/supportability_gate/semantic_dispatch.py:148-215", "src/supportability_gate/semantic_dispatch.py:280-354", "src/supportability_gate/semantic_dispatch.py:377-410"]
 
 [[completion_report.claims]]
 id = "claim-shadow-no-publish"
 text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:339-356", "src/supportability_gate/semantic_dispatch.py:359-392"]
+citations = ["src/supportability_gate/semantic_dispatch.py:357-374", "src/supportability_gate/semantic_dispatch.py:377-410"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -9,11 +9,12 @@ responsibility_changes = [
 ]
 simplified_functions = [
     "Candidate.key",
+    "GitHubApp._handoff_runs",
     "GitHubApp.handoff_ready",
     "GitHubApp.installation_repositories",
     "_candidate",
     "_parser",
-    "_run",
+    "_parser",
     "_shadow",
     "_worker_arguments",
     "discover_candidates",
@@ -21,7 +22,9 @@ simplified_functions = [
     "fill_slots",
     "launch_worker",
     "main",
+    "main",
     "reap_workers",
+    "run_dispatch_loop",
 ]
 boundary_rationale = [
     "semantic_dispatch depends on GitHubApp and launches semantic_cli by fixed module argument vector; neither GitHubApp nor the exact-pull worker depends on dispatcher orchestration.",
@@ -49,24 +52,24 @@ gate_coverage = [
 [[completion_report.claims]]
 id = "claim-app-selected-pagination"
 text = "Repository discovery paginates until the authenticated installation total is complete and rejects malformed or incomplete pages."
-citations = ["src/supportability_gate/github_app.py:207-237"]
+citations = ["src/supportability_gate/github_app.py:207-241"]
 
 [[completion_report.claims]]
 id = "claim-exact-head-readiness"
 text = "A pull becomes eligible only after one successful exact-head organization-required workflow artifact exists."
-citations = ["src/supportability_gate/github_app.py:419-434", "src/supportability_gate/semantic_dispatch.py:72-87"]
+citations = ["src/supportability_gate/github_app.py:396-425", "src/supportability_gate/github_app.py:427-442", "src/supportability_gate/semantic_dispatch.py:83-98"]
 
 [[completion_report.claims]]
 id = "claim-fair-bounded-workers"
-text = "Candidates are ordered repository-round-robin with oldest pulls first, then deduplicated and launched only into two fixed worker slots."
-citations = ["src/supportability_gate/semantic_dispatch.py:90-115", "src/supportability_gate/semantic_dispatch.py:152-167"]
+text = "Candidates rotate repository-round-robin after each served pull, duplicate active keys are suppressed, and no more than two fixed worker slots launch."
+citations = ["src/supportability_gate/semantic_dispatch.py:101-126", "src/supportability_gate/semantic_dispatch.py:172-190"]
 
 [[completion_report.claims]]
 id = "claim-safe-process-boundary"
 text = "Each worker uses a fixed shell-free argument vector with captured output and is killed after the fixed finite timeout."
-citations = ["src/supportability_gate/semantic_dispatch.py:118-149", "src/supportability_gate/semantic_dispatch.py:170-194"]
+citations = ["src/supportability_gate/semantic_dispatch.py:129-169", "src/supportability_gate/semantic_dispatch.py:193-233"]
 
 [[completion_report.claims]]
 id = "claim-shadow-no-publish"
 text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:197-214", "src/supportability_gate/semantic_dispatch.py:217-244"]
+citations = ["src/supportability_gate/semantic_dispatch.py:236-253", "src/supportability_gate/semantic_dispatch.py:256-283"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -14,26 +14,32 @@ simplified_functions = [
     "GitHubApp.installation_repositories",
     "GitHubApp.open_pulls",
     "_candidate",
+    "_complete_current_check",
+    "_evaluation_lock",
     "_finish_worker",
+    "_lock",
     "_parser",
     "_parser",
-    "_shadow",
     "_report_worker",
-    "_require_lease",
     "_revoke_worker",
+    "_shadow",
     "_terminate_worker",
+    "_unlock",
     "_worker_arguments",
     "discover_candidates",
+    "exclusive_lease",
     "fair_order",
     "fill_slots",
     "launch_worker",
     "main",
     "main",
+    "publication_lease",
     "reap_workers",
+    "revoke_publication_lease",
     "run_dispatch_loop",
 ]
 boundary_rationale = [
-    "semantic_dispatch depends on GitHubApp and launches semantic_cli by fixed module argument vector; neither GitHubApp nor the exact-pull worker depends on dispatcher orchestration.",
+    "semantic_dispatch and semantic_cli depend on the focused semantic_lease primitive; neither GitHubApp nor the exact-pull worker depends on dispatcher orchestration.",
 ]
 remaining_risks = [
     "Production remains on legacy per-repository tasks until separately authorized S02 cutover; dispatcher throughput is intentionally capped at two active pull workers.",
@@ -63,7 +69,7 @@ citations = ["src/supportability_gate/semantic_contract.py:20-22", "src/supporta
 [[completion_report.claims]]
 id = "claim-exact-head-readiness"
 text = "A pull becomes eligible only after one successful exact-head organization-required workflow artifact exists."
-citations = ["src/supportability_gate/github_app.py:401-430", "src/supportability_gate/github_app.py:432-447", "src/supportability_gate/semantic_dispatch.py:91-106"]
+citations = ["src/supportability_gate/github_app.py:401-430", "src/supportability_gate/github_app.py:432-447", "src/supportability_gate/semantic_dispatch.py:92-107"]
 
 [[completion_report.claims]]
 id = "claim-open-pull-pagination"
@@ -73,14 +79,14 @@ citations = ["src/supportability_gate/github_app.py:247-255"]
 [[completion_report.claims]]
 id = "claim-fair-bounded-workers"
 text = "Candidates rotate repository-round-robin after each served pull, duplicate active keys are suppressed, and no more than two fixed worker slots launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:109-134", "src/supportability_gate/semantic_dispatch.py:196-215"]
+citations = ["src/supportability_gate/semantic_dispatch.py:110-135", "src/supportability_gate/semantic_dispatch.py:197-215"]
 
 [[completion_report.claims]]
 id = "claim-safe-process-boundary"
 text = "Each worker uses isolated Python, an absolute key path, a trusted working directory, captured output, and a publication lease. An unconfirmed exit revokes that lease, gives every sibling one bounded termination sequence, and returns a technical failure; a revoked worker cannot publish a verdict."
-citations = ["src/supportability_gate/semantic_cli.py:102-120", "src/supportability_gate/semantic_dispatch.py:137-194", "src/supportability_gate/semantic_dispatch.py:217-302", "src/supportability_gate/semantic_dispatch.py:324-357"]
+citations = ["src/supportability_gate/semantic_cli.py:101-114", "src/supportability_gate/semantic_lease.py:60-95", "src/supportability_gate/semantic_dispatch.py:138-194", "src/supportability_gate/semantic_dispatch.py:218-305", "src/supportability_gate/semantic_dispatch.py:328-361"]
 
 [[completion_report.claims]]
 id = "claim-shadow-no-publish"
 text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:304-321", "src/supportability_gate/semantic_dispatch.py:324-357"]
+citations = ["src/supportability_gate/semantic_dispatch.py:308-325", "src/supportability_gate/semantic_dispatch.py:328-361"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -36,6 +36,7 @@ simplified_functions = [
     "_publish_worker_result",
     "reap_workers",
     "run_dispatch_loop",
+    "unresolved_review_blocks",
 ]
 boundary_rationale = [
     "semantic_cli depends on the focused semantic_lease primitive for exact-pull exclusion and writes deferred results; semantic_dispatch alone validates and publishes them after confirmed worker exit.",
@@ -68,12 +69,12 @@ citations = ["src/supportability_gate/semantic_contract.py:20-22", "src/supporta
 [[completion_report.claims]]
 id = "claim-exact-head-readiness"
 text = "A pull becomes eligible only after one successful exact-head organization-required workflow artifact exists."
-citations = ["src/supportability_gate/github_app.py:401-430", "src/supportability_gate/github_app.py:432-447", "src/supportability_gate/semantic_dispatch.py:94-114"]
+citations = ["src/supportability_gate/github_app.py:401-430", "src/supportability_gate/github_app.py:432-447", "src/supportability_gate/semantic_dispatch.py:95-115"]
 
 [[completion_report.claims]]
 id = "claim-exact-generation-deduplication"
 text = "Discovery excludes a completed exact evidence generation before worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:94-114"]
+citations = ["src/supportability_gate/semantic_dispatch.py:95-115"]
 
 [[completion_report.claims]]
 id = "claim-open-pull-pagination"
@@ -83,14 +84,14 @@ citations = ["src/supportability_gate/github_app.py:247-255"]
 [[completion_report.claims]]
 id = "claim-fair-bounded-workers"
 text = "Candidates rotate repository-round-robin after each served pull, duplicate active keys are suppressed, and no more than two fixed worker slots launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:117-142", "src/supportability_gate/semantic_dispatch.py:207-225"]
+citations = ["src/supportability_gate/semantic_dispatch.py:118-143", "src/supportability_gate/semantic_dispatch.py:208-226"]
 
 [[completion_report.claims]]
 id = "claim-safe-process-boundary"
 text = "Each worker uses isolated Python, an absolute key path, a trusted working directory, and captured output. Workers write bounded deferred results but cannot complete checks; only the dispatcher validates the exact evidence digest, reasserts current state, and publishes after confirmed process exit. A timed-out or unconfirmed surviving worker therefore has no final-check publication path."
-citations = ["src/supportability_gate/semantic_cli.py:102-128", "src/supportability_gate/semantic_dispatch.py:145-204", "src/supportability_gate/semantic_dispatch.py:228-335", "src/supportability_gate/semantic_dispatch.py:358-391"]
+citations = ["src/supportability_gate/semantic_cli.py:86-112", "src/supportability_gate/semantic_dispatch.py:146-205", "src/supportability_gate/semantic_dispatch.py:229-336", "src/supportability_gate/semantic_dispatch.py:359-392"]
 
 [[completion_report.claims]]
 id = "claim-shadow-no-publish"
 text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:338-355", "src/supportability_gate/semantic_dispatch.py:358-391"]
+citations = ["src/supportability_gate/semantic_dispatch.py:339-356", "src/supportability_gate/semantic_dispatch.py:359-392"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -5,7 +5,7 @@ architecture_judgment = "PASS"
 base_sha = "d6c17ce518a1e2e3b4ff5a7642ee5b6b266ec660"
 overall_result = "PASS"
 responsibility_changes = [
-    "semantic_dispatch owns App-selected repository discovery, exact-generation replay suppression, fair queueing, isolated trusted worker launch, bounded process monitoring, and publication-lease revocation; the existing exact-pull worker validates that lease before check publication.",
+    "semantic_dispatch owns App-selected repository discovery, exact-generation replay suppression, fair queueing, isolated trusted worker launch, bounded process monitoring, and final check publication after confirmed worker exit; exact-pull workers can only write bounded deferred results.",
 ]
 simplified_functions = [
     "Candidate.key",
@@ -21,7 +21,7 @@ simplified_functions = [
     "_parser",
     "_parser",
     "_report_worker",
-    "_revoke_worker",
+    "_review",
     "_shadow",
     "_terminate_worker",
     "_unlock",
@@ -33,13 +33,12 @@ simplified_functions = [
     "launch_worker",
     "main",
     "main",
-    "publication_lease",
+    "_publish_worker_result",
     "reap_workers",
-    "revoke_publication_lease",
     "run_dispatch_loop",
 ]
 boundary_rationale = [
-    "semantic_dispatch and semantic_cli depend on the focused semantic_lease primitive; neither GitHubApp nor the exact-pull worker depends on dispatcher orchestration.",
+    "semantic_cli depends on the focused semantic_lease primitive for exact-pull exclusion and writes deferred results; semantic_dispatch alone validates and publishes them after confirmed worker exit.",
 ]
 remaining_risks = [
     "Production remains on legacy per-repository tasks until separately authorized S02 cutover; dispatcher throughput is intentionally capped at two active pull workers.",
@@ -69,12 +68,12 @@ citations = ["src/supportability_gate/semantic_contract.py:20-22", "src/supporta
 [[completion_report.claims]]
 id = "claim-exact-head-readiness"
 text = "A pull becomes eligible only after one successful exact-head organization-required workflow artifact exists."
-citations = ["src/supportability_gate/github_app.py:401-430", "src/supportability_gate/github_app.py:432-447", "src/supportability_gate/semantic_dispatch.py:92-112"]
+citations = ["src/supportability_gate/github_app.py:401-430", "src/supportability_gate/github_app.py:432-447", "src/supportability_gate/semantic_dispatch.py:94-114"]
 
 [[completion_report.claims]]
 id = "claim-exact-generation-deduplication"
 text = "Discovery excludes a completed exact evidence generation before worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:92-112"]
+citations = ["src/supportability_gate/semantic_dispatch.py:94-114"]
 
 [[completion_report.claims]]
 id = "claim-open-pull-pagination"
@@ -84,14 +83,14 @@ citations = ["src/supportability_gate/github_app.py:247-255"]
 [[completion_report.claims]]
 id = "claim-fair-bounded-workers"
 text = "Candidates rotate repository-round-robin after each served pull, duplicate active keys are suppressed, and no more than two fixed worker slots launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:115-140", "src/supportability_gate/semantic_dispatch.py:206-224"]
+citations = ["src/supportability_gate/semantic_dispatch.py:117-142", "src/supportability_gate/semantic_dispatch.py:207-225"]
 
 [[completion_report.claims]]
 id = "claim-safe-process-boundary"
-text = "Each worker uses isolated Python, an absolute key path, a trusted working directory, captured output, and a writable credential-directory publication lease. An unconfirmed exit independently marks future publication revoked before one bounded termination sequence, so even a surviving process cannot reacquire publication authority."
-citations = ["src/supportability_gate/semantic_cli.py:101-114", "src/supportability_gate/semantic_lease.py:59-80", "src/supportability_gate/semantic_dispatch.py:143-203", "src/supportability_gate/semantic_dispatch.py:227-320", "src/supportability_gate/semantic_dispatch.py:343-376"]
+text = "Each worker uses isolated Python, an absolute key path, a trusted working directory, and captured output. Workers write bounded deferred results but cannot complete checks; only the dispatcher validates the exact evidence digest, reasserts current state, and publishes after confirmed process exit. A timed-out or unconfirmed surviving worker therefore has no final-check publication path."
+citations = ["src/supportability_gate/semantic_cli.py:102-128", "src/supportability_gate/semantic_dispatch.py:145-204", "src/supportability_gate/semantic_dispatch.py:228-335", "src/supportability_gate/semantic_dispatch.py:358-391"]
 
 [[completion_report.claims]]
 id = "claim-shadow-no-publish"
 text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:321-338", "src/supportability_gate/semantic_dispatch.py:341-374"]
+citations = ["src/supportability_gate/semantic_dispatch.py:338-355", "src/supportability_gate/semantic_dispatch.py:358-391"]

--- a/.supportability-handoff.toml
+++ b/.supportability-handoff.toml
@@ -17,6 +17,7 @@ simplified_functions = [
     "_parser",
     "_parser",
     "_shadow",
+    "_report_worker",
     "_terminate_worker",
     "_worker_arguments",
     "discover_candidates",
@@ -73,10 +74,10 @@ citations = ["src/supportability_gate/semantic_dispatch.py:101-126", "src/suppor
 
 [[completion_report.claims]]
 id = "claim-safe-process-boundary"
-text = "Each worker uses a fixed shell-free argument vector with captured output and is killed after the fixed finite timeout."
-citations = ["src/supportability_gate/semantic_dispatch.py:129-169", "src/supportability_gate/semantic_dispatch.py:193-242"]
+text = "Each worker uses a fixed shell-free argument vector with captured output; timeout cleanup requests termination and fails closed after two bounded waits when the OS does not confirm exit."
+citations = ["src/supportability_gate/semantic_dispatch.py:129-169", "src/supportability_gate/semantic_dispatch.py:193-247", "src/supportability_gate/semantic_dispatch.py:270-298"]
 
 [[completion_report.claims]]
 id = "claim-shadow-no-publish"
 text = "Shadow mode reports every App-selected repository and eligible pull, then returns before any worker launch."
-citations = ["src/supportability_gate/semantic_dispatch.py:245-262", "src/supportability_gate/semantic_dispatch.py:265-296"]
+citations = ["src/supportability_gate/semantic_dispatch.py:250-267", "src/supportability_gate/semantic_dispatch.py:270-298"]

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0"
 
 [behavior]
-intended_behavior = "One dispatcher discovers every App-selected repository, fairly launches at most two ephemeral exact-pull workers, and publishes only a complete valid deferred ensemble after confirmed worker exit."
+intended_behavior = "One dispatcher discovers every App-selected repository and fairly launches at most two ephemeral exact-pull workers; semantic_result publishes only a complete valid deferred ensemble after confirmed successful worker exit."
 proof = "tests/test_semantic_dispatch.py::test_fill_slots_deduplicates_and_caps_workers"
 
 [characterization]
@@ -10,10 +10,10 @@ proof = "tests/characterization/semantic-dispatch.characterization.py"
 
 [separation_of_concerns]
 before = "Three scheduled repository workers contended on one machine-wide lock and each reconciled an entire repository."
-after = "semantic_dispatch owns installation discovery, bounded process scheduling, deferred-result validation, and final publication; semantic_cli owns one exact-pull evaluation; GitHubApp retains authenticated evidence and check transport."
+after = "semantic_dispatch owns installation discovery and bounded process scheduling; semantic_result owns deferred-result validation and final publication; semantic_cli owns one exact-pull evaluation; GitHubApp retains authenticated evidence and check transport."
 
 [architecture]
-dependency_direction = "semantic_dispatch depends on GitHubApp, review_state, and semantic_lease while invoking semantic_cli by fixed process arguments; semantic_cli retains GitHubApp and responses_transport dependencies."
+dependency_direction = "semantic_dispatch depends on GitHubApp, review_state, semantic_lease, and semantic_result while invoking semantic_cli by fixed process arguments; semantic_result depends on GitHubApp and semantic_lease; semantic_cli retains GitHubApp and responses_transport dependencies."
 reviewed_paths = [
     "src/supportability_gate/characterization.py",
     "src/supportability_gate/architecture_policy.py",
@@ -33,25 +33,26 @@ reviewed_paths = [
     "src/supportability_gate/semantic_contract.py",
     "src/supportability_gate/semantic_diagnostics.py",
     "src/supportability_gate/semantic_dispatch.py",
+    "src/supportability_gate/semantic_result.py",
     "src/supportability_gate/semantic_review.py",
 ]
 
 [responsibility_boundary]
 path = "src/supportability_gate/semantic_dispatch.py"
-owns = "App-selected repository discovery, prerequisite eligibility, repository-fair queueing, two-worker launch, active-job deduplication, timeout, process cleanup, deferred-result validation, and final current-check publication."
-does_not_own = "Model transport, verdict aggregation, target execution, or per-repository configuration."
+owns = "App-selected repository discovery, prerequisite eligibility, repository-fair queueing, two-worker launch, active-job deduplication, timeout, bounded process reporting, and process cleanup."
+does_not_own = "Deferred-result validation, final publication, model transport, verdict aggregation, target execution, or per-repository configuration."
 
 [incremental_refactor]
 target = "Replace machine-wide serialization and per-repository reconciliation with one installation-wide on-demand dispatcher."
-completed_step = "Added shadow-proven App pagination, exact-head artifact eligibility, fair max-two worker scheduling, restart rediscovery, worker cleanup, and parent-owned publication without production cutover."
+completed_step = "Added shadow-proven App pagination, exact-head artifact eligibility, fair max-two worker scheduling, restart rediscovery, worker cleanup, and parent-gated publication without production cutover."
 
 [review_handoff]
-summary = "Review App pagination, exact-head readiness, repository/pull rotation, duplicate suppression, fixed subprocess arguments, timeout, forced cleanup, and parent-owned publication under the exact-pull lock."
+summary = "Review App pagination, strict workflow-run validation, repository/pull rotation, duplicate suppression, fixed subprocess arguments, timeout/nonzero rejection, forced cleanup, and semantic_result publication under the exact-pull lock."
 remaining_risks = ["Production remains on legacy per-repository scheduled tasks until S02 cutover."]
 
 [human_review]
 naming = "semantic_dispatch names installation discovery and ephemeral pull-worker supervision without a generic manager or engine."
-cohesion = "Dispatcher owns discovery, eligibility, queueing, worker supervision, deferred-result validation, and final publication; workers own evidence and model evaluation."
+cohesion = "Dispatcher owns discovery, eligibility, queueing, and worker supervision; semantic_result owns the deferred-result trust boundary and final publication; workers own evidence and model evaluation."
 intended_behavior = "No repository reserves agents; at most two exact-pull jobs run, and queued repositories cannot starve."
 reviewability = "Four hard-coded policy constants and focused pure queue functions expose capacity, cadence, timeout, and fairness directly."
 
@@ -143,7 +144,13 @@ justification = "Owns one exact-pull evaluation, fixed concurrent rounds, aggreg
 path = "src/supportability_gate/semantic_dispatch.py"
 owner_path = "src/supportability_gate/semantic_dispatch.py"
 basis = "responsibility"
-justification = "Owns installation-wide discovery, exact-head eligibility, fair two-worker scheduling, active-job suppression, bounded supervision, deferred-result validation, and current-check publication under the exact-pull lock, without model evaluation."
+justification = "Owns installation-wide discovery, exact-head eligibility, fair two-worker scheduling, active-job suppression, and bounded process supervision, without result validation, publication, or model evaluation."
+
+[[module_boundaries]]
+path = "src/supportability_gate/semantic_result.py"
+owner_path = "src/supportability_gate/semantic_result.py"
+basis = "responsibility"
+justification = "Owns bounded deferred-result validation and current-check publication under the exact-pull lock, without discovery, queueing, process supervision, or model evaluation."
 
 [[module_boundaries]]
 path = "src/supportability_gate/semantic_lease.py"

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -1,19 +1,19 @@
 schema_version = "1.0"
 
 [behavior]
-intended_behavior = "One required semantic check evaluates complete authenticated PR evidence through four fixed specialist profiles in two rounds and passes only eight trusted clean results."
-proof = "tests/test_semantic_review.py::test_ensemble_never_suppresses_and_byte_deduplicates_findings"
+intended_behavior = "One dispatcher discovers every App-selected repository, fairly launches at most two ephemeral exact-pull workers, and each worker publishes only a complete valid semantic ensemble."
+proof = "tests/test_semantic_dispatch.py::test_fill_slots_deduplicates_and_caps_workers"
 
 [characterization]
-captured_behavior = "The prior single-call semantic reviewer could pass a head that a later call blocked, while the packet discarded non-configuration diff text and did not bind closing-issue authority."
-proof = "tests/qualify_convergent_reviewer.py"
+captured_behavior = "Dispatcher policy fixes the 60-second poll, two-worker cap, per-repository pull rotation, fixed worker command, and finite worker timeout."
+proof = "tests/characterization/semantic-dispatch.characterization.py"
 
 [separation_of_concerns]
-before = "One model response evaluated parser-selected source plus only the semantic configuration patch and could stop discovery after one verdict."
-after = "GitHubApp supplies full canonical authority and diff evidence; semantic_contract fixes the rubric; semantic_review validates one response; semantic_cli aggregates eight unsuppressed attempts."
+before = "Three scheduled repository workers contended on one machine-wide lock and each reconciled an entire repository."
+after = "semantic_dispatch owns installation discovery and bounded process scheduling; semantic_cli owns one exact pull; GitHubApp retains authenticated evidence and check transport."
 
 [architecture]
-dependency_direction = "semantic_cli orchestrates GitHubApp and responses_transport; transport invokes semantic_diagnostics; semantic_review validates semantic_contract evidence without GitHub or transport ownership."
+dependency_direction = "semantic_dispatch depends on GitHubApp and invokes semantic_cli by fixed process arguments; semantic_cli retains its existing GitHubApp and responses_transport dependencies."
 reviewed_paths = [
     "src/supportability_gate/characterization.py",
     "src/supportability_gate/architecture_policy.py",
@@ -32,27 +32,28 @@ reviewed_paths = [
     "src/supportability_gate/semantic_cli.py",
     "src/supportability_gate/semantic_contract.py",
     "src/supportability_gate/semantic_diagnostics.py",
+    "src/supportability_gate/semantic_dispatch.py",
     "src/supportability_gate/semantic_review.py",
 ]
 
 [responsibility_boundary]
-path = "src/supportability_gate/semantic_cli.py"
-owns = "Fixed eight-attempt sequencing, deterministic union aggregation, replay use, and one current GitHub check conclusion."
-does_not_own = "GitHub evidence acquisition, HTTP transport, diagnostic persistence, response trust validation, target execution, or application remediation."
+path = "src/supportability_gate/semantic_dispatch.py"
+owns = "App-selected repository discovery, prerequisite eligibility, repository-fair queueing, two-worker launch, deduplication, timeout, and process cleanup."
+does_not_own = "Evidence construction, model transport, verdict aggregation, replay, check publication, target execution, or per-repository configuration."
 
 [incremental_refactor]
-target = "Replace single-trip latent discovery with fail-closed eight-response convergence without changing the required check identity."
-completed_step = "Bound full authority and diff evidence, fixed four profiles across two rounds, retained all findings, and required eight trusted PASS verdicts."
+target = "Replace machine-wide serialization and per-repository reconciliation with one installation-wide on-demand dispatcher."
+completed_step = "Added shadow-proven App pagination, exact-head artifact eligibility, fair max-two worker scheduling, restart rediscovery, and worker cleanup without production cutover."
 
 [review_handoff]
-summary = "Review full authority freshness, exact profile/round bindings, all-eight execution, unsuppressed finding union, diagnostics, replay identity, and historical/poison/clean qualification."
-remaining_risks = ["Two rounds materially reduce latent detection but cannot mathematically prove absence of every unknown defect."]
+summary = "Review App pagination, exact-head readiness, repository/pull rotation, duplicate suppression, fixed subprocess arguments, timeout, and forced cleanup."
+remaining_risks = ["Production remains on legacy per-repository scheduled tasks until S02 cutover."]
 
 [human_review]
-naming = "semantic-review.v2 and convergent-review.v1 name the response schema and fixed ensemble rubric without configurable variants."
-cohesion = "Each existing module retains one responsibility: authority, contract, transport, diagnostics, one-response validation, or ensemble orchestration."
-intended_behavior = "All eight calls run; any finding, uncertainty, stale authority, or technical failure prevents PASS."
-reviewability = "Fixed profile and round constants drive one nested sequence; focused tests cover continuation, aggregation, diagnostics, and replay."
+naming = "semantic_dispatch names installation discovery and ephemeral pull-worker supervision without a generic manager or engine."
+cohesion = "Dispatcher owns only discovery, eligibility, queueing, worker launch, and process monitoring; review semantics remain unchanged."
+intended_behavior = "No repository reserves agents; at most two exact-pull jobs run, and queued repositories cannot starve."
+reviewability = "Four hard-coded policy constants and focused pure queue functions expose capacity, cadence, timeout, and fairness directly."
 
 [[module_boundaries]]
 path = "src/supportability_gate/review_events.py"
@@ -136,4 +137,10 @@ justification = "Owns fail-closed trust validation of one structured response ag
 path = "src/supportability_gate/semantic_cli.py"
 owner_path = "src/supportability_gate/semantic_cli.py"
 basis = "responsibility"
-justification = "Owns fixed sequential ensemble execution, aggregate result, scheduled lock, and one current check conclusion without evidence acquisition, HTTP implementation, or single-response trust rules."
+justification = "Owns one exact pull, per-pull lock, fixed concurrent rounds, aggregate result, and one current check conclusion without installation discovery, queueing, HTTP implementation, or single-response trust rules."
+
+[[module_boundaries]]
+path = "src/supportability_gate/semantic_dispatch.py"
+owner_path = "src/supportability_gate/semantic_dispatch.py"
+basis = "responsibility"
+justification = "Owns installation-wide repository discovery, exact-head prerequisite eligibility, fair two-worker scheduling, duplicate suppression, finite process monitoring, and shutdown cleanup without semantic evaluation or check publication."

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0"
 
 [behavior]
-intended_behavior = "One dispatcher discovers every App-selected repository, fairly launches at most two ephemeral exact-pull workers, and each worker publishes only a complete valid semantic ensemble."
+intended_behavior = "One dispatcher discovers every App-selected repository, fairly launches at most two ephemeral exact-pull workers, and publishes only a complete valid deferred ensemble after confirmed worker exit."
 proof = "tests/test_semantic_dispatch.py::test_fill_slots_deduplicates_and_caps_workers"
 
 [characterization]
@@ -10,10 +10,10 @@ proof = "tests/characterization/semantic-dispatch.characterization.py"
 
 [separation_of_concerns]
 before = "Three scheduled repository workers contended on one machine-wide lock and each reconciled an entire repository."
-after = "semantic_dispatch owns installation discovery and bounded process scheduling; semantic_cli owns one exact pull; GitHubApp retains authenticated evidence and check transport."
+after = "semantic_dispatch owns installation discovery, bounded process scheduling, deferred-result validation, and final publication; semantic_cli owns one exact-pull evaluation; GitHubApp retains authenticated evidence and check transport."
 
 [architecture]
-dependency_direction = "semantic_dispatch depends on GitHubApp and invokes semantic_cli by fixed process arguments; semantic_cli retains its existing GitHubApp and responses_transport dependencies."
+dependency_direction = "semantic_dispatch depends on GitHubApp, review_state, and semantic_lease while invoking semantic_cli by fixed process arguments; semantic_cli retains GitHubApp and responses_transport dependencies."
 reviewed_paths = [
     "src/supportability_gate/characterization.py",
     "src/supportability_gate/architecture_policy.py",
@@ -38,20 +38,20 @@ reviewed_paths = [
 
 [responsibility_boundary]
 path = "src/supportability_gate/semantic_dispatch.py"
-owns = "App-selected repository discovery, prerequisite eligibility, repository-fair queueing, two-worker launch, active-job deduplication, timeout, process cleanup, and publication-lease revocation."
-does_not_own = "Evidence construction, model transport, verdict aggregation, replay, check publication, target execution, or per-repository configuration."
+owns = "App-selected repository discovery, prerequisite eligibility, repository-fair queueing, two-worker launch, active-job deduplication, timeout, process cleanup, deferred-result validation, and final current-check publication."
+does_not_own = "Model transport, verdict aggregation, target execution, or per-repository configuration."
 
 [incremental_refactor]
 target = "Replace machine-wide serialization and per-repository reconciliation with one installation-wide on-demand dispatcher."
-completed_step = "Added shadow-proven App pagination, exact-head artifact eligibility, fair max-two worker scheduling, restart rediscovery, and worker cleanup without production cutover."
+completed_step = "Added shadow-proven App pagination, exact-head artifact eligibility, fair max-two worker scheduling, restart rediscovery, worker cleanup, and parent-owned publication without production cutover."
 
 [review_handoff]
-summary = "Review App pagination, exact-head readiness, repository/pull rotation, duplicate suppression, fixed subprocess arguments, timeout, and forced cleanup."
+summary = "Review App pagination, exact-head readiness, repository/pull rotation, duplicate suppression, fixed subprocess arguments, timeout, forced cleanup, and parent-owned publication under the exact-pull lock."
 remaining_risks = ["Production remains on legacy per-repository scheduled tasks until S02 cutover."]
 
 [human_review]
 naming = "semantic_dispatch names installation discovery and ephemeral pull-worker supervision without a generic manager or engine."
-cohesion = "Dispatcher owns only discovery, eligibility, queueing, worker launch, and process monitoring; review semantics remain unchanged."
+cohesion = "Dispatcher owns discovery, eligibility, queueing, worker supervision, deferred-result validation, and final publication; workers own evidence and model evaluation."
 intended_behavior = "No repository reserves agents; at most two exact-pull jobs run, and queued repositories cannot starve."
 reviewability = "Four hard-coded policy constants and focused pure queue functions expose capacity, cadence, timeout, and fairness directly."
 
@@ -65,7 +65,7 @@ justification = "Owns HMAC authentication and strict identity normalization for 
 path = "src/supportability_gate/review_state.py"
 owner_path = "src/supportability_gate/review_state.py"
 basis = "responsibility"
-justification = "Owns normalization and cross-checking of authenticated GitHub review snapshots, but not API transport, unresolved-thread policy, model evaluation, check publication, or event invalidation."
+justification = "Owns normalization, cross-checking, and unresolved-thread blocking policy for authenticated GitHub review snapshots, but not API transport, model evaluation, check publication, or event invalidation."
 
 [[module_boundaries]]
 path = "src/supportability_gate/quality_profile.py"
@@ -137,16 +137,16 @@ justification = "Owns fail-closed trust validation of one structured response ag
 path = "src/supportability_gate/semantic_cli.py"
 owner_path = "src/supportability_gate/semantic_cli.py"
 basis = "responsibility"
-justification = "Owns one exact pull, per-pull lock, fixed concurrent rounds, aggregate result, and one current check conclusion without installation discovery, queueing, HTTP implementation, or single-response trust rules."
+justification = "Owns one exact-pull evaluation, fixed concurrent rounds, aggregate result, legacy direct completion, and bounded deferred-result writing without installation discovery, queueing, or deferred-result publication."
 
 [[module_boundaries]]
 path = "src/supportability_gate/semantic_dispatch.py"
 owner_path = "src/supportability_gate/semantic_dispatch.py"
 basis = "responsibility"
-justification = "Owns installation-wide repository discovery, exact-head prerequisite eligibility, fair two-worker scheduling, active-job duplicate suppression, and bounded process supervision with publication-lease revocation, without semantic evaluation or check publication."
+justification = "Owns installation-wide discovery, exact-head eligibility, fair two-worker scheduling, active-job suppression, bounded supervision, deferred-result validation, and current-check publication under the exact-pull lock, without model evaluation."
 
 [[module_boundaries]]
 path = "src/supportability_gate/semantic_lease.py"
 owner_path = "src/supportability_gate/semantic_lease.py"
 basis = "responsibility"
-justification = "Owns cross-process evaluation and publication lease locking without GitHub access, process launch, semantic evaluation, or check publication."
+justification = "Owns cross-process exact-pull evaluation locking and stable lock identity without GitHub access, process launch, semantic evaluation, or check publication."

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -38,7 +38,7 @@ reviewed_paths = [
 
 [responsibility_boundary]
 path = "src/supportability_gate/semantic_dispatch.py"
-owns = "App-selected repository discovery, prerequisite eligibility, repository-fair queueing, two-worker launch, active-job deduplication, timeout, and process cleanup."
+owns = "App-selected repository discovery, prerequisite eligibility, repository-fair queueing, two-worker launch, active-job deduplication, timeout, process cleanup, and publication-lease revocation."
 does_not_own = "Evidence construction, model transport, verdict aggregation, replay, check publication, target execution, or per-repository configuration."
 
 [incremental_refactor]
@@ -143,4 +143,4 @@ justification = "Owns one exact pull, per-pull lock, fixed concurrent rounds, ag
 path = "src/supportability_gate/semantic_dispatch.py"
 owner_path = "src/supportability_gate/semantic_dispatch.py"
 basis = "responsibility"
-justification = "Owns installation-wide repository discovery, exact-head prerequisite eligibility, fair two-worker scheduling, active-job duplicate suppression, and bounded fail-closed process supervision without semantic evaluation or check publication."
+justification = "Owns installation-wide repository discovery, exact-head prerequisite eligibility, fair two-worker scheduling, active-job duplicate suppression, and bounded process supervision with publication-lease revocation, without semantic evaluation or check publication."

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -143,4 +143,4 @@ justification = "Owns one exact pull, per-pull lock, fixed concurrent rounds, ag
 path = "src/supportability_gate/semantic_dispatch.py"
 owner_path = "src/supportability_gate/semantic_dispatch.py"
 basis = "responsibility"
-justification = "Owns installation-wide repository discovery, exact-head prerequisite eligibility, fair two-worker scheduling, active-job duplicate suppression, finite process monitoring, and shutdown cleanup without semantic evaluation or check publication."
+justification = "Owns installation-wide repository discovery, exact-head prerequisite eligibility, fair two-worker scheduling, active-job duplicate suppression, and bounded fail-closed process supervision without semantic evaluation or check publication."

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -144,3 +144,9 @@ path = "src/supportability_gate/semantic_dispatch.py"
 owner_path = "src/supportability_gate/semantic_dispatch.py"
 basis = "responsibility"
 justification = "Owns installation-wide repository discovery, exact-head prerequisite eligibility, fair two-worker scheduling, active-job duplicate suppression, and bounded process supervision with publication-lease revocation, without semantic evaluation or check publication."
+
+[[module_boundaries]]
+path = "src/supportability_gate/semantic_lease.py"
+owner_path = "src/supportability_gate/semantic_lease.py"
+basis = "responsibility"
+justification = "Owns cross-process evaluation and publication lease locking without GitHub access, process launch, semantic evaluation, or check publication."

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -38,7 +38,7 @@ reviewed_paths = [
 
 [responsibility_boundary]
 path = "src/supportability_gate/semantic_dispatch.py"
-owns = "App-selected repository discovery, prerequisite eligibility, repository-fair queueing, two-worker launch, deduplication, timeout, and process cleanup."
+owns = "App-selected repository discovery, prerequisite eligibility, repository-fair queueing, two-worker launch, active-job deduplication, timeout, and process cleanup."
 does_not_own = "Evidence construction, model transport, verdict aggregation, replay, check publication, target execution, or per-repository configuration."
 
 [incremental_refactor]
@@ -143,4 +143,4 @@ justification = "Owns one exact pull, per-pull lock, fixed concurrent rounds, ag
 path = "src/supportability_gate/semantic_dispatch.py"
 owner_path = "src/supportability_gate/semantic_dispatch.py"
 basis = "responsibility"
-justification = "Owns installation-wide repository discovery, exact-head prerequisite eligibility, fair two-worker scheduling, duplicate suppression, finite process monitoring, and shutdown cleanup without semantic evaluation or check publication."
+justification = "Owns installation-wide repository discovery, exact-head prerequisite eligibility, fair two-worker scheduling, active-job duplicate suppression, finite process monitoring, and shutdown cleanup without semantic evaluation or check publication."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,8 @@ layers = [
 name = "Semantic verifier dependency direction"
 type = "layers"
 layers = [
-    "supportability_gate.semantic_dispatch | supportability_gate.semantic_cli",
+    "supportability_gate.semantic_dispatch",
+    "supportability_gate.semantic_cli | supportability_gate.semantic_result",
     "supportability_gate.semantic_lease",
     "supportability_gate.github_app | supportability_gate.responses_transport",
     "supportability_gate.semantic_diagnostics",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ name = "Semantic verifier dependency direction"
 type = "layers"
 layers = [
     "supportability_gate.semantic_dispatch | supportability_gate.semantic_cli",
+    "supportability_gate.semantic_lease",
     "supportability_gate.github_app | supportability_gate.responses_transport",
     "supportability_gate.semantic_diagnostics",
     "supportability_gate.review_events | supportability_gate.review_state",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
 
 [project.scripts]
 supportability-gate = "supportability_gate.cli:main"
+supportability-semantic-dispatch = "supportability_gate.semantic_dispatch:main"
 supportability-semantic-review = "supportability_gate.semantic_cli:main"
 
 [tool.setuptools]
@@ -80,7 +81,7 @@ layers = [
 name = "Semantic verifier dependency direction"
 type = "layers"
 layers = [
-    "supportability_gate.semantic_cli",
+    "supportability_gate.semantic_dispatch | supportability_gate.semantic_cli",
     "supportability_gate.github_app | supportability_gate.responses_transport",
     "supportability_gate.semantic_diagnostics",
     "supportability_gate.review_events | supportability_gate.review_state",

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -242,12 +242,13 @@ class GitHubApp:
 
     def open_pulls(self, repository: str, token: str) -> tuple[dict[str, Any], ...]:
         """Return open pull requests from GitHub's immutable SHA metadata."""
-        result = self._request("GET", f"/repos/{repository}/pulls?state=open&per_page=100", token)
-        if not isinstance(result, list) or any(not isinstance(item, dict) for item in result):
+        rows = self._rest_pages(f"/repos/{repository}/pulls?state=open&per_page=100", token)
+        numbers = [item.get("number") for item in rows]
+        if any(type(number) is not int for number in numbers):
             raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
-        if len(result) >= 100:
+        if len(set(numbers)) != len(rows):
             raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
-        return tuple(result)
+        return rows
 
     def pull(self, repository: str, pull_number: int, token: str) -> dict[str, Any]:
         """Return current authenticated pull-request metadata for event reconciliation."""

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -407,13 +407,16 @@ class GitHubApp:
             token,
         )
         rows = result.get("workflow_runs") if isinstance(result, dict) else None
-        if not isinstance(rows, list) or len(rows) >= 100:
+        if (
+            not isinstance(rows, list)
+            or len(rows) >= 100
+            or any(not isinstance(row, dict) for row in rows)
+        ):
             raise SemanticReviewError("HANDOFF_EVIDENCE_UNAVAILABLE")
         runs = [
             row
             for row in rows
-            if isinstance(row, dict)
-            and row.get("path") == HANDOFF_WORKFLOW_PATH
+            if row.get("path") == HANDOFF_WORKFLOW_PATH
             and row.get("head_sha") == head_sha
             and row.get("event") == "pull_request"
             and row.get("status") == "completed"

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -204,6 +204,38 @@ class GitHubApp:
             raise SemanticReviewError("INSTALLATION_AUTHENTICATION_FAILURE")
         return token
 
+    def installation_repositories(self, token: str) -> tuple[dict[str, Any], ...]:
+        """Return every repository selected for this App installation."""
+        rows: list[dict[str, Any]] = []
+        page = 1
+        total: int | None = None
+        while total is None or len(rows) < total:
+            result = self._request(
+                "GET", f"/installation/repositories?per_page=100&page={page}", token
+            )
+            repositories = result.get("repositories") if isinstance(result, dict) else None
+            current_total = result.get("total_count") if isinstance(result, dict) else None
+            if (
+                type(current_total) is not int
+                or current_total < 0
+                or not isinstance(repositories, list)
+                or any(not isinstance(item, dict) for item in repositories)
+            ):
+                raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+            if total is not None and current_total != total:
+                raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
+            total = current_total
+            rows.extend(repositories)
+            if len(rows) > total or (len(repositories) < 100 and len(rows) != total):
+                raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
+            page += 1
+        if any(
+            type(item.get("id")) is not int or not isinstance(item.get("full_name"), str)
+            for item in rows
+        ):
+            raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        return tuple(rows)
+
     def open_pulls(self, repository: str, token: str) -> tuple[dict[str, Any], ...]:
         """Return open pull requests from GitHub's immutable SHA metadata."""
         result = self._request("GET", f"/repos/{repository}/pulls?state=open&per_page=100", token)
@@ -383,6 +415,23 @@ class GitHubApp:
         if ordered[0].get("conclusion") != "success":
             raise SemanticReviewError("HANDOFF_EVIDENCE_UNAVAILABLE")
         return tuple(run for run in ordered if run.get("conclusion") == "success")
+
+    def handoff_ready(self, repository: str, head_sha: str, token: str) -> bool:
+        """Report whether one successful exact-head prerequisite artifact exists."""
+        try:
+            runs = self._handoff_runs(repository, head_sha, token)
+        except SemanticReviewError as error:
+            if error.code == "HANDOFF_EVIDENCE_UNAVAILABLE":
+                return False
+            raise
+        for run in runs:
+            try:
+                self._handoff_artifact(repository, run, token)
+                return True
+            except SemanticReviewError as error:
+                if error.code != "HANDOFF_EVIDENCE_UNAVAILABLE":
+                    raise
+        return False
 
     @staticmethod
     def _handoff_run_order(run: dict[str, Any]) -> tuple[datetime, int]:

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -37,6 +37,7 @@ from supportability_gate.handoff_policy import (
 )
 from supportability_gate.review_state import normalize_review_state
 from supportability_gate.semantic_contract import (
+    REPOSITORY_PATTERN,
     SHA_PATTERN,
     TRUSTED_OWNER_ID,
     EvidencePacket,
@@ -230,7 +231,10 @@ class GitHubApp:
                 raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
             page += 1
         if any(
-            type(item.get("id")) is not int or not isinstance(item.get("full_name"), str)
+            type(item.get("id")) is not int
+            or item["id"] <= 0
+            or not isinstance(item.get("full_name"), str)
+            or REPOSITORY_PATTERN.fullmatch(item["full_name"]) is None
             for item in rows
         ):
             raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")

--- a/src/supportability_gate/github_app.py
+++ b/src/supportability_gate/github_app.py
@@ -234,6 +234,10 @@ class GitHubApp:
             for item in rows
         ):
             raise SemanticReviewError("MALFORMED_GITHUB_RESPONSE")
+        if len({item["id"] for item in rows}) != len(rows) or len(
+            {item["full_name"] for item in rows}
+        ) != len(rows):
+            raise SemanticReviewError("INCOMPLETE_GITHUB_EVIDENCE")
         return tuple(rows)
 
     def open_pulls(self, repository: str, token: str) -> tuple[dict[str, Any], ...]:
@@ -411,10 +415,14 @@ class GitHubApp:
         ]
         if not runs:
             raise SemanticReviewError("HANDOFF_EVIDENCE_UNAVAILABLE")
-        ordered = tuple(sorted(runs, key=self._handoff_run_order, reverse=True))
-        if ordered[0].get("conclusion") != "success":
+        ordered = tuple(
+            run
+            for run in sorted(runs, key=self._handoff_run_order, reverse=True)
+            if run.get("conclusion") == "success"
+        )
+        if not ordered:
             raise SemanticReviewError("HANDOFF_EVIDENCE_UNAVAILABLE")
-        return tuple(run for run in ordered if run.get("conclusion") == "success")
+        return ordered
 
     def handoff_ready(self, repository: str, head_sha: str, token: str) -> bool:
         """Report whether one successful exact-head prerequisite artifact exists."""

--- a/src/supportability_gate/review_state.py
+++ b/src/supportability_gate/review_state.py
@@ -12,6 +12,23 @@ def _malformed() -> SemanticReviewError:
     return SemanticReviewError("MALFORMED_REVIEW_STATE")
 
 
+def unresolved_review_blocks(evidence: dict[str, object]) -> tuple[str, ...]:
+    """Return deterministic blocks for current unresolved GitHub threads."""
+    state = evidence.get("review_state")
+    threads = state.get("threads") if isinstance(state, dict) else None
+    if not isinstance(threads, list):
+        raise _malformed()
+    blocks: list[str] = []
+    for thread in threads:
+        if not isinstance(thread, dict) or not isinstance(thread.get("id"), str):
+            raise _malformed()
+        if not isinstance(thread.get("is_resolved"), bool):
+            raise _malformed()
+        if not thread["is_resolved"]:
+            blocks.append(f"UNRESOLVED_REVIEW_THREAD:{thread['id']}")
+    return tuple(sorted(blocks))
+
+
 def _text(item: dict[str, Any], key: str) -> str:
     value = item.get(key)
     if not isinstance(value, str) or not value:

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -74,6 +74,7 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="supportability-semantic-review")
     parser.add_argument("--repository", required=True)
     parser.add_argument("--pull-number", required=True, type=int)
+    parser.add_argument("--head-sha", required=True)
     parser.add_argument("--app-id", required=True, type=int)
     parser.add_argument("--installation-id", required=True, type=int)
     parser.add_argument("--private-key", required=True, type=Path)
@@ -374,6 +375,9 @@ def main(argv: list[str] | None = None) -> int:
         app = GitHubApp(arguments.app_id, arguments.installation_id, private_key)
         token = app.installation_token()
         pull = app.pull(arguments.repository, arguments.pull_number, token)
+        head = pull.get("head")
+        if not isinstance(head, dict) or head.get("sha") != arguments.head_sha:
+            raise SemanticReviewError("STALE_EVIDENCE")
         lock_path = _pull_lock_path(
             arguments.private_key, arguments.repository, arguments.pull_number
         )

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import os
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from pathlib import Path
-from typing import BinaryIO
 
 from supportability_gate.github_app import GitHubApp
 from supportability_gate.handoff_policy import deterministic_completion_blocks
@@ -22,6 +20,7 @@ from supportability_gate.semantic_contract import (
     SemanticReviewError,
     SemanticVerdict,
 )
+from supportability_gate.semantic_lease import exclusive_lease, publication_lease
 from supportability_gate.semantic_review import parse_response
 
 
@@ -99,11 +98,6 @@ def unresolved_review_blocks(evidence: dict[str, object]) -> tuple[str, ...]:
     return tuple(sorted(blocks))
 
 
-def _require_lease(lease_file: Path | None) -> None:
-    if lease_file is not None and lease_file.read_text(encoding="utf-8") != "active":
-        raise SemanticReviewError("WORKER_LEASE_REVOKED")
-
-
 def _complete_current_check(
     app: GitHubApp,
     packet: EvidencePacket,
@@ -114,53 +108,16 @@ def _complete_current_check(
     summary: str,
     lease_file: Path | None = None,
 ) -> None:
-    _require_lease(lease_file)
     app.assert_current(packet, pull_number, token)
-    app.complete_check(packet, token, check_id, conclusion, summary)
-
-
-def _lock(handle: BinaryIO) -> None:
-    try:
-        if os.name == "nt":
-            import msvcrt
-
-            handle.seek(0, os.SEEK_END)
-            if handle.tell() == 0:
-                handle.write(b"\0")
-                handle.flush()
-            handle.seek(0)
-            getattr(msvcrt, "locking")(handle.fileno(), getattr(msvcrt, "LK_NBLCK"), 1)
-        else:
-            import fcntl
-
-            getattr(fcntl, "flock")(
-                handle.fileno(), getattr(fcntl, "LOCK_EX") | getattr(fcntl, "LOCK_NB")
-            )
-    except OSError as error:
-        raise SemanticReviewError("EVALUATION_IN_PROGRESS") from error
-
-
-def _unlock(handle: BinaryIO) -> None:
-    if os.name == "nt":
-        import msvcrt
-
-        handle.seek(0)
-        getattr(msvcrt, "locking")(handle.fileno(), getattr(msvcrt, "LK_UNLCK"), 1)
-    else:
-        import fcntl
-
-        getattr(fcntl, "flock")(handle.fileno(), getattr(fcntl, "LOCK_UN"))
+    with publication_lease(lease_file):
+        app.complete_check(packet, token, check_id, conclusion, summary)
 
 
 @contextmanager
 def _evaluation_lock(path: Path) -> Iterator[None]:
     """Give one pull-request worker exclusive verdict ownership."""
-    with path.open("a+b") as handle:
-        _lock(handle)
-        try:
-            yield
-        finally:
-            _unlock(handle)
+    with exclusive_lease(path):
+        yield
 
 
 def _pull_lock_path(private_key: Path, repository: str, pull_number: int) -> Path:
@@ -246,7 +203,6 @@ def _review(
         raise SemanticReviewError("MALFORMED_PULL_REQUEST")
     app.assert_current(packet, pull_number, token)
     if review_blocks:
-        _require_lease(lease_file)
         check_id = app.start_check(packet, token)
         _complete_current_check(
             app,
@@ -265,7 +221,6 @@ def _review(
     replay = app.replay_result(packet, token)
     if replay is not None:
         return replay
-    _require_lease(lease_file)
     check_id = app.start_check(packet, token)
     preflight = (
         deterministic_completion_blocks(

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -20,6 +20,7 @@ from supportability_gate.semantic_contract import (
     EvidencePacket,
     SemanticReviewError,
     SemanticVerdict,
+    unresolved_review_blocks,
 )
 from supportability_gate.semantic_lease import exclusive_lease
 from supportability_gate.semantic_review import parse_response
@@ -80,23 +81,6 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--private-key", required=True, type=Path)
     parser.add_argument("--result-file", type=Path)
     return parser
-
-
-def unresolved_review_blocks(evidence: dict[str, object]) -> tuple[str, ...]:
-    """Return deterministic blocks for current unresolved GitHub threads."""
-    state = evidence.get("review_state")
-    threads = state.get("threads") if isinstance(state, dict) else None
-    if not isinstance(threads, list):
-        raise SemanticReviewError("MALFORMED_REVIEW_STATE")
-    blocks: list[str] = []
-    for thread in threads:
-        if not isinstance(thread, dict) or not isinstance(thread.get("id"), str):
-            raise SemanticReviewError("MALFORMED_REVIEW_STATE")
-        if not isinstance(thread.get("is_resolved"), bool):
-            raise SemanticReviewError("MALFORMED_REVIEW_STATE")
-        if not thread["is_resolved"]:
-            blocks.append(f"UNRESOLVED_REVIEW_THREAD:{thread['id']}")
-    return tuple(sorted(blocks))
 
 
 def _complete_current_check(
@@ -216,9 +200,6 @@ def _review(
     if not isinstance(pull_number, int):
         raise SemanticReviewError("MALFORMED_PULL_REQUEST")
     app.assert_current(packet, pull_number, token)
-    packet = app.m10_evidence_packet(repository, pull, token, packet)
-    evidence = packet.evidence
-    app.assert_current(packet, pull_number, token)
     review_blocks = unresolved_review_blocks(evidence)
     if review_blocks:
         check_id = app.start_check(packet, token)
@@ -233,6 +214,9 @@ def _review(
             result_file,
         )
         return False
+    packet = app.m10_evidence_packet(repository, pull, token, packet)
+    evidence = packet.evidence
+    app.assert_current(packet, pull_number, token)
     replay = app.replay_result(packet, token)
     if replay is not None:
         return replay

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -78,6 +78,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--app-id", required=True, type=int)
     parser.add_argument("--installation-id", required=True, type=int)
     parser.add_argument("--private-key", required=True, type=Path)
+    parser.add_argument("--lease-file", type=Path)
     return parser
 
 
@@ -98,6 +99,11 @@ def unresolved_review_blocks(evidence: dict[str, object]) -> tuple[str, ...]:
     return tuple(sorted(blocks))
 
 
+def _require_lease(lease_file: Path | None) -> None:
+    if lease_file is not None and lease_file.read_text(encoding="utf-8") != "active":
+        raise SemanticReviewError("WORKER_LEASE_REVOKED")
+
+
 def _complete_current_check(
     app: GitHubApp,
     packet: EvidencePacket,
@@ -106,7 +112,9 @@ def _complete_current_check(
     check_id: int,
     conclusion: str,
     summary: str,
+    lease_file: Path | None = None,
 ) -> None:
+    _require_lease(lease_file)
     app.assert_current(packet, pull_number, token)
     app.complete_check(packet, token, check_id, conclusion, summary)
 
@@ -228,6 +236,7 @@ def _review(
     token: str,
     pull: dict[str, object],
     diagnostics_root: Path | None = None,
+    lease_file: Path | None = None,
 ) -> bool:
     packet = app.evidence_packet(repository, pull, token)
     evidence = packet.evidence
@@ -237,6 +246,7 @@ def _review(
         raise SemanticReviewError("MALFORMED_PULL_REQUEST")
     app.assert_current(packet, pull_number, token)
     if review_blocks:
+        _require_lease(lease_file)
         check_id = app.start_check(packet, token)
         _complete_current_check(
             app,
@@ -246,6 +256,7 @@ def _review(
             check_id,
             "failure",
             "BLOCK\n" + "\n".join(review_blocks),
+            lease_file,
         )
         return False
     packet = app.m10_evidence_packet(repository, pull, token, packet)
@@ -254,6 +265,7 @@ def _review(
     replay = app.replay_result(packet, token)
     if replay is not None:
         return replay
+    _require_lease(lease_file)
     check_id = app.start_check(packet, token)
     preflight = (
         deterministic_completion_blocks(
@@ -276,6 +288,7 @@ def _review(
             check_id,
             "action_required",
             "PREFLIGHT_BLOCK\n" + "\n".join(preflight),
+            lease_file,
         )
         return False
     verdicts: list[SemanticVerdict] = []
@@ -298,6 +311,7 @@ def _review(
             check_id,
             "action_required",
             _ensemble_summary(False, verdicts, errors, findings),
+            lease_file,
         )
         raise SemanticReviewError("ENSEMBLE_TECHNICAL_FAILURE")
     passed = (
@@ -314,6 +328,7 @@ def _review(
         check_id,
         "success" if passed else "failure",
         _ensemble_summary(passed, verdicts, errors, findings),
+        lease_file,
     )
     return passed
 
@@ -383,7 +398,12 @@ def main(argv: list[str] | None = None) -> int:
         )
         diagnostics_root = arguments.private_key.with_name("semantic-review-diagnostics")
         with _evaluation_lock(lock_path):
-            result = _review(app, arguments.repository, token, pull, diagnostics_root)
+            review_arguments = (app, arguments.repository, token, pull, diagnostics_root)
+            result = (
+                _review(*review_arguments, arguments.lease_file)
+                if arguments.lease_file is not None
+                else _review(*review_arguments)
+            )
     except (OSError, SemanticReviewError):
         print("TECHNICAL_FAILURE")
         return 2

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -20,7 +21,7 @@ from supportability_gate.semantic_contract import (
     SemanticReviewError,
     SemanticVerdict,
 )
-from supportability_gate.semantic_lease import exclusive_lease, publication_lease
+from supportability_gate.semantic_lease import exclusive_lease
 from supportability_gate.semantic_review import parse_response
 
 
@@ -77,7 +78,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--app-id", required=True, type=int)
     parser.add_argument("--installation-id", required=True, type=int)
     parser.add_argument("--private-key", required=True, type=Path)
-    parser.add_argument("--lease-file", type=Path)
+    parser.add_argument("--result-file", type=Path)
     return parser
 
 
@@ -106,11 +107,25 @@ def _complete_current_check(
     check_id: int,
     conclusion: str,
     summary: str,
-    lease_file: Path | None = None,
+    result_file: Path | None = None,
 ) -> None:
     app.assert_current(packet, pull_number, token)
-    with publication_lease(lease_file):
+    if result_file is None:
         app.complete_check(packet, token, check_id, conclusion, summary)
+        return
+    result_file.write_text(
+        json.dumps(
+            {
+                "check_id": check_id,
+                "conclusion": conclusion,
+                "evidence_sha256": packet.sha256,
+                "summary": summary,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
 
 
 @contextmanager
@@ -193,15 +208,18 @@ def _review(
     token: str,
     pull: dict[str, object],
     diagnostics_root: Path | None = None,
-    lease_file: Path | None = None,
+    result_file: Path | None = None,
 ) -> bool:
     packet = app.evidence_packet(repository, pull, token)
     evidence = packet.evidence
-    review_blocks = unresolved_review_blocks(evidence)
     pull_number = evidence.get("pull_request")
     if not isinstance(pull_number, int):
         raise SemanticReviewError("MALFORMED_PULL_REQUEST")
     app.assert_current(packet, pull_number, token)
+    packet = app.m10_evidence_packet(repository, pull, token, packet)
+    evidence = packet.evidence
+    app.assert_current(packet, pull_number, token)
+    review_blocks = unresolved_review_blocks(evidence)
     if review_blocks:
         check_id = app.start_check(packet, token)
         _complete_current_check(
@@ -212,12 +230,9 @@ def _review(
             check_id,
             "failure",
             "BLOCK\n" + "\n".join(review_blocks),
-            lease_file,
+            result_file,
         )
         return False
-    packet = app.m10_evidence_packet(repository, pull, token, packet)
-    evidence = packet.evidence
-    app.assert_current(packet, pull_number, token)
     replay = app.replay_result(packet, token)
     if replay is not None:
         return replay
@@ -243,7 +258,7 @@ def _review(
             check_id,
             "action_required",
             "PREFLIGHT_BLOCK\n" + "\n".join(preflight),
-            lease_file,
+            result_file,
         )
         return False
     verdicts: list[SemanticVerdict] = []
@@ -266,7 +281,7 @@ def _review(
             check_id,
             "action_required",
             _ensemble_summary(False, verdicts, errors, findings),
-            lease_file,
+            result_file,
         )
         raise SemanticReviewError("ENSEMBLE_TECHNICAL_FAILURE")
     passed = (
@@ -283,7 +298,7 @@ def _review(
         check_id,
         "success" if passed else "failure",
         _ensemble_summary(passed, verdicts, errors, findings),
-        lease_file,
+        result_file,
     )
     return passed
 
@@ -355,8 +370,8 @@ def main(argv: list[str] | None = None) -> int:
         with _evaluation_lock(lock_path):
             review_arguments = (app, arguments.repository, token, pull, diagnostics_root)
             result = (
-                _review(*review_arguments, arguments.lease_file)
-                if arguments.lease_file is not None
+                _review(*review_arguments, arguments.result_file)
+                if arguments.result_file is not None
                 else _review(*review_arguments)
             )
     except (OSError, SemanticReviewError):

--- a/src/supportability_gate/semantic_cli.py
+++ b/src/supportability_gate/semantic_cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
@@ -14,15 +13,16 @@ from supportability_gate.github_app import GitHubApp
 from supportability_gate.handoff_policy import deterministic_completion_blocks
 from supportability_gate.responses_transport import TransportResponse, request_response
 from supportability_gate.review_events import ReviewEvent, parse_review_event
+from supportability_gate.review_state import unresolved_review_blocks
 from supportability_gate.semantic_contract import (
+    MAX_WORKER_RESULT_BYTES,
     PROFILE_IDS,
     ROUNDS,
     EvidencePacket,
     SemanticReviewError,
     SemanticVerdict,
-    unresolved_review_blocks,
 )
-from supportability_gate.semantic_lease import exclusive_lease
+from supportability_gate.semantic_lease import exclusive_lease, pull_lock_path
 from supportability_gate.semantic_review import parse_response
 
 
@@ -86,30 +86,51 @@ def _parser() -> argparse.ArgumentParser:
 def _complete_current_check(
     app: GitHubApp,
     packet: EvidencePacket,
+    token: str,
+    check_id: int,
+    conclusion: str,
+    summary: str,
+) -> None:
+    app.complete_check(packet, token, check_id, conclusion, summary)
+
+
+def _write_deferred_result(
+    packet: EvidencePacket,
+    check_id: int,
+    conclusion: str,
+    summary: str,
+    result_file: Path,
+) -> None:
+    payload = json.dumps(
+        {
+            "check_id": check_id,
+            "conclusion": conclusion,
+            "evidence_sha256": packet.sha256,
+            "summary": summary,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    if len(payload.encode("utf-8")) > MAX_WORKER_RESULT_BYTES:
+        raise SemanticReviewError("WORKER_RESULT_TOO_LARGE")
+    result_file.write_text(payload, encoding="utf-8")
+
+
+def _conclude_current_check(
+    app: GitHubApp,
+    packet: EvidencePacket,
     pull_number: int,
     token: str,
     check_id: int,
     conclusion: str,
     summary: str,
-    result_file: Path | None = None,
+    result_file: Path | None,
 ) -> None:
     app.assert_current(packet, pull_number, token)
     if result_file is None:
-        app.complete_check(packet, token, check_id, conclusion, summary)
-        return
-    result_file.write_text(
-        json.dumps(
-            {
-                "check_id": check_id,
-                "conclusion": conclusion,
-                "evidence_sha256": packet.sha256,
-                "summary": summary,
-            },
-            separators=(",", ":"),
-            sort_keys=True,
-        ),
-        encoding="utf-8",
-    )
+        _complete_current_check(app, packet, token, check_id, conclusion, summary)
+    else:
+        _write_deferred_result(packet, check_id, conclusion, summary, result_file)
 
 
 @contextmanager
@@ -121,8 +142,7 @@ def _evaluation_lock(path: Path) -> Iterator[None]:
 
 def _pull_lock_path(private_key: Path, repository: str, pull_number: int) -> Path:
     """Return one stable, filesystem-safe lock path for an exact pull request."""
-    identity = hashlib.sha256(f"{repository.lower()}#{pull_number}".encode()).hexdigest()
-    return private_key.with_name(f"semantic-review-{identity}.lock")
+    return pull_lock_path(private_key, repository, pull_number)
 
 
 def _review_attempt(
@@ -203,7 +223,7 @@ def _review(
     review_blocks = unresolved_review_blocks(evidence)
     if review_blocks:
         check_id = app.start_check(packet, token)
-        _complete_current_check(
+        _conclude_current_check(
             app,
             packet,
             pull_number,
@@ -234,7 +254,7 @@ def _review(
         else ()
     )
     if preflight:
-        _complete_current_check(
+        _conclude_current_check(
             app,
             packet,
             pull_number,
@@ -257,7 +277,7 @@ def _review(
         dict.fromkeys((*preflight, *(finding for item in verdicts for finding in item.findings)))
     )
     if errors:
-        _complete_current_check(
+        _conclude_current_check(
             app,
             packet,
             pull_number,
@@ -274,7 +294,7 @@ def _review(
         and not findings
         and all(item.verdict == "PASS" for item in verdicts)
     )
-    _complete_current_check(
+    _conclude_current_check(
         app,
         packet,
         pull_number,

--- a/src/supportability_gate/semantic_contract.py
+++ b/src/supportability_gate/semantic_contract.py
@@ -55,6 +55,23 @@ class SemanticReviewError(ValueError):
         self.code = code
 
 
+def unresolved_review_blocks(evidence: dict[str, object]) -> tuple[str, ...]:
+    """Return deterministic blocks for current unresolved GitHub threads."""
+    state = evidence.get("review_state")
+    threads = state.get("threads") if isinstance(state, dict) else None
+    if not isinstance(threads, list):
+        raise SemanticReviewError("MALFORMED_REVIEW_STATE")
+    blocks: list[str] = []
+    for thread in threads:
+        if not isinstance(thread, dict) or not isinstance(thread.get("id"), str):
+            raise SemanticReviewError("MALFORMED_REVIEW_STATE")
+        if not isinstance(thread.get("is_resolved"), bool):
+            raise SemanticReviewError("MALFORMED_REVIEW_STATE")
+        if not thread["is_resolved"]:
+            blocks.append(f"UNRESOLVED_REVIEW_THREAD:{thread['id']}")
+    return tuple(sorted(blocks))
+
+
 @dataclass(frozen=True, init=False)
 class EvidencePacket:
     """Immutable model input bound to one pull-request head."""

--- a/src/supportability_gate/semantic_contract.py
+++ b/src/supportability_gate/semantic_contract.py
@@ -17,7 +17,9 @@ SCHEMA_VERSION = "semantic-review.v2"
 STANDARD_SHA256 = "81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2"
 TRUSTED_OWNER_ID = 229662739
 SHA_PATTERN = re.compile(r"[0-9a-f]{40}\Z")
-REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\Z")
+REPOSITORY_PATTERN = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?/(?!\.{1,2}\Z)[A-Za-z0-9_.-]+\Z"
+)
 PROFILE_INSTRUCTIONS = {
     "contract-correctness": (
         "Build a complete acceptance-criteria matrix from PR and closing-issue authority, then "

--- a/src/supportability_gate/semantic_contract.py
+++ b/src/supportability_gate/semantic_contract.py
@@ -14,6 +14,7 @@ MODEL = "gpt-5.6-sol"
 REASONING_EFFORT = "medium"
 RUBRIC_VERSION = "convergent-review.v1"
 SCHEMA_VERSION = "semantic-review.v2"
+MAX_WORKER_RESULT_BYTES = 100_000
 STANDARD_SHA256 = "81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2"
 TRUSTED_OWNER_ID = 229662739
 SHA_PATTERN = re.compile(r"[0-9a-f]{40}\Z")
@@ -53,23 +54,6 @@ class SemanticReviewError(ValueError):
     def __init__(self, code: str) -> None:
         super().__init__(code)
         self.code = code
-
-
-def unresolved_review_blocks(evidence: dict[str, object]) -> tuple[str, ...]:
-    """Return deterministic blocks for current unresolved GitHub threads."""
-    state = evidence.get("review_state")
-    threads = state.get("threads") if isinstance(state, dict) else None
-    if not isinstance(threads, list):
-        raise SemanticReviewError("MALFORMED_REVIEW_STATE")
-    blocks: list[str] = []
-    for thread in threads:
-        if not isinstance(thread, dict) or not isinstance(thread.get("id"), str):
-            raise SemanticReviewError("MALFORMED_REVIEW_STATE")
-        if not isinstance(thread.get("is_resolved"), bool):
-            raise SemanticReviewError("MALFORMED_REVIEW_STATE")
-        if not thread["is_resolved"]:
-            blocks.append(f"UNRESOLVED_REVIEW_THREAD:{thread['id']}")
-    return tuple(sorted(blocks))
 
 
 @dataclass(frozen=True, init=False)

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -20,6 +20,7 @@ from supportability_gate.semantic_contract import (
     SHA_PATTERN,
     EvidencePacket,
     SemanticReviewError,
+    unresolved_review_blocks,
 )
 
 POLL_SECONDS = 60
@@ -106,9 +107,9 @@ def discover_candidates(
             candidate = _candidate(repository, pull)
             if not app.handoff_ready(name, candidate.head_sha, token):
                 continue
-            packet = app.m10_evidence_packet(
-                name, pull, token, app.evidence_packet(name, pull, token)
-            )
+            packet = app.evidence_packet(name, pull, token)
+            if not unresolved_review_blocks(packet.evidence):
+                packet = app.m10_evidence_packet(name, pull, token, packet)
             if app.replay_result(packet, token) is None:
                 candidates.append(replace(candidate, packet=packet))
     return tuple(candidates)

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -294,6 +294,7 @@ def _finish_worker(
         worker.stderr.close()
         if worker.lease_file is not None:
             worker.lease_file.unlink(missing_ok=True)
+            worker.lease_file.with_name(worker.lease_file.name + ".revoked").unlink(missing_ok=True)
         del active[key]
     return revoked
 

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -20,6 +20,7 @@ from supportability_gate.semantic_contract import (
     SHA_PATTERN,
     SemanticReviewError,
 )
+from supportability_gate.semantic_lease import revoke_publication_lease
 
 POLL_SECONDS = 60
 MAX_WORKERS = 2
@@ -258,7 +259,7 @@ def _report_worker(worker: ActiveWorker, timed_out: bool) -> None:
 def _revoke_worker(worker: ActiveWorker) -> None:
     """Revoke final-check publication before abandoning an unconfirmed process."""
     if worker.lease_file is not None:
-        worker.lease_file.write_text("revoked", encoding="utf-8")
+        revoke_publication_lease(worker.lease_file)
 
 
 def _finish_worker(
@@ -267,8 +268,11 @@ def _finish_worker(
     worker: ActiveWorker,
     timed_out: bool,
 ) -> bool:
-    if not _terminate_worker(worker, timed_out):
+    if timed_out:
         _revoke_worker(worker)
+    if not _terminate_worker(worker, timed_out):
+        if not timed_out:
+            _revoke_worker(worker)
         return False
     try:
         _report_worker(worker, timed_out)

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -102,7 +102,12 @@ def discover_candidates(
         name = repository["full_name"]
         for pull in app.open_pulls(name, token):
             candidate = _candidate(repository, pull)
-            if app.handoff_ready(name, candidate.head_sha, token):
+            if not app.handoff_ready(name, candidate.head_sha, token):
+                continue
+            packet = app.m10_evidence_packet(
+                name, pull, token, app.evidence_packet(name, pull, token)
+            )
+            if app.replay_result(packet, token) is None:
                 candidates.append(candidate)
     return tuple(candidates)
 
@@ -172,7 +177,11 @@ def launch_worker(
     stderr = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
     trusted_directory = Path(sys.executable).resolve().parent
     lease = tempfile.NamedTemporaryFile(
-        mode="w", encoding="utf-8", dir=trusted_directory, prefix="semantic-worker-", delete=False
+        mode="w",
+        encoding="utf-8",
+        dir=private_key.resolve().parent,
+        prefix="semantic-worker-",
+        delete=False,
     )
     lease.write("active")
     lease.close()
@@ -256,10 +265,15 @@ def _report_worker(worker: ActiveWorker, timed_out: bool) -> None:
     )
 
 
-def _revoke_worker(worker: ActiveWorker) -> None:
+def _revoke_worker(worker: ActiveWorker) -> bool:
     """Revoke final-check publication before abandoning an unconfirmed process."""
-    if worker.lease_file is not None:
+    if worker.lease_file is None:
+        return True
+    try:
         revoke_publication_lease(worker.lease_file)
+    except (OSError, SemanticReviewError):
+        return False
+    return True
 
 
 def _finish_worker(
@@ -268,11 +282,10 @@ def _finish_worker(
     worker: ActiveWorker,
     timed_out: bool,
 ) -> bool:
-    if timed_out:
-        _revoke_worker(worker)
+    revoked = not timed_out or _revoke_worker(worker)
     if not _terminate_worker(worker, timed_out):
         if not timed_out:
-            _revoke_worker(worker)
+            revoked = _revoke_worker(worker)
         return False
     try:
         _report_worker(worker, timed_out)
@@ -282,7 +295,7 @@ def _finish_worker(
         if worker.lease_file is not None:
             worker.lease_file.unlink(missing_ok=True)
         del active[key]
-    return True
+    return revoked
 
 
 def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None = None) -> None:
@@ -299,7 +312,6 @@ def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None 
             cleanup_failed = True
     if cleanup_failed:
         for key, worker in tuple(active.items()):
-            _revoke_worker(worker)
             if key not in attempted:
                 _finish_worker(active, key, worker, True)
         raise subprocess.SubprocessError("WORKER_TERMINATION_FAILURE")

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -198,6 +198,7 @@ def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None 
         timed_out = current - worker.started_at > WORKER_TIMEOUT_SECONDS
         if worker.process.poll() is None and not timed_out:
             continue
+        terminated = True
         try:
             if timed_out:
                 worker.process.kill()
@@ -209,6 +210,9 @@ def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None 
                     worker.process.wait(timeout=30)
                 except subprocess.TimeoutExpired:
                     cleanup_failed = True
+                    terminated = False
+            if not terminated:
+                continue
             worker.stdout.seek(0)
             worker.stderr.seek(0)
             print(
@@ -226,9 +230,10 @@ def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None 
                 flush=True,
             )
         finally:
-            worker.stdout.close()
-            worker.stderr.close()
-            del active[key]
+            if terminated:
+                worker.stdout.close()
+                worker.stderr.close()
+                del active[key]
     if cleanup_failed:
         raise subprocess.SubprocessError("WORKER_TERMINATION_FAILURE")
 
@@ -280,7 +285,11 @@ def run_dispatch_loop(arguments: argparse.Namespace, app: GitHubApp) -> int:
                 last_repository = launched_repository
             time.sleep(POLL_SECONDS)
     finally:
-        reap_workers(active, float("inf"))
+        while active:
+            try:
+                reap_workers(active, float("inf"))
+            except subprocess.SubprocessError:
+                time.sleep(1)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 
 from supportability_gate.github_app import GitHubApp
 from supportability_gate.semantic_contract import SHA_PATTERN, SemanticReviewError
@@ -17,6 +20,7 @@ from supportability_gate.semantic_contract import SHA_PATTERN, SemanticReviewErr
 POLL_SECONDS = 60
 MAX_WORKERS = 2
 WORKER_TIMEOUT_SECONDS = 90 * 60
+CREATED_AT_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\Z")
 
 
 @dataclass(frozen=True)
@@ -27,7 +31,7 @@ class Candidate:
     repository: str
     pull_number: int
     head_sha: str
-    created_at: str
+    created_at: datetime
 
     @property
     def key(self) -> tuple[int, int]:
@@ -41,6 +45,8 @@ class ActiveWorker:
     candidate: Candidate
     process: subprocess.Popen[str]
     started_at: float
+    stdout: IO[str]
+    stderr: IO[str]
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -62,11 +68,16 @@ def _candidate(repository: dict[str, Any], pull: dict[str, Any]) -> Candidate:
         or not isinstance(name, str)
         or type(pull_number) is not int
         or not isinstance(created_at, str)
+        or CREATED_AT_PATTERN.fullmatch(created_at) is None
         or not isinstance(head_sha, str)
         or SHA_PATTERN.fullmatch(head_sha) is None
     ):
         raise SemanticReviewError("MALFORMED_PULL_REQUEST")
-    return Candidate(repository_id, name, pull_number, head_sha, created_at)
+    try:
+        created = datetime.fromisoformat(created_at[:-1] + "+00:00")
+    except ValueError as error:
+        raise SemanticReviewError("MALFORMED_PULL_REQUEST") from error
+    return Candidate(repository_id, name, pull_number, head_sha, created)
 
 
 def discover_candidates(
@@ -126,6 +137,8 @@ def _worker_arguments(
         candidate.repository,
         "--pull-number",
         str(candidate.pull_number),
+        "--head-sha",
+        candidate.head_sha,
         "--app-id",
         str(app_id),
         "--installation-id",
@@ -139,14 +152,21 @@ def launch_worker(
     candidate: Candidate, app_id: int, installation_id: int, private_key: Path
 ) -> ActiveWorker:
     """Launch one fixed worker command without a shell."""
-    process = subprocess.Popen(
-        _worker_arguments(candidate, app_id, installation_id, private_key),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        shell=False,
-    )
-    return ActiveWorker(candidate, process, time.monotonic())
+    stdout = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
+    stderr = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
+    try:
+        process = subprocess.Popen(
+            _worker_arguments(candidate, app_id, installation_id, private_key),
+            stdout=stdout,
+            stderr=stderr,
+            text=True,
+            shell=False,
+        )
+    except Exception:
+        stdout.close()
+        stderr.close()
+        raise
+    return ActiveWorker(candidate, process, time.monotonic(), stdout, stderr)
 
 
 def fill_slots(
@@ -159,8 +179,11 @@ def fill_slots(
 ) -> int | None:
     """Launch only nonduplicate candidates up to the fixed machine cap."""
     last_repository = None
-    waiting = tuple(item for item in candidates if item.key not in active)
-    for candidate in waiting[: MAX_WORKERS - len(active)]:
+    waiting: dict[tuple[int, int], Candidate] = {}
+    for item in candidates:
+        if item.key not in active:
+            waiting.setdefault(item.key, item)
+    for candidate in tuple(waiting.values())[: MAX_WORKERS - len(active)]:
         active[candidate.key] = launch_worker(candidate, app_id, installation_id, private_key)
         last_repository = candidate.repository_id
         after_pulls[candidate.repository_id] = candidate.pull_number
@@ -170,28 +193,44 @@ def fill_slots(
 def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None = None) -> None:
     """Capture completed output and terminate workers beyond the fixed timeout."""
     current = time.monotonic() if now is None else now
+    cleanup_failed = False
     for key, worker in tuple(active.items()):
         timed_out = current - worker.started_at > WORKER_TIMEOUT_SECONDS
         if worker.process.poll() is None and not timed_out:
             continue
-        if timed_out:
-            worker.process.kill()
-        stdout, stderr = worker.process.communicate(timeout=30)
-        print(
-            json.dumps(
-                {
-                    "pull": worker.candidate.pull_number,
-                    "repository": worker.candidate.repository,
-                    "returncode": worker.process.returncode,
-                    "stderr": stderr[-2000:],
-                    "stdout": stdout[-2000:],
-                    "timed_out": timed_out,
-                },
-                sort_keys=True,
-            ),
-            flush=True,
-        )
-        del active[key]
+        try:
+            if timed_out:
+                worker.process.kill()
+            try:
+                worker.process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                worker.process.kill()
+                try:
+                    worker.process.wait(timeout=30)
+                except subprocess.TimeoutExpired:
+                    cleanup_failed = True
+            worker.stdout.seek(0)
+            worker.stderr.seek(0)
+            print(
+                json.dumps(
+                    {
+                        "pull": worker.candidate.pull_number,
+                        "repository": worker.candidate.repository,
+                        "returncode": worker.process.returncode,
+                        "stderr": worker.stderr.read()[-2000:],
+                        "stdout": worker.stdout.read()[-2000:],
+                        "timed_out": timed_out,
+                    },
+                    sort_keys=True,
+                ),
+                flush=True,
+            )
+        finally:
+            worker.stdout.close()
+            worker.stderr.close()
+            del active[key]
+    if cleanup_failed:
+        raise subprocess.SubprocessError("WORKER_TERMINATION_FAILURE")
 
 
 def _shadow(repositories: tuple[dict[str, Any], ...], candidates: tuple[Candidate, ...]) -> None:
@@ -214,7 +253,7 @@ def _shadow(repositories: tuple[dict[str, Any], ...], candidates: tuple[Candidat
     )
 
 
-def _run(arguments: argparse.Namespace, app: GitHubApp) -> int:
+def run_dispatch_loop(arguments: argparse.Namespace, app: GitHubApp) -> int:
     active: dict[tuple[int, int], ActiveWorker] = {}
     last_repository: int | None = None
     after_pulls: dict[int, int] = {}
@@ -249,7 +288,7 @@ def main(argv: list[str] | None = None) -> int:
     arguments = _parser().parse_args(argv)
     try:
         private_key = arguments.private_key.read_bytes()
-        return _run(
+        return run_dispatch_loop(
             arguments,
             GitHubApp(arguments.app_id, arguments.installation_id, private_key),
         )

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -205,6 +205,26 @@ def _terminate_worker(worker: ActiveWorker, timed_out: bool) -> bool:
     return True
 
 
+def _report_worker(worker: ActiveWorker, timed_out: bool) -> None:
+    """Emit bounded worker output after confirmed process termination."""
+    worker.stdout.seek(0)
+    worker.stderr.seek(0)
+    print(
+        json.dumps(
+            {
+                "pull": worker.candidate.pull_number,
+                "repository": worker.candidate.repository,
+                "returncode": worker.process.returncode,
+                "stderr": worker.stderr.read()[-2000:],
+                "stdout": worker.stdout.read()[-2000:],
+                "timed_out": timed_out,
+            },
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+
+
 def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None = None) -> None:
     """Capture completed output and terminate workers beyond the fixed timeout."""
     current = time.monotonic() if now is None else now
@@ -218,22 +238,7 @@ def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None 
             cleanup_failed = True
             continue
         try:
-            worker.stdout.seek(0)
-            worker.stderr.seek(0)
-            print(
-                json.dumps(
-                    {
-                        "pull": worker.candidate.pull_number,
-                        "repository": worker.candidate.repository,
-                        "returncode": worker.process.returncode,
-                        "stderr": worker.stderr.read()[-2000:],
-                        "stdout": worker.stdout.read()[-2000:],
-                        "timed_out": timed_out,
-                    },
-                    sort_keys=True,
-                ),
-                flush=True,
-            )
+            _report_worker(worker, timed_out)
         finally:
             worker.stdout.close()
             worker.stderr.close()
@@ -289,11 +294,8 @@ def run_dispatch_loop(arguments: argparse.Namespace, app: GitHubApp) -> int:
                 last_repository = launched_repository
             time.sleep(POLL_SECONDS)
     finally:
-        while active:
-            try:
-                reap_workers(active, float("inf"))
-            except subprocess.SubprocessError:
-                time.sleep(1)
+        if active:
+            reap_workers(active, float("inf"))
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -190,6 +190,21 @@ def fill_slots(
     return last_repository
 
 
+def _terminate_worker(worker: ActiveWorker, timed_out: bool) -> bool:
+    """Return only after one worker terminates or two bounded kill waits fail."""
+    if timed_out:
+        worker.process.kill()
+    try:
+        worker.process.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        worker.process.kill()
+        try:
+            worker.process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            return False
+    return True
+
+
 def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None = None) -> None:
     """Capture completed output and terminate workers beyond the fixed timeout."""
     current = time.monotonic() if now is None else now
@@ -198,21 +213,11 @@ def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None 
         timed_out = current - worker.started_at > WORKER_TIMEOUT_SECONDS
         if worker.process.poll() is None and not timed_out:
             continue
-        terminated = True
+        terminated = _terminate_worker(worker, timed_out)
+        if not terminated:
+            cleanup_failed = True
+            continue
         try:
-            if timed_out:
-                worker.process.kill()
-            try:
-                worker.process.wait(timeout=30)
-            except subprocess.TimeoutExpired:
-                worker.process.kill()
-                try:
-                    worker.process.wait(timeout=30)
-                except subprocess.TimeoutExpired:
-                    cleanup_failed = True
-                    terminated = False
-            if not terminated:
-                continue
             worker.stdout.seek(0)
             worker.stderr.seek(0)
             print(
@@ -230,10 +235,9 @@ def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None 
                 flush=True,
             )
         finally:
-            if terminated:
-                worker.stdout.close()
-                worker.stderr.close()
-                del active[key]
+            worker.stdout.close()
+            worker.stderr.close()
+            del active[key]
     if cleanup_failed:
         raise subprocess.SubprocessError("WORKER_TERMINATION_FAILURE")
 

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -15,18 +15,19 @@ from pathlib import Path
 from typing import IO, Any
 
 from supportability_gate.github_app import GitHubApp
+from supportability_gate.review_state import unresolved_review_blocks
 from supportability_gate.semantic_contract import (
+    MAX_WORKER_RESULT_BYTES,
     REPOSITORY_PATTERN,
     SHA_PATTERN,
     EvidencePacket,
     SemanticReviewError,
-    unresolved_review_blocks,
 )
+from supportability_gate.semantic_lease import exclusive_lease, pull_lock_path
 
 POLL_SECONDS = 60
 MAX_WORKERS = 2
 WORKER_TIMEOUT_SECONDS = 90 * 60
-MAX_RESULT_BYTES = 100_000
 CREATED_AT_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\Z")
 
 
@@ -56,6 +57,7 @@ class ActiveWorker:
     stdout: IO[str]
     stderr: IO[str]
     result_file: Path | None = None
+    lock_file: Path | None = None
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -202,7 +204,15 @@ def launch_worker(
         stderr.close()
         result_file.unlink(missing_ok=True)
         raise
-    return ActiveWorker(candidate, process, time.monotonic(), stdout, stderr, result_file)
+    return ActiveWorker(
+        candidate,
+        process,
+        time.monotonic(),
+        stdout,
+        stderr,
+        result_file,
+        pull_lock_path(private_key, candidate.repository, candidate.pull_number),
+    )
 
 
 def fill_slots(
@@ -269,8 +279,13 @@ def _report_worker(worker: ActiveWorker, timed_out: bool) -> None:
 
 def _publish_worker_result(app: GitHubApp, worker: ActiveWorker) -> None:
     """Publish one bounded worker result only after confirmed process exit."""
-    packet, path = worker.candidate.packet, worker.result_file
-    if packet is None or path is None or path.stat().st_size > MAX_RESULT_BYTES:
+    packet, path, lock_file = worker.candidate.packet, worker.result_file, worker.lock_file
+    if (
+        packet is None
+        or path is None
+        or lock_file is None
+        or path.stat().st_size > MAX_WORKER_RESULT_BYTES
+    ):
         raise SemanticReviewError("MALFORMED_WORKER_RESULT")
     try:
         result = json.loads(path.read_text(encoding="utf-8"))
@@ -286,9 +301,12 @@ def _publish_worker_result(app: GitHubApp, worker: ActiveWorker) -> None:
         or not isinstance(result["summary"], str)
     ):
         raise SemanticReviewError("MALFORMED_WORKER_RESULT")
-    token = app.installation_token()
-    app.assert_current(packet, worker.candidate.pull_number, token)
-    app.complete_check(packet, token, result["check_id"], result["conclusion"], result["summary"])
+    with exclusive_lease(lock_file):
+        token = app.installation_token()
+        app.assert_current(packet, worker.candidate.pull_number, token)
+        app.complete_check(
+            packet, token, result["check_id"], result["conclusion"], result["summary"]
+        )
 
 
 def _finish_worker(

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -44,13 +44,14 @@ class Candidate:
 
 @dataclass
 class ActiveWorker:
-    """One launched worker plus its finite runtime boundary."""
+    """One launched worker plus bounded supervision and publication lease."""
 
     candidate: Candidate
     process: subprocess.Popen[str]
     started_at: float
     stdout: IO[str]
     stderr: IO[str]
+    lease_file: Path | None = None
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -134,7 +135,11 @@ def fair_order(
 
 
 def _worker_arguments(
-    candidate: Candidate, app_id: int, installation_id: int, private_key: Path
+    candidate: Candidate,
+    app_id: int,
+    installation_id: int,
+    private_key: Path,
+    lease_file: Path,
 ) -> list[str]:
     return [
         sys.executable,
@@ -152,7 +157,9 @@ def _worker_arguments(
         "--installation-id",
         str(installation_id),
         "--private-key",
-        str(private_key),
+        str(private_key.resolve()),
+        "--lease-file",
+        str(lease_file),
     ]
 
 
@@ -162,20 +169,28 @@ def launch_worker(
     """Launch one fixed worker command without a shell."""
     stdout = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
     stderr = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
+    trusted_directory = Path(sys.executable).resolve().parent
+    lease = tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=trusted_directory, prefix="semantic-worker-", delete=False
+    )
+    lease.write("active")
+    lease.close()
+    lease_file = Path(lease.name)
     try:
         process = subprocess.Popen(
-            _worker_arguments(candidate, app_id, installation_id, private_key),
+            _worker_arguments(candidate, app_id, installation_id, private_key, lease_file),
             stdout=stdout,
             stderr=stderr,
             text=True,
             shell=False,
-            cwd=Path(sys.executable).resolve().parent,
+            cwd=trusted_directory,
         )
     except Exception:
         stdout.close()
         stderr.close()
+        lease_file.unlink(missing_ok=True)
         raise
-    return ActiveWorker(candidate, process, time.monotonic(), stdout, stderr)
+    return ActiveWorker(candidate, process, time.monotonic(), stdout, stderr, lease_file)
 
 
 def fill_slots(
@@ -240,25 +255,49 @@ def _report_worker(worker: ActiveWorker, timed_out: bool) -> None:
     )
 
 
+def _revoke_worker(worker: ActiveWorker) -> None:
+    """Revoke final-check publication before abandoning an unconfirmed process."""
+    if worker.lease_file is not None:
+        worker.lease_file.write_text("revoked", encoding="utf-8")
+
+
+def _finish_worker(
+    active: dict[tuple[int, int], ActiveWorker],
+    key: tuple[int, int],
+    worker: ActiveWorker,
+    timed_out: bool,
+) -> bool:
+    if not _terminate_worker(worker, timed_out):
+        _revoke_worker(worker)
+        return False
+    try:
+        _report_worker(worker, timed_out)
+    finally:
+        worker.stdout.close()
+        worker.stderr.close()
+        if worker.lease_file is not None:
+            worker.lease_file.unlink(missing_ok=True)
+        del active[key]
+    return True
+
+
 def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None = None) -> None:
     """Capture completed output and terminate workers beyond the fixed timeout."""
     current = time.monotonic() if now is None else now
+    attempted: set[tuple[int, int]] = set()
     cleanup_failed = False
     for key, worker in tuple(active.items()):
         timed_out = current - worker.started_at > WORKER_TIMEOUT_SECONDS
         if worker.process.poll() is None and not timed_out:
             continue
-        terminated = _terminate_worker(worker, timed_out)
-        if not terminated:
+        attempted.add(key)
+        if not _finish_worker(active, key, worker, timed_out):
             cleanup_failed = True
-            continue
-        try:
-            _report_worker(worker, timed_out)
-        finally:
-            worker.stdout.close()
-            worker.stderr.close()
-            del active[key]
     if cleanup_failed:
+        for key, worker in tuple(active.items()):
+            _revoke_worker(worker)
+            if key not in attempted:
+                _finish_worker(active, key, worker, True)
         raise subprocess.SubprocessError("WORKER_TERMINATION_FAILURE")
 
 

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -17,13 +17,13 @@ from typing import IO, Any
 from supportability_gate.github_app import GitHubApp
 from supportability_gate.review_state import unresolved_review_blocks
 from supportability_gate.semantic_contract import (
-    MAX_WORKER_RESULT_BYTES,
     REPOSITORY_PATTERN,
     SHA_PATTERN,
     EvidencePacket,
     SemanticReviewError,
 )
-from supportability_gate.semantic_lease import exclusive_lease, pull_lock_path
+from supportability_gate.semantic_lease import pull_lock_path
+from supportability_gate.semantic_result import publish_worker_result
 
 POLL_SECONDS = 60
 MAX_WORKERS = 2
@@ -277,38 +277,6 @@ def _report_worker(worker: ActiveWorker, timed_out: bool) -> None:
     )
 
 
-def _publish_worker_result(app: GitHubApp, worker: ActiveWorker) -> None:
-    """Publish one bounded worker result only after confirmed process exit."""
-    packet, path, lock_file = worker.candidate.packet, worker.result_file, worker.lock_file
-    if (
-        packet is None
-        or path is None
-        or lock_file is None
-        or path.stat().st_size > MAX_WORKER_RESULT_BYTES
-    ):
-        raise SemanticReviewError("MALFORMED_WORKER_RESULT")
-    try:
-        result = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as error:
-        raise SemanticReviewError("MALFORMED_WORKER_RESULT") from error
-    if (
-        not isinstance(result, dict)
-        or set(result) != {"check_id", "conclusion", "evidence_sha256", "summary"}
-        or type(result["check_id"]) is not int
-        or result["check_id"] <= 0
-        or result["conclusion"] not in {"success", "failure", "action_required"}
-        or result["evidence_sha256"] != packet.sha256
-        or not isinstance(result["summary"], str)
-    ):
-        raise SemanticReviewError("MALFORMED_WORKER_RESULT")
-    with exclusive_lease(lock_file):
-        token = app.installation_token()
-        app.assert_current(packet, worker.candidate.pull_number, token)
-        app.complete_check(
-            packet, token, result["check_id"], result["conclusion"], result["summary"]
-        )
-
-
 def _finish_worker(
     active: dict[tuple[int, int], ActiveWorker],
     key: tuple[int, int],
@@ -320,8 +288,14 @@ def _finish_worker(
         return False
     try:
         _report_worker(worker, timed_out)
-        if not timed_out and app is not None:
-            _publish_worker_result(app, worker)
+        if not timed_out and worker.process.returncode == 0 and app is not None:
+            publish_worker_result(
+                app,
+                worker.candidate.packet,
+                worker.candidate.pull_number,
+                worker.result_file,
+                worker.lock_file,
+            )
     finally:
         worker.stdout.close()
         worker.stderr.close()

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -1,0 +1,244 @@
+"""Discover eligible App repositories and supervise ephemeral pull-request workers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from supportability_gate.github_app import GitHubApp
+from supportability_gate.semantic_contract import SHA_PATTERN, SemanticReviewError
+
+POLL_SECONDS = 60
+MAX_WORKERS = 2
+WORKER_TIMEOUT_SECONDS = 90 * 60
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One exact pull request ready for semantic review."""
+
+    repository_id: int
+    repository: str
+    pull_number: int
+    head_sha: str
+    created_at: str
+
+    @property
+    def key(self) -> tuple[int, int]:
+        return self.repository_id, self.pull_number
+
+
+@dataclass
+class ActiveWorker:
+    """One launched worker plus its finite runtime boundary."""
+
+    candidate: Candidate
+    process: subprocess.Popen[str]
+    started_at: float
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="supportability-semantic-dispatch")
+    parser.add_argument("--app-id", required=True, type=int)
+    parser.add_argument("--installation-id", required=True, type=int)
+    parser.add_argument("--private-key", required=True, type=Path)
+    parser.add_argument("--shadow", action="store_true")
+    return parser
+
+
+def _candidate(repository: dict[str, Any], pull: dict[str, Any]) -> Candidate:
+    repository_id, name = repository.get("id"), repository.get("full_name")
+    pull_number, created_at = pull.get("number"), pull.get("created_at")
+    head = pull.get("head")
+    head_sha = head.get("sha") if isinstance(head, dict) else None
+    if (
+        type(repository_id) is not int
+        or not isinstance(name, str)
+        or type(pull_number) is not int
+        or not isinstance(created_at, str)
+        or not isinstance(head_sha, str)
+        or SHA_PATTERN.fullmatch(head_sha) is None
+    ):
+        raise SemanticReviewError("MALFORMED_PULL_REQUEST")
+    return Candidate(repository_id, name, pull_number, head_sha, created_at)
+
+
+def discover_candidates(
+    app: GitHubApp,
+    token: str,
+    repositories: tuple[dict[str, Any], ...] | None = None,
+) -> tuple[Candidate, ...]:
+    """Discover exact-head PRs whose prerequisite artifact already exists."""
+    candidates = []
+    for repository in (
+        app.installation_repositories(token) if repositories is None else repositories
+    ):
+        name = repository["full_name"]
+        for pull in app.open_pulls(name, token):
+            candidate = _candidate(repository, pull)
+            if app.handoff_ready(name, candidate.head_sha, token):
+                candidates.append(candidate)
+    return tuple(candidates)
+
+
+def fair_order(
+    candidates: tuple[Candidate, ...], after_repository: int | None = None
+) -> tuple[Candidate, ...]:
+    """Round-robin repositories while preserving oldest-PR order within each."""
+    grouped: dict[int, list[Candidate]] = {}
+    for candidate in sorted(candidates, key=lambda item: (item.created_at, item.pull_number)):
+        grouped.setdefault(candidate.repository_id, []).append(candidate)
+    repositories = list(grouped)
+    if after_repository in repositories:
+        offset = repositories.index(after_repository) + 1
+        repositories = repositories[offset:] + repositories[:offset]
+    ordered: list[Candidate] = []
+    while any(grouped.values()):
+        for repository_id in repositories:
+            if grouped[repository_id]:
+                ordered.append(grouped[repository_id].pop(0))
+    return tuple(ordered)
+
+
+def _worker_arguments(
+    candidate: Candidate, app_id: int, installation_id: int, private_key: Path
+) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "supportability_gate.semantic_cli",
+        "--repository",
+        candidate.repository,
+        "--pull-number",
+        str(candidate.pull_number),
+        "--app-id",
+        str(app_id),
+        "--installation-id",
+        str(installation_id),
+        "--private-key",
+        str(private_key),
+    ]
+
+
+def launch_worker(
+    candidate: Candidate, app_id: int, installation_id: int, private_key: Path
+) -> ActiveWorker:
+    """Launch one fixed worker command without a shell."""
+    process = subprocess.Popen(
+        _worker_arguments(candidate, app_id, installation_id, private_key),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        shell=False,
+    )
+    return ActiveWorker(candidate, process, time.monotonic())
+
+
+def fill_slots(
+    active: dict[tuple[int, int], ActiveWorker],
+    candidates: tuple[Candidate, ...],
+    app_id: int,
+    installation_id: int,
+    private_key: Path,
+) -> int | None:
+    """Launch only nonduplicate candidates up to the fixed machine cap."""
+    last_repository = None
+    waiting = tuple(item for item in candidates if item.key not in active)
+    for candidate in waiting[: MAX_WORKERS - len(active)]:
+        active[candidate.key] = launch_worker(candidate, app_id, installation_id, private_key)
+        last_repository = candidate.repository_id
+    return last_repository
+
+
+def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None = None) -> None:
+    """Capture completed output and terminate workers beyond the fixed timeout."""
+    current = time.monotonic() if now is None else now
+    for key, worker in tuple(active.items()):
+        timed_out = current - worker.started_at > WORKER_TIMEOUT_SECONDS
+        if worker.process.poll() is None and not timed_out:
+            continue
+        if timed_out:
+            worker.process.kill()
+        stdout, stderr = worker.process.communicate(timeout=30)
+        print(
+            json.dumps(
+                {
+                    "pull": worker.candidate.pull_number,
+                    "repository": worker.candidate.repository,
+                    "returncode": worker.process.returncode,
+                    "stderr": stderr[-2000:],
+                    "stdout": stdout[-2000:],
+                    "timed_out": timed_out,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+        del active[key]
+
+
+def _shadow(repositories: tuple[dict[str, Any], ...], candidates: tuple[Candidate, ...]) -> None:
+    print(
+        json.dumps(
+            {
+                "candidates": [
+                    {
+                        "head_sha": item.head_sha,
+                        "pull": item.pull_number,
+                        "repository": item.repository,
+                        "repository_id": item.repository_id,
+                    }
+                    for item in candidates
+                ],
+                "selected_repositories": [item["full_name"] for item in repositories],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def _run(arguments: argparse.Namespace, app: GitHubApp) -> int:
+    active: dict[tuple[int, int], ActiveWorker] = {}
+    last_repository: int | None = None
+    while True:
+        reap_workers(active)
+        token = app.installation_token()
+        repositories = app.installation_repositories(token)
+        candidates = fair_order(discover_candidates(app, token, repositories), last_repository)
+        if arguments.shadow:
+            _shadow(repositories, candidates)
+            return 0
+        launched_repository = fill_slots(
+            active,
+            candidates,
+            arguments.app_id,
+            arguments.installation_id,
+            arguments.private_key,
+        )
+        if launched_repository is not None:
+            last_repository = launched_repository
+        time.sleep(POLL_SECONDS)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run one shadow scan or the production polling dispatcher."""
+    arguments = _parser().parse_args(argv)
+    try:
+        private_key = arguments.private_key.read_bytes()
+        return _run(
+            arguments,
+            GitHubApp(arguments.app_id, arguments.installation_id, private_key),
+        )
+    except (OSError, SemanticReviewError, subprocess.SubprocessError):
+        print("TECHNICAL_FAILURE")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from typing import IO, Any
@@ -18,13 +18,14 @@ from supportability_gate.github_app import GitHubApp
 from supportability_gate.semantic_contract import (
     REPOSITORY_PATTERN,
     SHA_PATTERN,
+    EvidencePacket,
     SemanticReviewError,
 )
-from supportability_gate.semantic_lease import revoke_publication_lease
 
 POLL_SECONDS = 60
 MAX_WORKERS = 2
 WORKER_TIMEOUT_SECONDS = 90 * 60
+MAX_RESULT_BYTES = 100_000
 CREATED_AT_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\Z")
 
 
@@ -37,6 +38,7 @@ class Candidate:
     pull_number: int
     head_sha: str
     created_at: datetime
+    packet: EvidencePacket | None = None
 
     @property
     def key(self) -> tuple[int, int]:
@@ -45,14 +47,14 @@ class Candidate:
 
 @dataclass
 class ActiveWorker:
-    """One launched worker plus bounded supervision and publication lease."""
+    """One launched worker plus bounded supervision and deferred result."""
 
     candidate: Candidate
     process: subprocess.Popen[str]
     started_at: float
     stdout: IO[str]
     stderr: IO[str]
-    lease_file: Path | None = None
+    result_file: Path | None = None
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -108,7 +110,7 @@ def discover_candidates(
                 name, pull, token, app.evidence_packet(name, pull, token)
             )
             if app.replay_result(packet, token) is None:
-                candidates.append(candidate)
+                candidates.append(replace(candidate, packet=packet))
     return tuple(candidates)
 
 
@@ -145,7 +147,7 @@ def _worker_arguments(
     app_id: int,
     installation_id: int,
     private_key: Path,
-    lease_file: Path,
+    result_file: Path,
 ) -> list[str]:
     return [
         sys.executable,
@@ -164,8 +166,8 @@ def _worker_arguments(
         str(installation_id),
         "--private-key",
         str(private_key.resolve()),
-        "--lease-file",
-        str(lease_file),
+        "--result-file",
+        str(result_file),
     ]
 
 
@@ -176,19 +178,18 @@ def launch_worker(
     stdout = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
     stderr = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
     trusted_directory = Path(sys.executable).resolve().parent
-    lease = tempfile.NamedTemporaryFile(
+    result = tempfile.NamedTemporaryFile(
         mode="w",
         encoding="utf-8",
         dir=private_key.resolve().parent,
-        prefix="semantic-worker-",
+        prefix="semantic-result-",
         delete=False,
     )
-    lease.write("active")
-    lease.close()
-    lease_file = Path(lease.name)
+    result.close()
+    result_file = Path(result.name)
     try:
         process = subprocess.Popen(
-            _worker_arguments(candidate, app_id, installation_id, private_key, lease_file),
+            _worker_arguments(candidate, app_id, installation_id, private_key, result_file),
             stdout=stdout,
             stderr=stderr,
             text=True,
@@ -198,9 +199,9 @@ def launch_worker(
     except Exception:
         stdout.close()
         stderr.close()
-        lease_file.unlink(missing_ok=True)
+        result_file.unlink(missing_ok=True)
         raise
-    return ActiveWorker(candidate, process, time.monotonic(), stdout, stderr, lease_file)
+    return ActiveWorker(candidate, process, time.monotonic(), stdout, stderr, result_file)
 
 
 def fill_slots(
@@ -265,15 +266,28 @@ def _report_worker(worker: ActiveWorker, timed_out: bool) -> None:
     )
 
 
-def _revoke_worker(worker: ActiveWorker) -> bool:
-    """Revoke final-check publication before abandoning an unconfirmed process."""
-    if worker.lease_file is None:
-        return True
+def _publish_worker_result(app: GitHubApp, worker: ActiveWorker) -> None:
+    """Publish one bounded worker result only after confirmed process exit."""
+    packet, path = worker.candidate.packet, worker.result_file
+    if packet is None or path is None or path.stat().st_size > MAX_RESULT_BYTES:
+        raise SemanticReviewError("MALFORMED_WORKER_RESULT")
     try:
-        revoke_publication_lease(worker.lease_file)
-    except (OSError, SemanticReviewError):
-        return False
-    return True
+        result = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise SemanticReviewError("MALFORMED_WORKER_RESULT") from error
+    if (
+        not isinstance(result, dict)
+        or set(result) != {"check_id", "conclusion", "evidence_sha256", "summary"}
+        or type(result["check_id"]) is not int
+        or result["check_id"] <= 0
+        or result["conclusion"] not in {"success", "failure", "action_required"}
+        or result["evidence_sha256"] != packet.sha256
+        or not isinstance(result["summary"], str)
+    ):
+        raise SemanticReviewError("MALFORMED_WORKER_RESULT")
+    token = app.installation_token()
+    app.assert_current(packet, worker.candidate.pull_number, token)
+    app.complete_check(packet, token, result["check_id"], result["conclusion"], result["summary"])
 
 
 def _finish_worker(
@@ -281,25 +295,28 @@ def _finish_worker(
     key: tuple[int, int],
     worker: ActiveWorker,
     timed_out: bool,
+    app: GitHubApp | None = None,
 ) -> bool:
-    revoked = not timed_out or _revoke_worker(worker)
     if not _terminate_worker(worker, timed_out):
-        if not timed_out:
-            revoked = _revoke_worker(worker)
         return False
     try:
         _report_worker(worker, timed_out)
+        if not timed_out and app is not None:
+            _publish_worker_result(app, worker)
     finally:
         worker.stdout.close()
         worker.stderr.close()
-        if worker.lease_file is not None:
-            worker.lease_file.unlink(missing_ok=True)
-            worker.lease_file.with_name(worker.lease_file.name + ".revoked").unlink(missing_ok=True)
+        if worker.result_file is not None:
+            worker.result_file.unlink(missing_ok=True)
         del active[key]
-    return revoked
+    return True
 
 
-def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None = None) -> None:
+def reap_workers(
+    active: dict[tuple[int, int], ActiveWorker],
+    now: float | None = None,
+    app: GitHubApp | None = None,
+) -> None:
     """Capture completed output and terminate workers beyond the fixed timeout."""
     current = time.monotonic() if now is None else now
     attempted: set[tuple[int, int]] = set()
@@ -309,12 +326,12 @@ def reap_workers(active: dict[tuple[int, int], ActiveWorker], now: float | None 
         if worker.process.poll() is None and not timed_out:
             continue
         attempted.add(key)
-        if not _finish_worker(active, key, worker, timed_out):
+        if not _finish_worker(active, key, worker, timed_out, app):
             cleanup_failed = True
     if cleanup_failed:
         for key, worker in tuple(active.items()):
             if key not in attempted:
-                _finish_worker(active, key, worker, True)
+                _finish_worker(active, key, worker, True, app)
         raise subprocess.SubprocessError("WORKER_TERMINATION_FAILURE")
 
 
@@ -346,7 +363,7 @@ def run_dispatch_loop(arguments: argparse.Namespace, app: GitHubApp) -> int:
     try:
         while True:
             try:
-                reap_workers(active)
+                reap_workers(active, app=app)
             except subprocess.SubprocessError:
                 reap_failed = True
                 raise
@@ -371,7 +388,7 @@ def run_dispatch_loop(arguments: argparse.Namespace, app: GitHubApp) -> int:
             time.sleep(POLL_SECONDS)
     finally:
         if active and not reap_failed:
-            reap_workers(active, float("inf"))
+            reap_workers(active, float("inf"), app)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -15,7 +15,11 @@ from pathlib import Path
 from typing import IO, Any
 
 from supportability_gate.github_app import GitHubApp
-from supportability_gate.semantic_contract import SHA_PATTERN, SemanticReviewError
+from supportability_gate.semantic_contract import (
+    REPOSITORY_PATTERN,
+    SHA_PATTERN,
+    SemanticReviewError,
+)
 
 POLL_SECONDS = 60
 MAX_WORKERS = 2
@@ -65,8 +69,11 @@ def _candidate(repository: dict[str, Any], pull: dict[str, Any]) -> Candidate:
     head_sha = head.get("sha") if isinstance(head, dict) else None
     if (
         type(repository_id) is not int
+        or repository_id <= 0
         or not isinstance(name, str)
+        or REPOSITORY_PATTERN.fullmatch(name) is None
         or type(pull_number) is not int
+        or pull_number <= 0
         or not isinstance(created_at, str)
         or CREATED_AT_PATTERN.fullmatch(created_at) is None
         or not isinstance(head_sha, str)
@@ -131,6 +138,7 @@ def _worker_arguments(
 ) -> list[str]:
     return [
         sys.executable,
+        "-I",
         "-m",
         "supportability_gate.semantic_cli",
         "--repository",
@@ -161,6 +169,7 @@ def launch_worker(
             stderr=stderr,
             text=True,
             shell=False,
+            cwd=Path(sys.executable).resolve().parent,
         )
     except Exception:
         stdout.close()
@@ -193,11 +202,17 @@ def fill_slots(
 def _terminate_worker(worker: ActiveWorker, timed_out: bool) -> bool:
     """Return only after one worker terminates or two bounded kill waits fail."""
     if timed_out:
-        worker.process.kill()
+        try:
+            worker.process.kill()
+        except OSError:
+            pass
     try:
         worker.process.wait(timeout=30)
     except subprocess.TimeoutExpired:
-        worker.process.kill()
+        try:
+            worker.process.kill()
+        except OSError:
+            pass
         try:
             worker.process.wait(timeout=30)
         except subprocess.TimeoutExpired:
@@ -271,9 +286,14 @@ def run_dispatch_loop(arguments: argparse.Namespace, app: GitHubApp) -> int:
     active: dict[tuple[int, int], ActiveWorker] = {}
     last_repository: int | None = None
     after_pulls: dict[int, int] = {}
+    reap_failed = False
     try:
         while True:
-            reap_workers(active)
+            try:
+                reap_workers(active)
+            except subprocess.SubprocessError:
+                reap_failed = True
+                raise
             token = app.installation_token()
             repositories = app.installation_repositories(token)
             candidates = fair_order(
@@ -294,7 +314,7 @@ def run_dispatch_loop(arguments: argparse.Namespace, app: GitHubApp) -> int:
                 last_repository = launched_repository
             time.sleep(POLL_SECONDS)
     finally:
-        if active:
+        if active and not reap_failed:
             reap_workers(active, float("inf"))
 
 

--- a/src/supportability_gate/semantic_dispatch.py
+++ b/src/supportability_gate/semantic_dispatch.py
@@ -88,12 +88,21 @@ def discover_candidates(
 
 
 def fair_order(
-    candidates: tuple[Candidate, ...], after_repository: int | None = None
+    candidates: tuple[Candidate, ...],
+    after_repository: int | None = None,
+    after_pulls: dict[int, int] | None = None,
 ) -> tuple[Candidate, ...]:
     """Round-robin repositories while preserving oldest-PR order within each."""
     grouped: dict[int, list[Candidate]] = {}
     for candidate in sorted(candidates, key=lambda item: (item.created_at, item.pull_number)):
         grouped.setdefault(candidate.repository_id, []).append(candidate)
+    for repository_id, pull_number in (after_pulls or {}).items():
+        pulls = [item.pull_number for item in grouped.get(repository_id, [])]
+        if pull_number in pulls:
+            offset = pulls.index(pull_number) + 1
+            grouped[repository_id] = (
+                grouped[repository_id][offset:] + grouped[repository_id][:offset]
+            )
     repositories = list(grouped)
     if after_repository in repositories:
         offset = repositories.index(after_repository) + 1
@@ -146,6 +155,7 @@ def fill_slots(
     app_id: int,
     installation_id: int,
     private_key: Path,
+    after_pulls: dict[int, int],
 ) -> int | None:
     """Launch only nonduplicate candidates up to the fixed machine cap."""
     last_repository = None
@@ -153,6 +163,7 @@ def fill_slots(
     for candidate in waiting[: MAX_WORKERS - len(active)]:
         active[candidate.key] = launch_worker(candidate, app_id, installation_id, private_key)
         last_repository = candidate.repository_id
+        after_pulls[candidate.repository_id] = candidate.pull_number
     return last_repository
 
 
@@ -206,24 +217,31 @@ def _shadow(repositories: tuple[dict[str, Any], ...], candidates: tuple[Candidat
 def _run(arguments: argparse.Namespace, app: GitHubApp) -> int:
     active: dict[tuple[int, int], ActiveWorker] = {}
     last_repository: int | None = None
-    while True:
-        reap_workers(active)
-        token = app.installation_token()
-        repositories = app.installation_repositories(token)
-        candidates = fair_order(discover_candidates(app, token, repositories), last_repository)
-        if arguments.shadow:
-            _shadow(repositories, candidates)
-            return 0
-        launched_repository = fill_slots(
-            active,
-            candidates,
-            arguments.app_id,
-            arguments.installation_id,
-            arguments.private_key,
-        )
-        if launched_repository is not None:
-            last_repository = launched_repository
-        time.sleep(POLL_SECONDS)
+    after_pulls: dict[int, int] = {}
+    try:
+        while True:
+            reap_workers(active)
+            token = app.installation_token()
+            repositories = app.installation_repositories(token)
+            candidates = fair_order(
+                discover_candidates(app, token, repositories), last_repository, after_pulls
+            )
+            if arguments.shadow:
+                _shadow(repositories, candidates)
+                return 0
+            launched_repository = fill_slots(
+                active,
+                candidates,
+                arguments.app_id,
+                arguments.installation_id,
+                arguments.private_key,
+                after_pulls,
+            )
+            if launched_repository is not None:
+                last_repository = launched_repository
+            time.sleep(POLL_SECONDS)
+    finally:
+        reap_workers(active, float("inf"))
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/supportability_gate/semantic_lease.py
+++ b/src/supportability_gate/semantic_lease.py
@@ -1,0 +1,95 @@
+"""Coordinate cross-process semantic-worker publication leases."""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import BinaryIO
+
+from supportability_gate.semantic_contract import SemanticReviewError
+
+
+def _lock(handle: BinaryIO) -> None:
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+            getattr(msvcrt, "locking")(handle.fileno(), getattr(msvcrt, "LK_NBLCK"), 1)
+        else:
+            import fcntl
+
+            getattr(fcntl, "flock")(
+                handle.fileno(), getattr(fcntl, "LOCK_EX") | getattr(fcntl, "LOCK_NB")
+            )
+    except OSError as error:
+        raise SemanticReviewError("EVALUATION_IN_PROGRESS") from error
+
+
+def _unlock(handle: BinaryIO) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        getattr(msvcrt, "locking")(handle.fileno(), getattr(msvcrt, "LK_UNLCK"), 1)
+    else:
+        import fcntl
+
+        getattr(fcntl, "flock")(handle.fileno(), getattr(fcntl, "LOCK_UN"))
+
+
+@contextmanager
+def exclusive_lease(path: Path) -> Iterator[None]:
+    """Hold one local cross-process lease."""
+    with path.open("a+b") as handle:
+        _lock(handle)
+        try:
+            yield
+        finally:
+            _unlock(handle)
+
+
+@contextmanager
+def publication_lease(path: Path | None) -> Iterator[None]:
+    """Make active-lease validation atomic with final-check publication."""
+    if path is None:
+        yield
+        return
+    with path.open("r+b") as handle:
+        _lock(handle)
+        try:
+            handle.seek(0)
+            if handle.read() != b"active":
+                raise SemanticReviewError("WORKER_LEASE_REVOKED")
+            yield
+        finally:
+            _unlock(handle)
+
+
+def revoke_publication_lease(path: Path) -> None:
+    """Revoke one worker after any in-flight publication finishes."""
+    deadline = time.monotonic() + 35
+    while True:
+        with path.open("r+b") as handle:
+            try:
+                _lock(handle)
+            except SemanticReviewError as error:
+                if error.code != "EVALUATION_IN_PROGRESS" or time.monotonic() >= deadline:
+                    raise SemanticReviewError("WORKER_LEASE_BUSY") from error
+            else:
+                try:
+                    handle.seek(0)
+                    handle.truncate()
+                    handle.write(b"revoked")
+                    handle.flush()
+                finally:
+                    _unlock(handle)
+                return
+        time.sleep(0.1)

--- a/src/supportability_gate/semantic_lease.py
+++ b/src/supportability_gate/semantic_lease.py
@@ -53,29 +53,3 @@ def exclusive_lease(path: Path) -> Iterator[None]:
             yield
         finally:
             _unlock(handle)
-
-
-@contextmanager
-def publication_lease(path: Path | None) -> Iterator[None]:
-    """Hold one validated worker lease through final-check publication."""
-    if path is None:
-        yield
-        return
-    with path.open("r+b") as handle:
-        _lock(handle)
-        try:
-            handle.seek(0)
-            if path.with_name(path.name + ".revoked").exists() or handle.read() != b"active":
-                raise SemanticReviewError("WORKER_LEASE_REVOKED")
-            yield
-        finally:
-            _unlock(handle)
-
-
-def revoke_publication_lease(path: Path) -> None:
-    """Prevent every future publication acquisition by one worker."""
-    marker = path.with_name(path.name + ".revoked")
-    try:
-        marker.touch(exist_ok=False)
-    except FileExistsError:
-        pass

--- a/src/supportability_gate/semantic_lease.py
+++ b/src/supportability_gate/semantic_lease.py
@@ -1,4 +1,4 @@
-"""Coordinate cross-process semantic-worker publication leases."""
+"""Coordinate cross-process exact-pull evaluation leases."""
 
 from __future__ import annotations
 
@@ -53,3 +53,11 @@ def exclusive_lease(path: Path) -> Iterator[None]:
             yield
         finally:
             _unlock(handle)
+
+
+def pull_lock_path(private_key: Path, repository: str, pull_number: int) -> Path:
+    """Return one stable, filesystem-safe lock path for an exact pull request."""
+    import hashlib
+
+    identity = hashlib.sha256(f"{repository.lower()}#{pull_number}".encode()).hexdigest()
+    return private_key.with_name(f"semantic-review-{identity}.lock")

--- a/src/supportability_gate/semantic_lease.py
+++ b/src/supportability_gate/semantic_lease.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -58,7 +57,7 @@ def exclusive_lease(path: Path) -> Iterator[None]:
 
 @contextmanager
 def publication_lease(path: Path | None) -> Iterator[None]:
-    """Make active-lease validation atomic with final-check publication."""
+    """Hold one validated worker lease through final-check publication."""
     if path is None:
         yield
         return
@@ -66,7 +65,7 @@ def publication_lease(path: Path | None) -> Iterator[None]:
         _lock(handle)
         try:
             handle.seek(0)
-            if handle.read() != b"active":
+            if path.with_name(path.name + ".revoked").exists() or handle.read() != b"active":
                 raise SemanticReviewError("WORKER_LEASE_REVOKED")
             yield
         finally:
@@ -74,22 +73,9 @@ def publication_lease(path: Path | None) -> Iterator[None]:
 
 
 def revoke_publication_lease(path: Path) -> None:
-    """Revoke one worker after any in-flight publication finishes."""
-    deadline = time.monotonic() + 35
-    while True:
-        with path.open("r+b") as handle:
-            try:
-                _lock(handle)
-            except SemanticReviewError as error:
-                if error.code != "EVALUATION_IN_PROGRESS" or time.monotonic() >= deadline:
-                    raise SemanticReviewError("WORKER_LEASE_BUSY") from error
-            else:
-                try:
-                    handle.seek(0)
-                    handle.truncate()
-                    handle.write(b"revoked")
-                    handle.flush()
-                finally:
-                    _unlock(handle)
-                return
-        time.sleep(0.1)
+    """Prevent every future publication acquisition by one worker."""
+    marker = path.with_name(path.name + ".revoked")
+    try:
+        marker.touch(exist_ok=False)
+    except FileExistsError:
+        pass

--- a/src/supportability_gate/semantic_result.py
+++ b/src/supportability_gate/semantic_result.py
@@ -1,0 +1,52 @@
+"""Validate and publish one deferred semantic worker result."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from supportability_gate.github_app import GitHubApp
+from supportability_gate.semantic_contract import (
+    MAX_WORKER_RESULT_BYTES,
+    EvidencePacket,
+    SemanticReviewError,
+)
+from supportability_gate.semantic_lease import exclusive_lease
+
+
+def publish_worker_result(
+    app: GitHubApp,
+    packet: EvidencePacket | None,
+    pull_number: int,
+    path: Path | None,
+    lock_file: Path | None,
+) -> None:
+    """Validate exact evidence, reacquire its lease, then publish."""
+    if (
+        packet is None
+        or path is None
+        or lock_file is None
+        or path.stat().st_size > MAX_WORKER_RESULT_BYTES
+    ):
+        raise SemanticReviewError("MALFORMED_WORKER_RESULT")
+    try:
+        result: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise SemanticReviewError("MALFORMED_WORKER_RESULT") from error
+    if (
+        not isinstance(result, dict)
+        or set(result) != {"check_id", "conclusion", "evidence_sha256", "summary"}
+        or type(result["check_id"]) is not int
+        or result["check_id"] <= 0
+        or result["conclusion"] not in {"success", "failure", "action_required"}
+        or result["evidence_sha256"] != packet.sha256
+        or not isinstance(result["summary"], str)
+    ):
+        raise SemanticReviewError("MALFORMED_WORKER_RESULT")
+    with exclusive_lease(lock_file):
+        token = app.installation_token()
+        app.assert_current(packet, pull_number, token)
+        app.complete_check(
+            packet, token, result["check_id"], result["conclusion"], result["summary"]
+        )

--- a/tests/characterization/semantic-dispatch.characterization.py
+++ b/tests/characterization/semantic-dispatch.characterization.py
@@ -31,7 +31,7 @@ def _behavior() -> dict[str, object]:
         Candidate(2, "owner/two", 2, "c" * 40, datetime.fromisoformat("2026-08-09T02:00:00+00:00")),
     )
     ordered = fair_order(candidates)
-    arguments = _worker_arguments(ordered[0], 42, 7, Path("key.pem"))
+    arguments = _worker_arguments(ordered[0], 42, 7, Path("key.pem"), Path("lease"))
     assert arguments[1:] == [
         "-I",
         "-m",
@@ -47,7 +47,9 @@ def _behavior() -> dict[str, object]:
         "--installation-id",
         "7",
         "--private-key",
-        "key.pem",
+        str(Path("key.pem").resolve()),
+        "--lease-file",
+        "lease",
     ]
     return {
         "fair_order": [[item.repository_id, item.pull_number] for item in ordered],

--- a/tests/characterization/semantic-dispatch.characterization.py
+++ b/tests/characterization/semantic-dispatch.characterization.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _behavior() -> dict[str, object]:
+    expected = {
+        "fair_order": [[1, 1], [2, 2], [1, 3]],
+        "max_workers": 2,
+        "poll_seconds": 60,
+        "worker_timeout_seconds": 5400,
+    }
+    if importlib.util.find_spec("supportability_gate.semantic_dispatch") is None:
+        return expected
+
+    from supportability_gate.semantic_dispatch import (
+        MAX_WORKERS,
+        POLL_SECONDS,
+        WORKER_TIMEOUT_SECONDS,
+        Candidate,
+        _worker_arguments,
+        fair_order,
+    )
+
+    candidates = (
+        Candidate(1, "owner/one", 3, "a" * 40, "2026-08-09T03:00:00Z"),
+        Candidate(1, "owner/one", 1, "b" * 40, "2026-08-09T01:00:00Z"),
+        Candidate(2, "owner/two", 2, "c" * 40, "2026-08-09T02:00:00Z"),
+    )
+    ordered = fair_order(candidates)
+    arguments = _worker_arguments(ordered[0], 42, 7, Path("key.pem"))
+    assert arguments[1:] == [
+        "-m",
+        "supportability_gate.semantic_cli",
+        "--repository",
+        "owner/one",
+        "--pull-number",
+        "1",
+        "--app-id",
+        "42",
+        "--installation-id",
+        "7",
+        "--private-key",
+        "key.pem",
+    ]
+    return {
+        "fair_order": [[item.repository_id, item.pull_number] for item in ordered],
+        "max_workers": MAX_WORKERS,
+        "poll_seconds": POLL_SECONDS,
+        "worker_timeout_seconds": WORKER_TIMEOUT_SECONDS,
+    }
+
+
+print(
+    json.dumps(
+        {"behavior": _behavior(), "scenario": "semantic-dispatch", "schema_version": "1.0"},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+)

--- a/tests/characterization/semantic-dispatch.characterization.py
+++ b/tests/characterization/semantic-dispatch.characterization.py
@@ -33,6 +33,7 @@ def _behavior() -> dict[str, object]:
     ordered = fair_order(candidates)
     arguments = _worker_arguments(ordered[0], 42, 7, Path("key.pem"))
     assert arguments[1:] == [
+        "-I",
         "-m",
         "supportability_gate.semantic_cli",
         "--repository",

--- a/tests/characterization/semantic-dispatch.characterization.py
+++ b/tests/characterization/semantic-dispatch.characterization.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+from datetime import datetime
 from pathlib import Path
 
 
@@ -25,9 +26,9 @@ def _behavior() -> dict[str, object]:
     )
 
     candidates = (
-        Candidate(1, "owner/one", 3, "a" * 40, "2026-08-09T03:00:00Z"),
-        Candidate(1, "owner/one", 1, "b" * 40, "2026-08-09T01:00:00Z"),
-        Candidate(2, "owner/two", 2, "c" * 40, "2026-08-09T02:00:00Z"),
+        Candidate(1, "owner/one", 3, "a" * 40, datetime.fromisoformat("2026-08-09T03:00:00+00:00")),
+        Candidate(1, "owner/one", 1, "b" * 40, datetime.fromisoformat("2026-08-09T01:00:00+00:00")),
+        Candidate(2, "owner/two", 2, "c" * 40, datetime.fromisoformat("2026-08-09T02:00:00+00:00")),
     )
     ordered = fair_order(candidates)
     arguments = _worker_arguments(ordered[0], 42, 7, Path("key.pem"))
@@ -38,6 +39,8 @@ def _behavior() -> dict[str, object]:
         "owner/one",
         "--pull-number",
         "1",
+        "--head-sha",
+        "b" * 40,
         "--app-id",
         "42",
         "--installation-id",

--- a/tests/characterization/semantic-dispatch.characterization.py
+++ b/tests/characterization/semantic-dispatch.characterization.py
@@ -48,7 +48,7 @@ def _behavior() -> dict[str, object]:
         "7",
         "--private-key",
         str(Path("key.pem").resolve()),
-        "--lease-file",
+        "--result-file",
         "lease",
     ]
     return {

--- a/tests/characterization/semantic-dispatch.golden.json
+++ b/tests/characterization/semantic-dispatch.golden.json
@@ -1,0 +1,19 @@
+{
+  "fair_order": [
+    [
+      1,
+      1
+    ],
+    [
+      2,
+      2
+    ],
+    [
+      1,
+      3
+    ]
+  ],
+  "max_workers": 2,
+  "poll_seconds": 60,
+  "worker_timeout_seconds": 5400
+}

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -595,6 +595,34 @@ def test_handoff_ready_requires_successful_exact_head_artifact() -> None:
     assert app.handoff_ready("owner/repo", head_sha, "token") is True
 
 
+def test_handoff_ready_rejects_mixed_malformed_run_collection() -> None:
+    head_sha = "b" * 40
+    app = GitHubApp(
+        42,
+        7,
+        b"unused",
+        opener=lambda *args, **kwargs: _Reply(
+            {
+                "workflow_runs": [
+                    "malformed",
+                    {
+                        "conclusion": "success",
+                        "event": "pull_request",
+                        "head_sha": head_sha,
+                        "id": 123,
+                        "path": ".github/workflows/organization-required.yml",
+                        "run_attempt": 1,
+                        "status": "completed",
+                        "updated_at": "2026-08-09T17:00:00Z",
+                    },
+                ]
+            }
+        ),
+    )
+
+    assert app.handoff_ready("owner/repo", head_sha, "token") is False
+
+
 def test_handoff_ready_accepts_older_success_when_newer_attempt_failed() -> None:
     head_sha = "b" * 40
     replies = iter(

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -494,9 +494,9 @@ def test_installation_repository_discovery_paginates_every_selected_repository()
         urls.append(request.full_url)
         page = 2 if "page=2" in request.full_url else 1
         repositories = (
-            [{"full_name": f"owner/repo-{number}", "id": number} for number in range(100)]
+            [{"full_name": f"owner/repo-{number}", "id": number} for number in range(1, 101)]
             if page == 1
-            else [{"full_name": "owner/repo-100", "id": 100}]
+            else [{"full_name": "owner/repo-101", "id": 101}]
         )
         return _Reply({"repositories": repositories, "total_count": 101})
 
@@ -537,6 +537,26 @@ def test_duplicate_installation_repository_identity_blocks() -> None:
     )
 
     with pytest.raises(SemanticReviewError, match="INCOMPLETE_GITHUB_EVIDENCE"):
+        app.installation_repositories("token")
+
+
+@pytest.mark.parametrize(
+    "repository",
+    [
+        {"full_name": "../repo", "id": 1},
+        {"full_name": "owner/repo?query", "id": 1},
+        {"full_name": "owner/repo", "id": 0},
+    ],
+)
+def test_invalid_installation_repository_identity_blocks(repository: dict[str, Any]) -> None:
+    app = GitHubApp(
+        42,
+        7,
+        b"unused",
+        opener=lambda *args, **kwargs: _Reply({"repositories": [repository], "total_count": 1}),
+    )
+
+    with pytest.raises(SemanticReviewError, match="MALFORMED_GITHUB_RESPONSE"):
         app.installation_repositories("token")
 
 

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -620,10 +620,15 @@ def test_wrong_app_identity_blocks() -> None:
         app.installation_token()
 
 
-def test_open_pull_truncation_blocks() -> None:
-    app = GitHubApp(42, 7, b"unused", opener=lambda *args, **kwargs: _Reply([{}] * 100))
-    with pytest.raises(SemanticReviewError, match="INCOMPLETE_GITHUB_EVIDENCE"):
-        app.open_pulls("mbh-solutions/supportability-gate", "token")
+def test_open_pull_discovery_paginates() -> None:
+    def open_request(request: Any, **kwargs: object) -> _Reply:
+        page = 2 if "page=2" in request.full_url else 1
+        pulls = [{"number": number} for number in range(100)] if page == 1 else [{"number": 100}]
+        return _Reply(pulls)
+
+    app = GitHubApp(42, 7, b"unused", opener=open_request)
+
+    assert len(app.open_pulls("mbh-solutions/supportability-gate", "token")) == 101
 
 
 def test_closed_exact_pull_blocks_before_evaluation() -> None:

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -520,6 +520,26 @@ def test_incomplete_installation_repository_page_blocks() -> None:
         app.installation_repositories("token")
 
 
+def test_duplicate_installation_repository_identity_blocks() -> None:
+    app = GitHubApp(
+        42,
+        7,
+        b"unused",
+        opener=lambda *args, **kwargs: _Reply(
+            {
+                "repositories": [
+                    {"full_name": "owner/one", "id": 1},
+                    {"full_name": "owner/two", "id": 1},
+                ],
+                "total_count": 2,
+            }
+        ),
+    )
+
+    with pytest.raises(SemanticReviewError, match="INCOMPLETE_GITHUB_EVIDENCE"):
+        app.installation_repositories("token")
+
+
 def test_handoff_ready_requires_successful_exact_head_artifact() -> None:
     head_sha = "b" * 40
     replies = iter(
@@ -536,6 +556,45 @@ def test_handoff_ready_requires_successful_exact_head_artifact() -> None:
                         "status": "completed",
                         "updated_at": "2026-08-09T17:00:00Z",
                     }
+                ]
+            },
+            {
+                "artifacts": [
+                    {
+                        "digest": f"sha256:{'c' * 64}",
+                        "expired": False,
+                        "id": 456,
+                        "name": "supportability-evidence-123-1",
+                    }
+                ]
+            },
+        ]
+    )
+    app = GitHubApp(42, 7, b"unused", opener=lambda *args, **kwargs: _Reply(next(replies)))
+
+    assert app.handoff_ready("owner/repo", head_sha, "token") is True
+
+
+def test_handoff_ready_accepts_older_success_when_newer_attempt_failed() -> None:
+    head_sha = "b" * 40
+    replies = iter(
+        [
+            {
+                "workflow_runs": [
+                    {
+                        "conclusion": conclusion,
+                        "event": "pull_request",
+                        "head_sha": head_sha,
+                        "id": run_id,
+                        "path": ".github/workflows/organization-required.yml",
+                        "run_attempt": attempt,
+                        "status": "completed",
+                        "updated_at": updated,
+                    }
+                    for conclusion, run_id, attempt, updated in (
+                        ("failure", 124, 2, "2026-08-09T18:00:00Z"),
+                        ("success", 123, 1, "2026-08-09T17:00:00Z"),
+                    )
                 ]
             },
             {

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -487,6 +487,74 @@ def test_installation_auth_verifies_app_identity() -> None:
     assert app.installation_token() == "installation-token"
 
 
+def test_installation_repository_discovery_paginates_every_selected_repository() -> None:
+    urls: list[str] = []
+
+    def open_request(request: Any, **kwargs: object) -> _Reply:
+        urls.append(request.full_url)
+        page = 2 if "page=2" in request.full_url else 1
+        repositories = (
+            [{"full_name": f"owner/repo-{number}", "id": number} for number in range(100)]
+            if page == 1
+            else [{"full_name": "owner/repo-100", "id": 100}]
+        )
+        return _Reply({"repositories": repositories, "total_count": 101})
+
+    app = GitHubApp(42, 7, b"unused", opener=open_request)
+
+    assert len(app.installation_repositories("token")) == 101
+    assert urls[-1].endswith("/installation/repositories?per_page=100&page=2")
+
+
+def test_incomplete_installation_repository_page_blocks() -> None:
+    app = GitHubApp(
+        42,
+        7,
+        b"unused",
+        opener=lambda *args, **kwargs: _Reply(
+            {"repositories": [{"full_name": "owner/repo", "id": 1}], "total_count": 2}
+        ),
+    )
+
+    with pytest.raises(SemanticReviewError, match="INCOMPLETE_GITHUB_EVIDENCE"):
+        app.installation_repositories("token")
+
+
+def test_handoff_ready_requires_successful_exact_head_artifact() -> None:
+    head_sha = "b" * 40
+    replies = iter(
+        [
+            {
+                "workflow_runs": [
+                    {
+                        "conclusion": "success",
+                        "event": "pull_request",
+                        "head_sha": head_sha,
+                        "id": 123,
+                        "path": ".github/workflows/organization-required.yml",
+                        "run_attempt": 1,
+                        "status": "completed",
+                        "updated_at": "2026-08-09T17:00:00Z",
+                    }
+                ]
+            },
+            {
+                "artifacts": [
+                    {
+                        "digest": f"sha256:{'c' * 64}",
+                        "expired": False,
+                        "id": 456,
+                        "name": "supportability-evidence-123-1",
+                    }
+                ]
+            },
+        ]
+    )
+    app = GitHubApp(42, 7, b"unused", opener=lambda *args, **kwargs: _Reply(next(replies)))
+
+    assert app.handoff_ready("owner/repo", head_sha, "token") is True
+
+
 def test_wrong_app_identity_blocks() -> None:
     app = GitHubApp(42, 7, _private_key(), opener=lambda *args, **kwargs: _Reply({"id": 41}))
     with pytest.raises(SemanticReviewError, match="APP_IDENTITY_MISMATCH"):

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -222,12 +222,13 @@ def test_revoked_worker_lease_blocks_publication(tmp_path: Path) -> None:
         pass
 
     revoke_publication_lease(lease)
+    assert lease.with_name("lease.revoked").exists()
     with pytest.raises(SemanticReviewError, match="WORKER_LEASE_REVOKED"):
         with publication_lease(lease):
             pytest.fail("revoked worker acquired publication lease")
 
 
-def test_publication_and_lease_revocation_are_atomic(tmp_path: Path) -> None:
+def test_revocation_blocks_reacquisition_during_current_publication(tmp_path: Path) -> None:
     lease = tmp_path / "lease"
     lease.write_text("active", encoding="utf-8")
     entered, release, revoked = threading.Event(), threading.Event(), threading.Event()
@@ -260,12 +261,15 @@ def test_publication_and_lease_revocation_are_atomic(tmp_path: Path) -> None:
         publication = executor.submit(publish)
         assert entered.wait(timeout=1)
         revocation = executor.submit(revoke)
-        assert not revoked.wait(timeout=0.1)
+        assert revoked.wait(timeout=1)
         release.set()
         publication.result(timeout=1)
         revocation.result(timeout=1)
 
-    assert lease.read_text(encoding="utf-8") == "revoked"
+    assert lease.with_name("lease.revoked").exists()
+    with pytest.raises(SemanticReviewError, match="WORKER_LEASE_REVOKED"):
+        with publication_lease(lease):
+            pytest.fail("surviving worker reacquired revoked publication authority")
 
 
 def test_main_reviews_only_the_requested_pull(

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -225,7 +225,7 @@ def test_worker_defers_final_check_publication(tmp_path: Path) -> None:
             pytest.fail("worker published a final check")
 
     packet = _packet("deferred")
-    semantic_cli._complete_current_check(
+    semantic_cli._conclude_current_check(
         App(),
         packet,
         67,
@@ -242,6 +242,18 @@ def test_worker_defers_final_check_publication(tmp_path: Path) -> None:
         "evidence_sha256": packet.sha256,
         "summary": "PASS",
     }
+
+
+def test_worker_result_size_is_bounded_before_write(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    result = tmp_path / "result"
+    monkeypatch.setattr(semantic_cli, "MAX_WORKER_RESULT_BYTES", 1)
+
+    with pytest.raises(SemanticReviewError, match="WORKER_RESULT_TOO_LARGE"):
+        semantic_cli._write_deferred_result(_packet("bounded"), 2, "success", "PASS", result)
+
+    assert not result.exists()
 
 
 def test_main_reviews_only_the_requested_pull(

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -227,7 +227,7 @@ def test_main_reviews_only_the_requested_pull(
 
         def pull(self, repository: str, pull_number: int, token: str) -> dict[str, object]:
             observed.append((repository, pull_number, token))
-            return {"number": pull_number}
+            return {"head": {"sha": "a" * 40}, "number": pull_number}
 
     monkeypatch.setattr(semantic_cli, "GitHubApp", lambda *args: App())
 
@@ -244,6 +244,8 @@ def test_main_reviews_only_the_requested_pull(
                 "owner/repository",
                 "--pull-number",
                 "17",
+                "--head-sha",
+                "a" * 40,
                 "--app-id",
                 "42",
                 "--installation-id",
@@ -254,7 +256,10 @@ def test_main_reviews_only_the_requested_pull(
         )
         == 0
     )
-    assert observed == [("owner/repository", 17, "token"), {"number": 17}]
+    assert observed == [
+        ("owner/repository", 17, "token"),
+        {"head": {"sha": "a" * 40}, "number": 17},
+    ]
     assert capsys.readouterr().out == "PASS\n"
     assert semantic_cli._pull_lock_path(private_key, "owner/repository", 17).exists()
 
@@ -272,7 +277,7 @@ def test_duplicate_exact_main_invocation_runs_one_ensemble(
             return "token"
 
         def pull(self, *args: object) -> dict[str, object]:
-            return {"number": 17}
+            return {"head": {"sha": "a" * 40}, "number": 17}
 
     def review(*args: object) -> bool:
         nonlocal reviews
@@ -286,6 +291,8 @@ def test_duplicate_exact_main_invocation_runs_one_ensemble(
         "owner/repository",
         "--pull-number",
         "17",
+        "--head-sha",
+        "a" * 40,
         "--app-id",
         "42",
         "--installation-id",
@@ -303,6 +310,47 @@ def test_duplicate_exact_main_invocation_runs_one_ensemble(
         release.set()
         assert first.result(timeout=1) == 0
     assert reviews == 1
+
+
+def test_main_rejects_head_changed_after_dispatch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    private_key = tmp_path / "key.pem"
+    private_key.write_bytes(b"private")
+
+    class App:
+        def installation_token(self) -> str:
+            return "token"
+
+        def pull(self, *args: object) -> dict[str, object]:
+            return {"head": {"sha": "b" * 40}, "number": 17}
+
+    monkeypatch.setattr(semantic_cli, "GitHubApp", lambda *args: App())
+    monkeypatch.setattr(
+        semantic_cli,
+        "_review",
+        lambda *args: pytest.fail("stale dispatch reached semantic review"),
+    )
+
+    result = semantic_cli.main(
+        [
+            "--repository",
+            "owner/repository",
+            "--pull-number",
+            "17",
+            "--head-sha",
+            "a" * 40,
+            "--app-id",
+            "42",
+            "--installation-id",
+            "7",
+            "--private-key",
+            str(private_key),
+        ]
+    )
+
+    assert result == 2
+    assert capsys.readouterr().out == "TECHNICAL_FAILURE\n"
 
 
 def test_same_head_change_becomes_pending_before_fresh_evaluation(

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -214,6 +214,16 @@ def test_pull_lock_path_is_exact_and_repository_isolated(tmp_path: Path) -> None
     assert first.parent == tmp_path
 
 
+def test_revoked_worker_lease_blocks_publication(tmp_path: Path) -> None:
+    lease = tmp_path / "lease"
+    lease.write_text("active", encoding="utf-8")
+    semantic_cli._require_lease(lease)
+
+    lease.write_text("revoked", encoding="utf-8")
+    with pytest.raises(SemanticReviewError, match="WORKER_LEASE_REVOKED"):
+        semantic_cli._require_lease(lease)
+
+
 def test_main_reviews_only_the_requested_pull(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -12,7 +12,6 @@ import pytest
 from supportability_gate import semantic_cli
 from supportability_gate.review_events import ReviewEvent, parse_review_event
 from supportability_gate.semantic_contract import EvidencePacket, SemanticReviewError
-from supportability_gate.semantic_lease import publication_lease, revoke_publication_lease
 
 
 def _body(action: str = "submitted") -> bytes:
@@ -215,61 +214,34 @@ def test_pull_lock_path_is_exact_and_repository_isolated(tmp_path: Path) -> None
     assert first.parent == tmp_path
 
 
-def test_revoked_worker_lease_blocks_publication(tmp_path: Path) -> None:
-    lease = tmp_path / "lease"
-    lease.write_text("active", encoding="utf-8")
-    with publication_lease(lease):
-        pass
-
-    revoke_publication_lease(lease)
-    assert lease.with_name("lease.revoked").exists()
-    with pytest.raises(SemanticReviewError, match="WORKER_LEASE_REVOKED"):
-        with publication_lease(lease):
-            pytest.fail("revoked worker acquired publication lease")
-
-
-def test_revocation_blocks_reacquisition_during_current_publication(tmp_path: Path) -> None:
-    lease = tmp_path / "lease"
-    lease.write_text("active", encoding="utf-8")
-    entered, release, revoked = threading.Event(), threading.Event(), threading.Event()
+def test_worker_defers_final_check_publication(tmp_path: Path) -> None:
+    result = tmp_path / "result"
 
     class App:
         def assert_current(self, *args: object) -> None:
             return None
 
         def complete_check(self, *args: object) -> None:
-            entered.set()
-            assert release.wait(timeout=2)
+            pytest.fail("worker published a final check")
 
-    def publish() -> None:
-        semantic_cli._complete_current_check(
-            App(),
-            object(),
-            1,
-            "token",
-            2,
-            "success",
-            "PASS",
-            lease,  # type: ignore[arg-type]
-        )
+    packet = _packet("deferred")
+    semantic_cli._complete_current_check(
+        App(),
+        packet,
+        67,
+        "token",
+        2,
+        "success",
+        "PASS",
+        result,  # type: ignore[arg-type]
+    )
 
-    def revoke() -> None:
-        revoke_publication_lease(lease)
-        revoked.set()
-
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        publication = executor.submit(publish)
-        assert entered.wait(timeout=1)
-        revocation = executor.submit(revoke)
-        assert revoked.wait(timeout=1)
-        release.set()
-        publication.result(timeout=1)
-        revocation.result(timeout=1)
-
-    assert lease.with_name("lease.revoked").exists()
-    with pytest.raises(SemanticReviewError, match="WORKER_LEASE_REVOKED"):
-        with publication_lease(lease):
-            pytest.fail("surviving worker reacquired revoked publication authority")
+    assert json.loads(result.read_text(encoding="utf-8")) == {
+        "check_id": 2,
+        "conclusion": "success",
+        "evidence_sha256": packet.sha256,
+        "summary": "PASS",
+    }
 
 
 def test_main_reviews_only_the_requested_pull(

--- a/tests/test_review_events.py
+++ b/tests/test_review_events.py
@@ -12,6 +12,7 @@ import pytest
 from supportability_gate import semantic_cli
 from supportability_gate.review_events import ReviewEvent, parse_review_event
 from supportability_gate.semantic_contract import EvidencePacket, SemanticReviewError
+from supportability_gate.semantic_lease import publication_lease, revoke_publication_lease
 
 
 def _body(action: str = "submitted") -> bytes:
@@ -217,11 +218,54 @@ def test_pull_lock_path_is_exact_and_repository_isolated(tmp_path: Path) -> None
 def test_revoked_worker_lease_blocks_publication(tmp_path: Path) -> None:
     lease = tmp_path / "lease"
     lease.write_text("active", encoding="utf-8")
-    semantic_cli._require_lease(lease)
+    with publication_lease(lease):
+        pass
 
-    lease.write_text("revoked", encoding="utf-8")
+    revoke_publication_lease(lease)
     with pytest.raises(SemanticReviewError, match="WORKER_LEASE_REVOKED"):
-        semantic_cli._require_lease(lease)
+        with publication_lease(lease):
+            pytest.fail("revoked worker acquired publication lease")
+
+
+def test_publication_and_lease_revocation_are_atomic(tmp_path: Path) -> None:
+    lease = tmp_path / "lease"
+    lease.write_text("active", encoding="utf-8")
+    entered, release, revoked = threading.Event(), threading.Event(), threading.Event()
+
+    class App:
+        def assert_current(self, *args: object) -> None:
+            return None
+
+        def complete_check(self, *args: object) -> None:
+            entered.set()
+            assert release.wait(timeout=2)
+
+    def publish() -> None:
+        semantic_cli._complete_current_check(
+            App(),
+            object(),
+            1,
+            "token",
+            2,
+            "success",
+            "PASS",
+            lease,  # type: ignore[arg-type]
+        )
+
+    def revoke() -> None:
+        revoke_publication_lease(lease)
+        revoked.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        publication = executor.submit(publish)
+        assert entered.wait(timeout=1)
+        revocation = executor.submit(revoke)
+        assert not revoked.wait(timeout=0.1)
+        release.set()
+        publication.result(timeout=1)
+        revocation.result(timeout=1)
+
+    assert lease.read_text(encoding="utf-8") == "revoked"
 
 
 def test_main_reviews_only_the_requested_pull(

--- a/tests/test_semantic_dispatch.py
+++ b/tests/test_semantic_dispatch.py
@@ -196,6 +196,7 @@ def test_poll_failure_force_reaps_active_worker(monkeypatch: Any, capsys: Any) -
     class Process:
         returncode = -9
         killed = False
+        wait_calls = 0
 
         def poll(self) -> None:
             return None
@@ -204,6 +205,9 @@ def test_poll_failure_force_reaps_active_worker(monkeypatch: Any, capsys: Any) -
             self.killed = True
 
         def wait(self, timeout: int) -> int:
+            self.wait_calls += 1
+            if self.wait_calls < 3:
+                raise subprocess.TimeoutExpired("worker", timeout)
             return self.returncode
 
     class App:
@@ -226,6 +230,7 @@ def test_poll_failure_force_reaps_active_worker(monkeypatch: Any, capsys: Any) -
         "launch_worker",
         lambda *args: ActiveWorker(candidate, process, 0.0, io.StringIO(), io.StringIO()),
     )
+    monkeypatch.setattr(dispatch.time, "monotonic", lambda: 0.0)
     monkeypatch.setattr(dispatch.time, "sleep", lambda seconds: None)
     arguments = argparse.Namespace(
         app_id=42, installation_id=7, private_key=Path("key.pem"), shadow=False
@@ -235,6 +240,7 @@ def test_poll_failure_force_reaps_active_worker(monkeypatch: Any, capsys: Any) -
         dispatch.run_dispatch_loop(arguments, App())  # type: ignore[arg-type]
 
     assert process.killed is True
+    assert process.wait_calls == 3
     assert json.loads(capsys.readouterr().out)["timed_out"] is True
 
 
@@ -262,7 +268,11 @@ def test_second_wait_timeout_still_cleans_every_worker(monkeypatch: Any) -> None
     with pytest.raises(subprocess.SubprocessError, match="WORKER_TERMINATION_FAILURE"):
         dispatch.reap_workers(active, dispatch.WORKER_TIMEOUT_SECONDS + 1)
 
-    assert active == {}
+    assert set(active) == {first.key, second.key}
+    assert all(not worker.stdout.closed and not worker.stderr.closed for worker in active.values())
+    for worker in active.values():
+        worker.stdout.close()
+        worker.stderr.close()
 
 
 def test_shadow_reports_selected_repositories_even_without_candidates(capsys: Any) -> None:

--- a/tests/test_semantic_dispatch.py
+++ b/tests/test_semantic_dispatch.py
@@ -47,8 +47,16 @@ def test_discovery_is_app_selected_exact_head_and_restart_safe() -> None:
         def handoff_ready(self, repository: str, head_sha: str, token: str) -> bool:
             return repository != "owner/twmn"
 
-        def evidence_packet(self, repository: str, pull: dict[str, Any], token: str) -> object:
-            return pull
+        def evidence_packet(
+            self, repository: str, pull: dict[str, Any], token: str
+        ) -> EvidencePacket:
+            return EvidencePacket(
+                repository,
+                "b" * 40,
+                pull["head"]["sha"],
+                42,
+                {"pull_request": pull["number"], "review_state": {"threads": []}},
+            )
 
         def m10_evidence_packet(self, *args: object) -> object:
             return args[3]
@@ -212,14 +220,20 @@ def test_discovery_skips_completed_exact_generation() -> None:
         def handoff_ready(self, *args: object) -> bool:
             return True
 
-        def evidence_packet(self, *args: object) -> object:
-            return "base"
+        def evidence_packet(self, *args: object) -> EvidencePacket:
+            return EvidencePacket(
+                "owner/repo",
+                "b" * 40,
+                "a" * 40,
+                42,
+                {"pull_request": 1, "review_state": {"threads": []}},
+            )
 
         def m10_evidence_packet(self, *args: object) -> object:
-            return "exact-generation"
+            return args[3]
 
         def replay_result(self, packet: object, token: str) -> bool | None:
-            assert packet == "exact-generation"
+            assert isinstance(packet, EvidencePacket)
             return True
 
     assert dispatch.discover_candidates(App(), "token") == ()  # type: ignore[arg-type]

--- a/tests/test_semantic_dispatch.py
+++ b/tests/test_semantic_dispatch.py
@@ -206,7 +206,7 @@ def test_poll_failure_force_reaps_active_worker(monkeypatch: Any, capsys: Any) -
 
         def wait(self, timeout: int) -> int:
             self.wait_calls += 1
-            if self.wait_calls < 3:
+            if self.wait_calls < 2:
                 raise subprocess.TimeoutExpired("worker", timeout)
             return self.returncode
 
@@ -240,11 +240,11 @@ def test_poll_failure_force_reaps_active_worker(monkeypatch: Any, capsys: Any) -
         dispatch.run_dispatch_loop(arguments, App())  # type: ignore[arg-type]
 
     assert process.killed is True
-    assert process.wait_calls == 3
+    assert process.wait_calls == 2
     assert json.loads(capsys.readouterr().out)["timed_out"] is True
 
 
-def test_second_wait_timeout_still_cleans_every_worker(monkeypatch: Any) -> None:
+def test_second_wait_timeout_retains_every_worker(monkeypatch: Any) -> None:
     class Process:
         returncode = None
 
@@ -273,6 +273,53 @@ def test_second_wait_timeout_still_cleans_every_worker(monkeypatch: Any) -> None
     for worker in active.values():
         worker.stdout.close()
         worker.stderr.close()
+
+
+def test_shutdown_fails_after_two_bounded_waits(monkeypatch: Any) -> None:
+    class Process:
+        returncode = None
+        wait_calls = 0
+
+        def poll(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+        def wait(self, timeout: int) -> int:
+            self.wait_calls += 1
+            raise subprocess.TimeoutExpired("worker", timeout)
+
+    class App:
+        calls = 0
+
+        def installation_token(self) -> str:
+            self.calls += 1
+            if self.calls == 2:
+                raise SemanticReviewError("GITHUB_TRANSPORT_FAILURE")
+            return "token"
+
+        def installation_repositories(self, token: str) -> tuple[dict[str, Any], ...]:
+            return ({"full_name": "owner/repo-1", "id": 1},)
+
+    candidate = _candidate(1, 1, "2026-08-09T00:00:00Z")
+    process = Process()
+    worker = ActiveWorker(candidate, process, 0.0, io.StringIO(), io.StringIO())
+    monkeypatch.setattr(dispatch, "discover_candidates", lambda *args: (candidate,))
+    monkeypatch.setattr(dispatch, "launch_worker", lambda *args: worker)
+    monkeypatch.setattr(dispatch.time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(dispatch.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)
+    arguments = argparse.Namespace(
+        app_id=42, installation_id=7, private_key=Path("key.pem"), shadow=False
+    )
+
+    with pytest.raises(subprocess.SubprocessError, match="WORKER_TERMINATION_FAILURE"):
+        dispatch.run_dispatch_loop(arguments, App())  # type: ignore[arg-type]
+
+    assert process.wait_calls == 2
+    worker.stdout.close()
+    worker.stderr.close()
 
 
 def test_shadow_reports_selected_repositories_even_without_candidates(capsys: Any) -> None:

--- a/tests/test_semantic_dispatch.py
+++ b/tests/test_semantic_dispatch.py
@@ -338,9 +338,17 @@ def test_dispatcher_alone_publishes_confirmed_worker_result(tmp_path: Path) -> N
             self.completed.append(args)
 
     app = App()
+    lock = tmp_path / "lock"
     active = {
-        candidate.key: ActiveWorker(candidate, Process(), 0.0, io.StringIO(), io.StringIO(), result)
+        candidate.key: ActiveWorker(
+            candidate, Process(), 0.0, io.StringIO(), io.StringIO(), result, lock
+        )
     }  # type: ignore[arg-type]
+
+    with dispatch.exclusive_lease(lock):
+        with pytest.raises(SemanticReviewError, match="EVALUATION_IN_PROGRESS"):
+            dispatch._publish_worker_result(app, active[candidate.key])  # type: ignore[arg-type]
+    assert app.completed == []
 
     dispatch.reap_workers(active, now=0.0, app=app)  # type: ignore[arg-type]
 

--- a/tests/test_semantic_dispatch.py
+++ b/tests/test_semantic_dispatch.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import subprocess
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -14,7 +16,13 @@ from supportability_gate.semantic_dispatch import ActiveWorker, Candidate
 
 
 def _candidate(repository_id: int, pull: int, created_at: str) -> Candidate:
-    return Candidate(repository_id, f"owner/repo-{repository_id}", pull, "a" * 40, created_at)
+    return Candidate(
+        repository_id,
+        f"owner/repo-{repository_id}",
+        pull,
+        "a" * 40,
+        datetime.fromisoformat(created_at.replace("Z", "+00:00")),
+    )
 
 
 def test_discovery_is_app_selected_exact_head_and_restart_safe() -> None:
@@ -49,6 +57,14 @@ def test_discovery_is_app_selected_exact_head_and_restart_safe() -> None:
     assert restarted == first
 
 
+def test_candidate_rejects_noncanonical_github_timestamp() -> None:
+    with pytest.raises(SemanticReviewError, match="MALFORMED_PULL_REQUEST"):
+        dispatch._candidate(
+            {"full_name": "owner/repo", "id": 1},
+            {"created_at": "tomorrow", "head": {"sha": "a" * 40}, "number": 1},
+        )
+
+
 def test_fair_order_is_round_robin_oldest_pull_first() -> None:
     candidates = (
         _candidate(1, 3, "2026-08-09T03:00:00Z"),
@@ -76,10 +92,12 @@ def test_fill_slots_deduplicates_and_caps_workers(monkeypatch: Any) -> None:
 
     def launch(candidate: Candidate, *args: object) -> ActiveWorker:
         launched.append(candidate)
-        return ActiveWorker(candidate, object(), 0.0)  # type: ignore[arg-type]
+        return ActiveWorker(candidate, object(), 0.0, io.StringIO(), io.StringIO())  # type: ignore[arg-type]
 
     monkeypatch.setattr(dispatch, "launch_worker", launch)
-    active = {running.key: ActiveWorker(running, object(), 0.0)}  # type: ignore[arg-type]
+    active = {
+        running.key: ActiveWorker(running, object(), 0.0, io.StringIO(), io.StringIO())  # type: ignore[arg-type]
+    }
 
     after_pulls: dict[int, int] = {}
     assert dispatch.fill_slots(active, candidates, 42, 7, Path("key.pem"), after_pulls) == 2
@@ -88,11 +106,27 @@ def test_fill_slots_deduplicates_and_caps_workers(monkeypatch: Any) -> None:
     assert after_pulls == {2: 2}
 
 
+def test_fill_slots_deduplicates_same_scan_candidates(monkeypatch: Any) -> None:
+    candidate = _candidate(1, 1, "2026-08-09T00:00:00Z")
+    launched: list[Candidate] = []
+
+    def launch(item: Candidate, *args: object) -> ActiveWorker:
+        launched.append(item)
+        return ActiveWorker(item, object(), 0.0, io.StringIO(), io.StringIO())  # type: ignore[arg-type]
+
+    monkeypatch.setattr(dispatch, "launch_worker", launch)
+    active: dict[tuple[int, int], ActiveWorker] = {}
+
+    dispatch.fill_slots(active, (candidate, candidate), 42, 7, Path("key.pem"), {})
+
+    assert launched == [candidate]
+
+
 def test_worker_launch_uses_fixed_shell_free_captured_command(monkeypatch: Any) -> None:
     captured: dict[str, object] = {}
 
     class Process:
-        pass
+        returncode = None
 
     def popen(arguments: list[str], **kwargs: object) -> Process:
         captured.update(arguments=arguments, **kwargs)
@@ -106,15 +140,17 @@ def test_worker_launch_uses_fixed_shell_free_captured_command(monkeypatch: Any) 
 
     assert worker.started_at == 12.0
     assert captured["shell"] is False
-    assert captured["stdout"] is subprocess.PIPE
-    assert captured["stderr"] is subprocess.PIPE
-    assert captured["arguments"][-12:] == [
+    assert captured["stdout"] is not subprocess.PIPE
+    assert captured["stderr"] is not subprocess.PIPE
+    assert captured["arguments"][1:] == [
         "-m",
         "supportability_gate.semantic_cli",
         "--repository",
         "owner/repo-9",
         "--pull-number",
         "24",
+        "--head-sha",
+        "a" * 40,
         "--app-id",
         "42",
         "--installation-id",
@@ -122,6 +158,8 @@ def test_worker_launch_uses_fixed_shell_free_captured_command(monkeypatch: Any) 
         "--private-key",
         "key.pem",
     ]
+    worker.stdout.close()
+    worker.stderr.close()
 
 
 def test_reaper_kills_and_removes_timed_out_worker(capsys: Any) -> None:
@@ -135,13 +173,17 @@ def test_reaper_kills_and_removes_timed_out_worker(capsys: Any) -> None:
         def kill(self) -> None:
             self.killed = True
 
-        def communicate(self, timeout: int) -> tuple[str, str]:
+        def wait(self, timeout: int) -> int:
             assert timeout == 30
-            return "partial output", "timeout"
+            return self.returncode
 
     process = Process()
     candidate = _candidate(1, 1, "2026-08-09T00:00:00Z")
-    active = {candidate.key: ActiveWorker(candidate, process, 0.0)}  # type: ignore[arg-type]
+    active = {
+        candidate.key: ActiveWorker(
+            candidate, process, 0.0, io.StringIO("partial output"), io.StringIO("timeout")
+        )  # type: ignore[arg-type]
+    }
 
     dispatch.reap_workers(active, dispatch.WORKER_TIMEOUT_SECONDS + 1)
 
@@ -161,8 +203,8 @@ def test_poll_failure_force_reaps_active_worker(monkeypatch: Any, capsys: Any) -
         def kill(self) -> None:
             self.killed = True
 
-        def communicate(self, timeout: int) -> tuple[str, str]:
-            return "", ""
+        def wait(self, timeout: int) -> int:
+            return self.returncode
 
     class App:
         calls = 0
@@ -182,7 +224,7 @@ def test_poll_failure_force_reaps_active_worker(monkeypatch: Any, capsys: Any) -
     monkeypatch.setattr(
         dispatch,
         "launch_worker",
-        lambda *args: ActiveWorker(candidate, process, 0.0),
+        lambda *args: ActiveWorker(candidate, process, 0.0, io.StringIO(), io.StringIO()),
     )
     monkeypatch.setattr(dispatch.time, "sleep", lambda seconds: None)
     arguments = argparse.Namespace(
@@ -190,10 +232,37 @@ def test_poll_failure_force_reaps_active_worker(monkeypatch: Any, capsys: Any) -
     )
 
     with pytest.raises(SemanticReviewError, match="GITHUB_TRANSPORT_FAILURE"):
-        dispatch._run(arguments, App())  # type: ignore[arg-type]
+        dispatch.run_dispatch_loop(arguments, App())  # type: ignore[arg-type]
 
     assert process.killed is True
     assert json.loads(capsys.readouterr().out)["timed_out"] is True
+
+
+def test_second_wait_timeout_still_cleans_every_worker(monkeypatch: Any) -> None:
+    class Process:
+        returncode = None
+
+        def poll(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+        def wait(self, timeout: int) -> int:
+            raise subprocess.TimeoutExpired("worker", timeout)
+
+    first = _candidate(1, 1, "2026-08-09T00:00:00Z")
+    second = _candidate(2, 2, "2026-08-09T00:00:00Z")
+    active = {
+        item.key: ActiveWorker(item, Process(), 0.0, io.StringIO(), io.StringIO())
+        for item in (first, second)
+    }  # type: ignore[arg-type]
+    monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)
+
+    with pytest.raises(subprocess.SubprocessError, match="WORKER_TERMINATION_FAILURE"):
+        dispatch.reap_workers(active, dispatch.WORKER_TIMEOUT_SECONDS + 1)
+
+    assert active == {}
 
 
 def test_shadow_reports_selected_repositories_even_without_candidates(capsys: Any) -> None:

--- a/tests/test_semantic_dispatch.py
+++ b/tests/test_semantic_dispatch.py
@@ -47,6 +47,15 @@ def test_discovery_is_app_selected_exact_head_and_restart_safe() -> None:
         def handoff_ready(self, repository: str, head_sha: str, token: str) -> bool:
             return repository != "owner/twmn"
 
+        def evidence_packet(self, repository: str, pull: dict[str, Any], token: str) -> object:
+            return pull
+
+        def m10_evidence_packet(self, *args: object) -> object:
+            return args[3]
+
+        def replay_result(self, packet: object, token: str) -> bool | None:
+            return None
+
     first = dispatch.discover_candidates(App(), "token")  # type: ignore[arg-type]
     restarted = dispatch.discover_candidates(App(), "token")  # type: ignore[arg-type]
 
@@ -179,10 +188,41 @@ def test_worker_launch_uses_fixed_shell_free_captured_command(monkeypatch: Any) 
         str(worker.lease_file),
     ]
     assert worker.lease_file is not None
+    assert worker.lease_file.parent == Path("key.pem").resolve().parent
     assert worker.lease_file.read_text(encoding="utf-8") == "active"
     worker.stdout.close()
     worker.stderr.close()
     worker.lease_file.unlink()
+
+
+def test_discovery_skips_completed_exact_generation() -> None:
+    class App:
+        def installation_repositories(self, token: str) -> tuple[dict[str, Any], ...]:
+            return ({"full_name": "owner/repo", "id": 1},)
+
+        def open_pulls(self, repository: str, token: str) -> tuple[dict[str, Any], ...]:
+            return (
+                {
+                    "created_at": "2026-08-09T00:00:00Z",
+                    "head": {"sha": "a" * 40},
+                    "number": 1,
+                },
+            )
+
+        def handoff_ready(self, *args: object) -> bool:
+            return True
+
+        def evidence_packet(self, *args: object) -> object:
+            return "base"
+
+        def m10_evidence_packet(self, *args: object) -> object:
+            return "exact-generation"
+
+        def replay_result(self, packet: object, token: str) -> bool | None:
+            assert packet == "exact-generation"
+            return True
+
+    assert dispatch.discover_candidates(App(), "token") == ()  # type: ignore[arg-type]
 
 
 def test_reaper_kills_and_removes_timed_out_worker(capsys: Any) -> None:
@@ -423,6 +463,53 @@ def test_failed_cleanup_revokes_stuck_worker_and_terminates_sibling(
     assert not second_lease.exists()
     active[first.key].stdout.close()
     active[first.key].stderr.close()
+
+
+def test_revocation_failure_still_terminates_worker_and_sibling(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    class Process:
+        returncode = -9
+        killed = False
+
+        def poll(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            self.killed = True
+
+        def wait(self, timeout: int) -> int:
+            return self.returncode
+
+    first = _candidate(1, 1, "2026-08-09T00:00:00Z")
+    second = _candidate(2, 2, "2026-08-09T00:00:00Z")
+    processes = (Process(), Process())
+    active = {
+        item.key: ActiveWorker(
+            item,
+            process,
+            0.0 if item is first else dispatch.WORKER_TIMEOUT_SECONDS + 1,
+            io.StringIO(),
+            io.StringIO(),
+            tmp_path / f"lease-{item.repository_id}",
+        )
+        for item, process in zip((first, second), processes, strict=True)
+    }  # type: ignore[arg-type]
+    for worker in active.values():
+        assert worker.lease_file is not None
+        worker.lease_file.write_text("active", encoding="utf-8")
+    monkeypatch.setattr(
+        dispatch,
+        "revoke_publication_lease",
+        lambda path: (_ for _ in ()).throw(SemanticReviewError("WORKER_LEASE_BUSY")),
+    )
+    monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)
+
+    with pytest.raises(subprocess.SubprocessError, match="WORKER_TERMINATION_FAILURE"):
+        dispatch.reap_workers(active, dispatch.WORKER_TIMEOUT_SECONDS + 1)
+
+    assert active == {}
+    assert all(process.killed for process in processes)
 
 
 def test_shadow_reports_selected_repositories_even_without_candidates(capsys: Any) -> None:

--- a/tests/test_semantic_dispatch.py
+++ b/tests/test_semantic_dispatch.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import argparse
 import json
 import subprocess
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 import supportability_gate.semantic_dispatch as dispatch
+from supportability_gate.semantic_contract import SemanticReviewError
 from supportability_gate.semantic_dispatch import ActiveWorker, Candidate
 
 
@@ -58,6 +62,7 @@ def test_fair_order_is_round_robin_oldest_pull_first() -> None:
         (1, 3),
     ]
     assert dispatch.fair_order(candidates, after_repository=1)[0].repository_id == 2
+    assert dispatch.fair_order(candidates, after_pulls={1: 1})[-1].pull_number == 1
 
 
 def test_fill_slots_deduplicates_and_caps_workers(monkeypatch: Any) -> None:
@@ -76,9 +81,11 @@ def test_fill_slots_deduplicates_and_caps_workers(monkeypatch: Any) -> None:
     monkeypatch.setattr(dispatch, "launch_worker", launch)
     active = {running.key: ActiveWorker(running, object(), 0.0)}  # type: ignore[arg-type]
 
-    assert dispatch.fill_slots(active, candidates, 42, 7, Path("key.pem")) == 2
+    after_pulls: dict[int, int] = {}
+    assert dispatch.fill_slots(active, candidates, 42, 7, Path("key.pem"), after_pulls) == 2
     assert launched == [candidates[1]]
     assert len(active) == dispatch.MAX_WORKERS
+    assert after_pulls == {2: 2}
 
 
 def test_worker_launch_uses_fixed_shell_free_captured_command(monkeypatch: Any) -> None:
@@ -140,6 +147,52 @@ def test_reaper_kills_and_removes_timed_out_worker(capsys: Any) -> None:
 
     assert process.killed is True
     assert active == {}
+    assert json.loads(capsys.readouterr().out)["timed_out"] is True
+
+
+def test_poll_failure_force_reaps_active_worker(monkeypatch: Any, capsys: Any) -> None:
+    class Process:
+        returncode = -9
+        killed = False
+
+        def poll(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            self.killed = True
+
+        def communicate(self, timeout: int) -> tuple[str, str]:
+            return "", ""
+
+    class App:
+        calls = 0
+
+        def installation_token(self) -> str:
+            self.calls += 1
+            if self.calls == 2:
+                raise SemanticReviewError("GITHUB_TRANSPORT_FAILURE")
+            return "token"
+
+        def installation_repositories(self, token: str) -> tuple[dict[str, Any], ...]:
+            return ({"full_name": "owner/repo-1", "id": 1},)
+
+    process = Process()
+    candidate = _candidate(1, 1, "2026-08-09T00:00:00Z")
+    monkeypatch.setattr(dispatch, "discover_candidates", lambda *args: (candidate,))
+    monkeypatch.setattr(
+        dispatch,
+        "launch_worker",
+        lambda *args: ActiveWorker(candidate, process, 0.0),
+    )
+    monkeypatch.setattr(dispatch.time, "sleep", lambda seconds: None)
+    arguments = argparse.Namespace(
+        app_id=42, installation_id=7, private_key=Path("key.pem"), shadow=False
+    )
+
+    with pytest.raises(SemanticReviewError, match="GITHUB_TRANSPORT_FAILURE"):
+        dispatch._run(arguments, App())  # type: ignore[arg-type]
+
+    assert process.killed is True
     assert json.loads(capsys.readouterr().out)["timed_out"] is True
 
 

--- a/tests/test_semantic_dispatch.py
+++ b/tests/test_semantic_dispatch.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import supportability_gate.semantic_dispatch as dispatch
+from supportability_gate.semantic_dispatch import ActiveWorker, Candidate
+
+
+def _candidate(repository_id: int, pull: int, created_at: str) -> Candidate:
+    return Candidate(repository_id, f"owner/repo-{repository_id}", pull, "a" * 40, created_at)
+
+
+def test_discovery_is_app_selected_exact_head_and_restart_safe() -> None:
+    class App:
+        def installation_repositories(self, token: str) -> tuple[dict[str, Any], ...]:
+            return (
+                {"full_name": "owner/source", "id": 1},
+                {"full_name": "owner/dc", "id": 2},
+                {"full_name": "owner/twmn", "id": 3},
+            )
+
+        def open_pulls(self, repository: str, token: str) -> tuple[dict[str, Any], ...]:
+            number = {"owner/source": 11, "owner/dc": 23, "owner/twmn": 65}[repository]
+            return (
+                {
+                    "created_at": "2026-08-09T00:00:00Z",
+                    "head": {"sha": f"{number % 10}" * 40},
+                    "number": number,
+                },
+            )
+
+        def handoff_ready(self, repository: str, head_sha: str, token: str) -> bool:
+            return repository != "owner/twmn"
+
+    first = dispatch.discover_candidates(App(), "token")  # type: ignore[arg-type]
+    restarted = dispatch.discover_candidates(App(), "token")  # type: ignore[arg-type]
+
+    assert [(item.repository, item.pull_number) for item in first] == [
+        ("owner/source", 11),
+        ("owner/dc", 23),
+    ]
+    assert restarted == first
+
+
+def test_fair_order_is_round_robin_oldest_pull_first() -> None:
+    candidates = (
+        _candidate(1, 3, "2026-08-09T03:00:00Z"),
+        _candidate(1, 1, "2026-08-09T01:00:00Z"),
+        _candidate(2, 2, "2026-08-09T02:00:00Z"),
+    )
+
+    assert [(item.repository_id, item.pull_number) for item in dispatch.fair_order(candidates)] == [
+        (1, 1),
+        (2, 2),
+        (1, 3),
+    ]
+    assert dispatch.fair_order(candidates, after_repository=1)[0].repository_id == 2
+
+
+def test_fill_slots_deduplicates_and_caps_workers(monkeypatch: Any) -> None:
+    running = _candidate(1, 1, "2026-08-09T01:00:00Z")
+    candidates = (
+        running,
+        _candidate(2, 2, "2026-08-09T02:00:00Z"),
+        _candidate(3, 3, "2026-08-09T03:00:00Z"),
+    )
+    launched: list[Candidate] = []
+
+    def launch(candidate: Candidate, *args: object) -> ActiveWorker:
+        launched.append(candidate)
+        return ActiveWorker(candidate, object(), 0.0)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(dispatch, "launch_worker", launch)
+    active = {running.key: ActiveWorker(running, object(), 0.0)}  # type: ignore[arg-type]
+
+    assert dispatch.fill_slots(active, candidates, 42, 7, Path("key.pem")) == 2
+    assert launched == [candidates[1]]
+    assert len(active) == dispatch.MAX_WORKERS
+
+
+def test_worker_launch_uses_fixed_shell_free_captured_command(monkeypatch: Any) -> None:
+    captured: dict[str, object] = {}
+
+    class Process:
+        pass
+
+    def popen(arguments: list[str], **kwargs: object) -> Process:
+        captured.update(arguments=arguments, **kwargs)
+        return Process()
+
+    monkeypatch.setattr(dispatch.subprocess, "Popen", popen)
+    monkeypatch.setattr(dispatch.time, "monotonic", lambda: 12.0)
+    candidate = _candidate(9, 24, "2026-08-09T00:00:00Z")
+
+    worker = dispatch.launch_worker(candidate, 42, 7, Path("key.pem"))
+
+    assert worker.started_at == 12.0
+    assert captured["shell"] is False
+    assert captured["stdout"] is subprocess.PIPE
+    assert captured["stderr"] is subprocess.PIPE
+    assert captured["arguments"][-12:] == [
+        "-m",
+        "supportability_gate.semantic_cli",
+        "--repository",
+        "owner/repo-9",
+        "--pull-number",
+        "24",
+        "--app-id",
+        "42",
+        "--installation-id",
+        "7",
+        "--private-key",
+        "key.pem",
+    ]
+
+
+def test_reaper_kills_and_removes_timed_out_worker(capsys: Any) -> None:
+    class Process:
+        returncode = -9
+        killed = False
+
+        def poll(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            self.killed = True
+
+        def communicate(self, timeout: int) -> tuple[str, str]:
+            assert timeout == 30
+            return "partial output", "timeout"
+
+    process = Process()
+    candidate = _candidate(1, 1, "2026-08-09T00:00:00Z")
+    active = {candidate.key: ActiveWorker(candidate, process, 0.0)}  # type: ignore[arg-type]
+
+    dispatch.reap_workers(active, dispatch.WORKER_TIMEOUT_SECONDS + 1)
+
+    assert process.killed is True
+    assert active == {}
+    assert json.loads(capsys.readouterr().out)["timed_out"] is True
+
+
+def test_shadow_reports_selected_repositories_even_without_candidates(capsys: Any) -> None:
+    repositories = (
+        {"full_name": "owner/source", "id": 1},
+        {"full_name": "owner/dc", "id": 2},
+        {"full_name": "owner/twmn", "id": 3},
+    )
+
+    dispatch._shadow(repositories, ())
+
+    assert json.loads(capsys.readouterr().out) == {
+        "candidates": [],
+        "selected_repositories": ["owner/source", "owner/dc", "owner/twmn"],
+    }

--- a/tests/test_semantic_dispatch.py
+++ b/tests/test_semantic_dispatch.py
@@ -402,7 +402,7 @@ def test_shutdown_fails_after_two_bounded_waits(monkeypatch: Any, tmp_path: Path
         dispatch.run_dispatch_loop(arguments, App())  # type: ignore[arg-type]
 
     assert process.wait_calls == 2
-    assert lease.read_text(encoding="utf-8") == "revoked"
+    assert lease.with_name("lease.revoked").exists()
     worker.stdout.close()
     worker.stderr.close()
 
@@ -458,7 +458,7 @@ def test_failed_cleanup_revokes_stuck_worker_and_terminates_sibling(
         dispatch.reap_workers(active, dispatch.WORKER_TIMEOUT_SECONDS + 1)
 
     assert set(active) == {first.key}
-    assert first_lease.read_text(encoding="utf-8") == "revoked"
+    assert first_lease.with_name("first.revoked").exists()
     assert pending.killed is True
     assert not second_lease.exists()
     active[first.key].stdout.close()
@@ -510,6 +510,32 @@ def test_revocation_failure_still_terminates_worker_and_sibling(
 
     assert active == {}
     assert all(process.killed for process in processes)
+
+
+def test_termination_failure_leaves_publication_revoked(tmp_path: Path) -> None:
+    class Process:
+        returncode = None
+
+        def poll(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+        def wait(self, timeout: int) -> int:
+            raise subprocess.TimeoutExpired("worker", timeout)
+
+    candidate = _candidate(1, 1, "2026-08-09T00:00:00Z")
+    lease = tmp_path / "lease"
+    lease.write_text("active", encoding="utf-8")
+    worker = ActiveWorker(candidate, Process(), 0.0, io.StringIO(), io.StringIO(), lease)  # type: ignore[arg-type]
+    active = {candidate.key: worker}
+
+    assert not dispatch._finish_worker(active, candidate.key, worker, True)
+    assert candidate.key in active
+    assert lease.with_name("lease.revoked").exists()
+    worker.stdout.close()
+    worker.stderr.close()
 
 
 def test_shadow_reports_selected_repositories_even_without_candidates(capsys: Any) -> None:

--- a/tests/test_semantic_dispatch.py
+++ b/tests/test_semantic_dispatch.py
@@ -174,10 +174,15 @@ def test_worker_launch_uses_fixed_shell_free_captured_command(monkeypatch: Any) 
         "--installation-id",
         "7",
         "--private-key",
-        "key.pem",
+        str(Path("key.pem").resolve()),
+        "--lease-file",
+        str(worker.lease_file),
     ]
+    assert worker.lease_file is not None
+    assert worker.lease_file.read_text(encoding="utf-8") == "active"
     worker.stdout.close()
     worker.stderr.close()
+    worker.lease_file.unlink()
 
 
 def test_reaper_kills_and_removes_timed_out_worker(capsys: Any) -> None:
@@ -317,7 +322,7 @@ def test_second_wait_timeout_retains_every_worker(monkeypatch: Any) -> None:
         worker.stderr.close()
 
 
-def test_shutdown_fails_after_two_bounded_waits(monkeypatch: Any) -> None:
+def test_shutdown_fails_after_two_bounded_waits(monkeypatch: Any, tmp_path: Path) -> None:
     class Process:
         returncode = None
         wait_calls = 0
@@ -341,7 +346,9 @@ def test_shutdown_fails_after_two_bounded_waits(monkeypatch: Any) -> None:
 
     candidate = _candidate(1, 1, "2026-08-09T00:00:00Z")
     process = Process()
-    worker = ActiveWorker(candidate, process, 0.0, io.StringIO(), io.StringIO())
+    lease = tmp_path / "lease"
+    lease.write_text("active", encoding="utf-8")
+    worker = ActiveWorker(candidate, process, 0.0, io.StringIO(), io.StringIO(), lease)
     monkeypatch.setattr(dispatch, "discover_candidates", lambda *args: (candidate,))
     monkeypatch.setattr(dispatch, "launch_worker", lambda *args: worker)
     monkeypatch.setattr(dispatch.time, "monotonic", lambda: dispatch.WORKER_TIMEOUT_SECONDS + 1)
@@ -355,8 +362,67 @@ def test_shutdown_fails_after_two_bounded_waits(monkeypatch: Any) -> None:
         dispatch.run_dispatch_loop(arguments, App())  # type: ignore[arg-type]
 
     assert process.wait_calls == 2
+    assert lease.read_text(encoding="utf-8") == "revoked"
     worker.stdout.close()
     worker.stderr.close()
+
+
+def test_failed_cleanup_revokes_stuck_worker_and_terminates_sibling(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    class Stuck:
+        returncode = None
+
+        def poll(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+        def wait(self, timeout: int) -> int:
+            raise subprocess.TimeoutExpired("worker", timeout)
+
+    class Pending:
+        returncode = -9
+        killed = False
+
+        def poll(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            self.killed = True
+
+        def wait(self, timeout: int) -> int:
+            return self.returncode
+
+    first = _candidate(1, 1, "2026-08-09T00:00:00Z")
+    second = _candidate(2, 2, "2026-08-09T00:00:00Z")
+    first_lease, second_lease = tmp_path / "first", tmp_path / "second"
+    first_lease.write_text("active", encoding="utf-8")
+    second_lease.write_text("active", encoding="utf-8")
+    pending = Pending()
+    active = {
+        first.key: ActiveWorker(first, Stuck(), 0.0, io.StringIO(), io.StringIO(), first_lease),  # type: ignore[arg-type]
+        second.key: ActiveWorker(
+            second,
+            pending,
+            dispatch.WORKER_TIMEOUT_SECONDS + 1,
+            io.StringIO(),
+            io.StringIO(),
+            second_lease,
+        ),  # type: ignore[arg-type]
+    }
+    monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)
+
+    with pytest.raises(subprocess.SubprocessError, match="WORKER_TERMINATION_FAILURE"):
+        dispatch.reap_workers(active, dispatch.WORKER_TIMEOUT_SECONDS + 1)
+
+    assert set(active) == {first.key}
+    assert first_lease.read_text(encoding="utf-8") == "revoked"
+    assert pending.killed is True
+    assert not second_lease.exists()
+    active[first.key].stdout.close()
+    active[first.key].stderr.close()
 
 
 def test_shadow_reports_selected_repositories_even_without_candidates(capsys: Any) -> None:

--- a/tests/test_semantic_dispatch.py
+++ b/tests/test_semantic_dispatch.py
@@ -65,6 +65,22 @@ def test_candidate_rejects_noncanonical_github_timestamp() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("repository", "pull"),
+    [
+        ({"full_name": "../repo", "id": 1}, {"number": 1}),
+        ({"full_name": "owner/repo", "id": 0}, {"number": 1}),
+        ({"full_name": "owner/repo", "id": 1}, {"number": 0}),
+    ],
+)
+def test_candidate_rejects_invalid_external_identity(
+    repository: dict[str, Any], pull: dict[str, Any]
+) -> None:
+    pull.update(created_at="2026-08-09T00:00:00Z", head={"sha": "a" * 40})
+    with pytest.raises(SemanticReviewError, match="MALFORMED_PULL_REQUEST"):
+        dispatch._candidate(repository, pull)
+
+
 def test_fair_order_is_round_robin_oldest_pull_first() -> None:
     candidates = (
         _candidate(1, 3, "2026-08-09T03:00:00Z"),
@@ -140,9 +156,11 @@ def test_worker_launch_uses_fixed_shell_free_captured_command(monkeypatch: Any) 
 
     assert worker.started_at == 12.0
     assert captured["shell"] is False
+    assert captured["cwd"] == Path(dispatch.sys.executable).resolve().parent
     assert captured["stdout"] is not subprocess.PIPE
     assert captured["stderr"] is not subprocess.PIPE
     assert captured["arguments"][1:] == [
+        "-I",
         "-m",
         "supportability_gate.semantic_cli",
         "--repository",
@@ -190,6 +208,30 @@ def test_reaper_kills_and_removes_timed_out_worker(capsys: Any) -> None:
     assert process.killed is True
     assert active == {}
     assert json.loads(capsys.readouterr().out)["timed_out"] is True
+
+
+def test_reaper_tolerates_kill_after_worker_exit(capsys: Any) -> None:
+    class Process:
+        returncode = 0
+
+        def poll(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            raise ProcessLookupError
+
+        def wait(self, timeout: int) -> int:
+            return self.returncode
+
+    candidate = _candidate(1, 1, "2026-08-09T00:00:00Z")
+    active = {
+        candidate.key: ActiveWorker(candidate, Process(), 0.0, io.StringIO(), io.StringIO())  # type: ignore[arg-type]
+    }
+
+    dispatch.reap_workers(active, dispatch.WORKER_TIMEOUT_SECONDS + 1)
+
+    assert active == {}
+    assert json.loads(capsys.readouterr().out)["returncode"] == 0
 
 
 def test_poll_failure_force_reaps_active_worker(monkeypatch: Any, capsys: Any) -> None:
@@ -291,12 +333,7 @@ def test_shutdown_fails_after_two_bounded_waits(monkeypatch: Any) -> None:
             raise subprocess.TimeoutExpired("worker", timeout)
 
     class App:
-        calls = 0
-
         def installation_token(self) -> str:
-            self.calls += 1
-            if self.calls == 2:
-                raise SemanticReviewError("GITHUB_TRANSPORT_FAILURE")
             return "token"
 
         def installation_repositories(self, token: str) -> tuple[dict[str, Any], ...]:
@@ -307,7 +344,7 @@ def test_shutdown_fails_after_two_bounded_waits(monkeypatch: Any) -> None:
     worker = ActiveWorker(candidate, process, 0.0, io.StringIO(), io.StringIO())
     monkeypatch.setattr(dispatch, "discover_candidates", lambda *args: (candidate,))
     monkeypatch.setattr(dispatch, "launch_worker", lambda *args: worker)
-    monkeypatch.setattr(dispatch.time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(dispatch.time, "monotonic", lambda: dispatch.WORKER_TIMEOUT_SECONDS + 1)
     monkeypatch.setattr(dispatch.time, "sleep", lambda seconds: None)
     monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)
     arguments = argparse.Namespace(

--- a/tests/test_semantic_dispatch.py
+++ b/tests/test_semantic_dispatch.py
@@ -11,8 +11,10 @@ from typing import Any
 import pytest
 
 import supportability_gate.semantic_dispatch as dispatch
+import supportability_gate.semantic_result as semantic_result
 from supportability_gate.semantic_contract import EvidencePacket, SemanticReviewError
 from supportability_gate.semantic_dispatch import ActiveWorker, Candidate
+from supportability_gate.semantic_lease import exclusive_lease
 
 
 def _candidate(repository_id: int, pull: int, created_at: str) -> Candidate:
@@ -345,15 +347,56 @@ def test_dispatcher_alone_publishes_confirmed_worker_result(tmp_path: Path) -> N
         )
     }  # type: ignore[arg-type]
 
-    with dispatch.exclusive_lease(lock):
+    with exclusive_lease(lock):
         with pytest.raises(SemanticReviewError, match="EVALUATION_IN_PROGRESS"):
-            dispatch._publish_worker_result(app, active[candidate.key])  # type: ignore[arg-type]
+            semantic_result.publish_worker_result(app, packet, 1, result, lock)  # type: ignore[arg-type]
     assert app.completed == []
 
     dispatch.reap_workers(active, now=0.0, app=app)  # type: ignore[arg-type]
 
     assert active == {}
     assert app.completed == [(packet, "token", 9, "success", "PASS")]
+    assert not result.exists()
+
+
+def test_nonzero_worker_exit_cannot_publish_valid_result(tmp_path: Path) -> None:
+    packet = EvidencePacket("owner/repo-1", "b" * 40, "a" * 40, 42, {"pull_request": 1})
+    candidate = Candidate(1, packet.repository, 1, packet.head_sha, datetime.now(), packet)
+    result = tmp_path / "result"
+    result.write_text(
+        json.dumps(
+            {
+                "check_id": 9,
+                "conclusion": "success",
+                "evidence_sha256": packet.sha256,
+                "summary": "PASS",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class Process:
+        returncode = 1
+
+        def poll(self) -> int:
+            return 1
+
+        def wait(self, timeout: int) -> int:
+            return 1
+
+    class App:
+        def complete_check(self, *args: object) -> None:
+            pytest.fail("nonzero worker result published")
+
+    active = {
+        candidate.key: ActiveWorker(
+            candidate, Process(), 0.0, io.StringIO(), io.StringIO(), result, tmp_path / "lock"
+        )
+    }  # type: ignore[arg-type]
+
+    dispatch.reap_workers(active, now=0.0, app=App())  # type: ignore[arg-type]
+
+    assert active == {}
     assert not result.exists()
 
 

--- a/tests/test_semantic_dispatch.py
+++ b/tests/test_semantic_dispatch.py
@@ -11,7 +11,7 @@ from typing import Any
 import pytest
 
 import supportability_gate.semantic_dispatch as dispatch
-from supportability_gate.semantic_contract import SemanticReviewError
+from supportability_gate.semantic_contract import EvidencePacket, SemanticReviewError
 from supportability_gate.semantic_dispatch import ActiveWorker, Candidate
 
 
@@ -184,15 +184,15 @@ def test_worker_launch_uses_fixed_shell_free_captured_command(monkeypatch: Any) 
         "7",
         "--private-key",
         str(Path("key.pem").resolve()),
-        "--lease-file",
-        str(worker.lease_file),
+        "--result-file",
+        str(worker.result_file),
     ]
-    assert worker.lease_file is not None
-    assert worker.lease_file.parent == Path("key.pem").resolve().parent
-    assert worker.lease_file.read_text(encoding="utf-8") == "active"
+    assert worker.result_file is not None
+    assert worker.result_file.parent == Path("key.pem").resolve().parent
+    assert worker.result_file.read_text(encoding="utf-8") == ""
     worker.stdout.close()
     worker.stderr.close()
-    worker.lease_file.unlink()
+    worker.result_file.unlink()
 
 
 def test_discovery_skips_completed_exact_generation() -> None:
@@ -277,6 +277,62 @@ def test_reaper_tolerates_kill_after_worker_exit(capsys: Any) -> None:
 
     assert active == {}
     assert json.loads(capsys.readouterr().out)["returncode"] == 0
+
+
+def test_dispatcher_alone_publishes_confirmed_worker_result(tmp_path: Path) -> None:
+    packet = EvidencePacket("owner/repo-1", "b" * 40, "a" * 40, 42, {"pull_request": 1})
+    candidate = Candidate(
+        1,
+        packet.repository,
+        1,
+        packet.head_sha,
+        datetime.fromisoformat("2026-08-09T00:00:00+00:00"),
+        packet,
+    )
+    result = tmp_path / "result"
+    result.write_text(
+        json.dumps(
+            {
+                "check_id": 9,
+                "conclusion": "success",
+                "evidence_sha256": packet.sha256,
+                "summary": "PASS",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class Process:
+        returncode = 0
+
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: int) -> int:
+            return 0
+
+    class App:
+        completed: list[tuple[object, ...]] = []
+
+        def installation_token(self) -> str:
+            return "token"
+
+        def assert_current(self, *args: object) -> None:
+            return None
+
+        def complete_check(self, *args: object) -> None:
+            self.completed.append(args)
+
+    app = App()
+    active = {
+        candidate.key: ActiveWorker(candidate, Process(), 0.0, io.StringIO(), io.StringIO(), result)
+    }  # type: ignore[arg-type]
+
+    dispatch.reap_workers(active, now=0.0, app=app)  # type: ignore[arg-type]
+
+    assert active == {}
+    assert app.completed == [(packet, "token", 9, "success", "PASS")]
+    assert not result.exists()
 
 
 def test_poll_failure_force_reaps_active_worker(monkeypatch: Any, capsys: Any) -> None:
@@ -386,9 +442,9 @@ def test_shutdown_fails_after_two_bounded_waits(monkeypatch: Any, tmp_path: Path
 
     candidate = _candidate(1, 1, "2026-08-09T00:00:00Z")
     process = Process()
-    lease = tmp_path / "lease"
-    lease.write_text("active", encoding="utf-8")
-    worker = ActiveWorker(candidate, process, 0.0, io.StringIO(), io.StringIO(), lease)
+    result = tmp_path / "result"
+    result.write_text("", encoding="utf-8")
+    worker = ActiveWorker(candidate, process, 0.0, io.StringIO(), io.StringIO(), result)
     monkeypatch.setattr(dispatch, "discover_candidates", lambda *args: (candidate,))
     monkeypatch.setattr(dispatch, "launch_worker", lambda *args: worker)
     monkeypatch.setattr(dispatch.time, "monotonic", lambda: dispatch.WORKER_TIMEOUT_SECONDS + 1)
@@ -402,12 +458,12 @@ def test_shutdown_fails_after_two_bounded_waits(monkeypatch: Any, tmp_path: Path
         dispatch.run_dispatch_loop(arguments, App())  # type: ignore[arg-type]
 
     assert process.wait_calls == 2
-    assert lease.with_name("lease.revoked").exists()
+    assert result.exists()
     worker.stdout.close()
     worker.stderr.close()
 
 
-def test_failed_cleanup_revokes_stuck_worker_and_terminates_sibling(
+def test_failed_cleanup_retains_stuck_worker_and_terminates_sibling(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
     class Stuck:
@@ -437,19 +493,19 @@ def test_failed_cleanup_revokes_stuck_worker_and_terminates_sibling(
 
     first = _candidate(1, 1, "2026-08-09T00:00:00Z")
     second = _candidate(2, 2, "2026-08-09T00:00:00Z")
-    first_lease, second_lease = tmp_path / "first", tmp_path / "second"
-    first_lease.write_text("active", encoding="utf-8")
-    second_lease.write_text("active", encoding="utf-8")
+    first_result, second_result = tmp_path / "first", tmp_path / "second"
+    first_result.write_text("", encoding="utf-8")
+    second_result.write_text("", encoding="utf-8")
     pending = Pending()
     active = {
-        first.key: ActiveWorker(first, Stuck(), 0.0, io.StringIO(), io.StringIO(), first_lease),  # type: ignore[arg-type]
+        first.key: ActiveWorker(first, Stuck(), 0.0, io.StringIO(), io.StringIO(), first_result),  # type: ignore[arg-type]
         second.key: ActiveWorker(
             second,
             pending,
             dispatch.WORKER_TIMEOUT_SECONDS + 1,
             io.StringIO(),
             io.StringIO(),
-            second_lease,
+            second_result,
         ),  # type: ignore[arg-type]
     }
     monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)
@@ -458,61 +514,14 @@ def test_failed_cleanup_revokes_stuck_worker_and_terminates_sibling(
         dispatch.reap_workers(active, dispatch.WORKER_TIMEOUT_SECONDS + 1)
 
     assert set(active) == {first.key}
-    assert first_lease.with_name("first.revoked").exists()
+    assert first_result.exists()
     assert pending.killed is True
-    assert not second_lease.exists()
+    assert not second_result.exists()
     active[first.key].stdout.close()
     active[first.key].stderr.close()
 
 
-def test_revocation_failure_still_terminates_worker_and_sibling(
-    monkeypatch: Any, tmp_path: Path
-) -> None:
-    class Process:
-        returncode = -9
-        killed = False
-
-        def poll(self) -> None:
-            return None
-
-        def kill(self) -> None:
-            self.killed = True
-
-        def wait(self, timeout: int) -> int:
-            return self.returncode
-
-    first = _candidate(1, 1, "2026-08-09T00:00:00Z")
-    second = _candidate(2, 2, "2026-08-09T00:00:00Z")
-    processes = (Process(), Process())
-    active = {
-        item.key: ActiveWorker(
-            item,
-            process,
-            0.0 if item is first else dispatch.WORKER_TIMEOUT_SECONDS + 1,
-            io.StringIO(),
-            io.StringIO(),
-            tmp_path / f"lease-{item.repository_id}",
-        )
-        for item, process in zip((first, second), processes, strict=True)
-    }  # type: ignore[arg-type]
-    for worker in active.values():
-        assert worker.lease_file is not None
-        worker.lease_file.write_text("active", encoding="utf-8")
-    monkeypatch.setattr(
-        dispatch,
-        "revoke_publication_lease",
-        lambda path: (_ for _ in ()).throw(SemanticReviewError("WORKER_LEASE_BUSY")),
-    )
-    monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)
-
-    with pytest.raises(subprocess.SubprocessError, match="WORKER_TERMINATION_FAILURE"):
-        dispatch.reap_workers(active, dispatch.WORKER_TIMEOUT_SECONDS + 1)
-
-    assert active == {}
-    assert all(process.killed for process in processes)
-
-
-def test_termination_failure_leaves_publication_revoked(tmp_path: Path) -> None:
+def test_termination_failure_cannot_publish_result(tmp_path: Path) -> None:
     class Process:
         returncode = None
 
@@ -526,14 +535,14 @@ def test_termination_failure_leaves_publication_revoked(tmp_path: Path) -> None:
             raise subprocess.TimeoutExpired("worker", timeout)
 
     candidate = _candidate(1, 1, "2026-08-09T00:00:00Z")
-    lease = tmp_path / "lease"
-    lease.write_text("active", encoding="utf-8")
-    worker = ActiveWorker(candidate, Process(), 0.0, io.StringIO(), io.StringIO(), lease)  # type: ignore[arg-type]
+    result = tmp_path / "result"
+    result.write_text("ready but untrusted", encoding="utf-8")
+    worker = ActiveWorker(candidate, Process(), 0.0, io.StringIO(), io.StringIO(), result)  # type: ignore[arg-type]
     active = {candidate.key: worker}
 
     assert not dispatch._finish_worker(active, candidate.key, worker, True)
     assert candidate.key in active
-    assert lease.with_name("lease.revoked").exists()
+    assert result.exists()
     worker.stdout.close()
     worker.stderr.close()
 


### PR DESCRIPTION
Implements Project #8 S01.\n\n- paginates all GitHub App-selected repositories\n- waits for successful exact-head organization-required evidence\n- queues oldest PRs fairly across repositories\n- supervises at most two deduplicated shell-free workers\n- adds nonpublishing shadow discovery\n\nLive shadow discovered source, DC, and TWMN; source #111 and DC #23 were eligible. Production tasks and runtime remain unchanged.\n\nRefs #119