### PR TITLE
fix: allow private PR review observation

### DIFF
--- a/.github/workflows/organization-required.yml
+++ b/.github/workflows/organization-required.yml
@@ -16,6 +16,7 @@ jobs:
       actions: read
       contents: read
       issues: read
+      pull-requests: read
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Why

Private target repositories require the observer job itself to retain pull-request read permission. The prior job-level permission block dropped the workflow-level grant, causing a safe 403 failure in TWMN while public DC Training masked it.

## Change

- add pull-requests: read to Observe Codex Review
- no code, dependency, or product-scope change

## Proof

- mandatory Python 3.12 source proof green: 188 passed, 2 skipped
- wheel build and fresh exact-lock install green
- installed supportability-gate --help green
- immutable standard hash poison test green
- docs/supportability_standard.md SHA-256 unchanged