### PR TITLE
Pilot focused Codex review lenses

### DIFF
--- a/.github/workflows/organization-required.yml
+++ b/.github/workflows/organization-required.yml
@@ -18,7 +18,7 @@ jobs:
       issues: read
       pull-requests: read
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 45
     steps:
       - name: Check out exact gate source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -33,14 +33,14 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Observe exact-request connector acknowledgement
+      - name: Observe serial focused connector reviews
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PULL_NUMBER: ${{ github.event.pull_request.number }}
           PYTHONPATH: ${{ github.workspace }}/gate/src
         run: |
-          python -P -c 'import os; from supportability_gate.codex_review import OBSERVER_MARKER, require_acknowledgement; comment_id = require_acknowledgement(os.environ["GITHUB_REPOSITORY"], int(os.environ["PULL_NUMBER"]), os.environ["HEAD_SHA"], int(os.environ["GITHUB_RUN_ID"]), os.environ["GITHUB_TOKEN"]); print(f"{OBSERVER_MARKER}{comment_id}")'
+          python -P -c 'import os; from supportability_gate.codex_review import FOCUSED_OBSERVER_MARKER, FOCUSES, require_focused_acknowledgements; comment_ids = require_focused_acknowledgements(os.environ["GITHUB_REPOSITORY"], int(os.environ["PULL_NUMBER"]), os.environ["HEAD_SHA"], int(os.environ["GITHUB_RUN_ID"]), os.environ["GITHUB_TOKEN"]); print("\n".join(f"{FOCUSED_OBSERVER_MARKER}{focus}:{comment_id}" for focus, comment_id in zip(FOCUSES, comment_ids, strict=True)))'
 
   characterize-base:
     name: Characterize Base
@@ -271,6 +271,7 @@ jobs:
   supportability-gate:
     name: Supportability Gate
     needs: [observe-codex-review, characterize-base, characterize-head, quality-profile]
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -296,30 +297,44 @@ jobs:
           python-version: "3.12"
 
       - name: Install exact gate
+        id: install
+        continue-on-error: true
         run: |
           python -m venv "$RUNNER_TEMP/gate-venv"
           "$RUNNER_TEMP/gate-venv/bin/python" -m pip install --disable-pip-version-check --require-hashes -r gate/requirements-dev.lock
           "$RUNNER_TEMP/gate-venv/bin/python" -m pip install --disable-pip-version-check --no-build-isolation --no-deps ./gate
 
       - name: Download authenticated base behavior
+        id: download_base
+        if: needs.characterize-base.result == 'success'
+        continue-on-error: true
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           artifact-ids: ${{ needs.characterize-base.outputs.artifact-id }}
           path: ${{ runner.temp }}/base
 
       - name: Download authenticated head behavior
+        id: download_head
+        if: needs.characterize-head.result == 'success'
+        continue-on-error: true
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           artifact-ids: ${{ needs.characterize-head.outputs.artifact-id }}
           path: ${{ runner.temp }}/head
 
       - name: Download authenticated quality evidence
+        id: download_quality
+        if: needs.quality-profile.result == 'success'
+        continue-on-error: true
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           artifact-ids: ${{ needs.quality-profile.outputs.artifact-id }}
           path: ${{ runner.temp }}/quality
 
       - name: Read back GitHub artifact metadata
+        id: artifact_metadata
+        if: steps.download_quality.outcome == 'success'
+        continue-on-error: true
         env:
           ARTIFACT_ID: ${{ needs.quality-profile.outputs.artifact-id }}
           GH_TOKEN: ${{ github.token }}
@@ -332,6 +347,12 @@ jobs:
             --output "$RUNNER_TEMP/quality/artifact-metadata.json"
 
       - name: Verify exact behavior and refactor policy
+        id: refactor_policy
+        if: >-
+          steps.install.outcome == 'success' &&
+          steps.download_base.outcome == 'success' &&
+          steps.download_head.outcome == 'success'
+        continue-on-error: true
         env:
           BASE_ARTIFACT_DIGEST: ${{ needs.characterize-base.outputs.artifact-digest }}
           BASE_ARTIFACT_ID: ${{ needs.characterize-base.outputs.artifact-id }}
@@ -377,6 +398,12 @@ jobs:
           exit "$refactor_status"
 
       - name: Evaluate immutable pull-request commits
+        id: evaluate
+        if: >-
+          steps.install.outcome == 'success' &&
+          steps.download_quality.outcome == 'success' &&
+          steps.artifact_metadata.outcome == 'success'
+        continue-on-error: true
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -408,9 +435,36 @@ jobs:
           exit "$status"
 
       - name: Upload authoritative supportability evidence
+        id: upload_evidence
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: supportability-evidence-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/evidence
           if-no-files-found: error
+
+      - name: Enforce aggregate result
+        if: always()
+        env:
+          OBSERVER_RESULT: ${{ needs.observe-codex-review.result }}
+          BASE_RESULT: ${{ needs.characterize-base.result }}
+          HEAD_RESULT: ${{ needs.characterize-head.result }}
+          QUALITY_RESULT: ${{ needs.quality-profile.result }}
+          INSTALL_OUTCOME: ${{ steps.install.outcome }}
+          BASE_DOWNLOAD_OUTCOME: ${{ steps.download_base.outcome }}
+          HEAD_DOWNLOAD_OUTCOME: ${{ steps.download_head.outcome }}
+          QUALITY_DOWNLOAD_OUTCOME: ${{ steps.download_quality.outcome }}
+          METADATA_OUTCOME: ${{ steps.artifact_metadata.outcome }}
+          REFACTOR_OUTCOME: ${{ steps.refactor_policy.outcome }}
+          EVALUATE_OUTCOME: ${{ steps.evaluate.outcome }}
+          UPLOAD_OUTCOME: ${{ steps.upload_evidence.outcome }}
+        run: |
+          status=0
+          for result in "$OBSERVER_RESULT" "$BASE_RESULT" "$HEAD_RESULT" "$QUALITY_RESULT" \
+            "$INSTALL_OUTCOME" "$BASE_DOWNLOAD_OUTCOME" "$HEAD_DOWNLOAD_OUTCOME" \
+            "$QUALITY_DOWNLOAD_OUTCOME" "$METADATA_OUTCOME" "$REFACTOR_OUTCOME" \
+            "$EVALUATE_OUTCOME" "$UPLOAD_OUTCOME"; do
+            if [ "$result" != "success" ]; then status=1; fi
+          done
+          exit "$status"

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -1,51 +1,52 @@
 schema_version = "1.0"
 
 [behavior]
-intended_behavior = "The required Supportability Gate remains non-green until the trusted Codex connector completes review for the exact pull-request head and workflow run."
-proof = "tests/test_codex_review.py::test_trusted_exact_head_submitted_review_passes"
+intended_behavior = "The required Supportability Gate reports all applicable deterministic failures and remains non-green until the trusted Codex connector completes distinct serial reviews for Standard focuses 2, 4, and 8 on the exact pull-request head and workflow run."
+proof = "tests/test_codex_review.py; tests/test_evaluate_complexity.py::test_policy_and_complexity_blocks_are_reported_together; tests/test_refactor_policy.py::test_connector_failure_does_not_suppress_refactor_result"
 
 [characterization]
-captured_behavior = "Missing, stale-head, stale-run, pending, spoofed, mutable, duplicate, paginated, and unavailable GitHub evidence fail closed; trusted exact-request completion passes."
+captured_behavior = "The retained single-review boundary remains stable while focused tests cover missing, stale, unfocused, mutable, duplicate, out-of-order, ambiguous, reused, and unavailable evidence; three distinct observer-bound completions pass."
 proof = "tests/test_codex_review.py"
 
 [separation_of_concerns]
 before = "The refactor policy could finish before advisory Codex review completed."
-after = "codex_review owns exact-head connector evidence while refactor_policy retains refactor authorization and invokes that boundary."
+after = "codex_review owns serial lens-bound connector evidence while refactor_policy writes deterministic authorization evidence before invoking that boundary."
 
 [architecture]
 dependency_direction = "refactor_policy depends on the focused codex_review policy; codex_review uses only the Python standard library and imports no Gate policy."
 reviewed_paths = [
     "src/supportability_gate/codex_review.py",
     "src/supportability_gate/refactor_policy.py",
+    "src/supportability_gate/cli.py",
 ]
 
 [responsibility_boundary]
 path = "src/supportability_gate/codex_review.py"
-owns = "Bounded GitHub evidence reads and trusted exact-head Codex review completion."
+owns = "Bounded GitHub evidence reads and three trusted, serial, exact-head focused Codex review completions."
 does_not_own = "Codex review judgment, deterministic Supportability evaluation, inline-thread resolution, or target execution."
 
 [incremental_refactor]
-target = "Close the merge race without restoring the retired semantic-review system."
-completed_step = "Added one focused evidence policy to the existing required Gate path with no new service, check, package, or dependency."
+target = "Increase first-pass qualitative review coverage without restoring a custom semantic-review runtime."
+completed_step = "Added three fixed focused invocations to the existing read-only observer and one aggregate Gate, with no new service, check, package, or dependency."
 
 [review_handoff]
-summary = "Deterministic enforcement now waits for trusted exact-head and exact-run Codex review completion; native thread resolution still blocks unresolved inline findings."
+summary = "Deterministic enforcement now reports applicable failures together and waits for distinct exact-head and exact-run Codex reviews focused on Standard items 2, 4, and 8; native thread resolution still blocks unresolved inline findings."
 remaining_risks = [
     "Codex review remains nondeterministic and is not exhaustive assurance.",
-    "A clean result is tied to the exact request comment; a findings result also requires the running Gate to observe the eyes handshake on that comment before the exact-head review.",
+    "Clean summaries and submitted reviews do not expose their triggering request ID, so their focus attribution relies on an observed request-specific eyes handshake, strict serial windows, and unique artifact identity.",
 ]
 
 [human_review]
-naming = "codex_review names its single external evidence responsibility."
-cohesion = "Request parsing, authenticated pagination, connector identity, exact-head review, clean reaction, and bounded polling form one policy boundary."
-intended_behavior = "The existing Gate waits for connector completion and fails closed on missing, stale, spoofed, malformed, or unavailable evidence."
-reviewability = "Eight focused tests cover every acceptance branch without target execution or a new runtime surface."
+naming = "codex_review names its single external evidence responsibility and the fixed Standard focus identifiers."
+cohesion = "Request parsing, authenticated pagination, connector identity, serial artifact binding, and bounded polling form one policy boundary."
+intended_behavior = "The Gate waits for three distinct focused connector completions and fails closed on missing, stale, spoofed, malformed, ambiguous, reused, or unavailable evidence."
+reviewability = "Focused protocol tests cover request order, observer binding, artifact uniqueness, and trust failures without target execution or a new runtime surface."
 
 [[module_boundaries]]
 path = "src/supportability_gate/codex_review.py"
 owner_path = "src/supportability_gate/codex_review.py"
 basis = "responsibility"
-justification = "Owns exact-head Codex request and completion evidence from fixed authenticated GitHub endpoints; it does not own refactor policy or review-thread resolution."
+justification = "Owns serial focused exact-head Codex request and completion evidence from fixed authenticated GitHub endpoints; it does not own refactor policy or review-thread resolution."
 
 [[module_boundaries]]
 path = "src/supportability_gate/quality_profile.py"

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -1,8 +1,8 @@
 schema_version = "1.0"
 
 [behavior]
-intended_behavior = "The required Supportability Gate reports all applicable deterministic failures and remains non-green until the trusted Codex connector completes distinct serial reviews for Standard focuses 2, 4, and 8 on the exact pull-request head and workflow run."
-proof = "tests/test_codex_review.py; tests/test_evaluate_complexity.py::test_policy_and_complexity_blocks_are_reported_together; tests/test_refactor_policy.py::test_connector_failure_does_not_suppress_refactor_result"
+intended_behavior = "The required Supportability Gate preserves independently computable deterministic results: policy violations and candidate-contract changes do not suppress complexity results, and connector failures do not suppress the refactor-policy result; it remains non-green until the trusted Codex connector completes distinct serial reviews for Standard focuses 2, 4, and 8 on the exact pull-request head and workflow run."
+proof = "tests/test_codex_review.py; tests/test_evaluate_complexity.py::test_policy_and_complexity_blocks_are_reported_together; tests/test_evaluate_complexity.py::test_candidate_contract_change_and_complexity_block_are_reported_together; tests/test_refactor_policy.py::test_connector_failure_does_not_suppress_refactor_result"
 
 [characterization]
 captured_behavior = "The retained single-review boundary remains stable while focused tests cover missing, stale, unfocused, mutable, duplicate, out-of-order, ambiguous, reused, and unavailable evidence; three distinct observer-bound completions pass."
@@ -27,13 +27,13 @@ does_not_own = "Codex review judgment, deterministic Supportability evaluation, 
 
 [incremental_refactor]
 target = "Increase first-pass qualitative review coverage without restoring a custom semantic-review runtime."
-completed_step = "Added three fixed focused invocations to the existing read-only observer and one aggregate Gate, with no new service, check, package, or dependency."
+completed_step = "Added enforcement for three fixed owner-posted focused review requests to the existing read-only observer and one aggregate Gate, with no new service, check, package, or dependency."
 
 [review_handoff]
-summary = "Deterministic enforcement now reports applicable failures together and waits for distinct exact-head and exact-run Codex reviews focused on Standard items 2, 4, and 8; native thread resolution still blocks unresolved inline findings."
+summary = "The Gate preserves independently computable deterministic results: policy violations and candidate-contract changes do not suppress complexity results, and connector failures do not suppress the refactor-policy result; it waits for distinct exact-head and exact-run Codex reviews focused on Standard items 2, 4, and 8, while native thread resolution still blocks unresolved inline findings."
 remaining_risks = [
     "Codex review remains nondeterministic and is not exhaustive assurance.",
-    "Clean summaries and submitted reviews do not expose their triggering request ID, so their focus attribution relies on an observed request-specific eyes handshake, strict serial windows, and unique artifact identity.",
+    "Clean summaries and submitted reviews do not expose their triggering request ID, so their focus attribution relies on an observed request-specific eyes handshake, serial request windows, bounded final polling, and unique artifact identity.",
 ]
 
 [human_review]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,14 +98,21 @@ Stop condition:
 
 ## Codex review completion
 
-- For every pull-request head and required-workflow run, post exactly one comment containing
-  `@codex review`, `Codex-Review-Head: <40-character-head-sha>`, and
-  `Codex-Review-Run: <workflow-run-id>` on separate lines.
+- For every pull-request head and required-workflow run, post exactly three owner-authenticated
+  comments, one at a time in focus order `2`, `4`, then `8`.
+- Each comment must contain the exact focus command below plus
+  `Codex-Review-Focus: <focus>`, `Codex-Review-Head: <40-character-head-sha>`, and
+  `Codex-Review-Run: <workflow-run-id>` on separate lines:
+  - `2`: `@codex review for mixed responsibilities or unclear single ownership in changed code only`
+  - `4`: `@codex review for weak domain ownership, low cohesion, avoidable coupling, or unjustified module boundaries only`
+  - `8`: `@codex review for unsupported, contradictory, stale, incomplete, or misleading handoff claims about change, boundaries, validation, risk, or gate coverage only`
+- Post the next focus only after the connector completes the prior focus. A generic request, an
+  out-of-order request, or one completion artifact reused across focuses does not count.
 - A new push requires a new exact-head request. Do not merge while the required Gate is waiting for
-  the trusted connector's thumbs-up on that exact request comment, exact-head clean summary, or
-  exact-head submitted review.
+  any trusted focused completion.
 - A clean summary or submitted review counts only after the exact-run observer job logged that
-  request's comment ID while connector eyes were present and the required Gate later saw eyes clear.
+  focus and request comment ID while connector eyes were present; the required Gate must then bind
+  one unique completion artifact to that focus's strict serial time window.
 - Resolve every inline finding before merge; GitHub's required review-thread resolution remains the
   enforcement boundary for unresolved findings.
 

--- a/src/supportability_gate/cli.py
+++ b/src/supportability_gate/cli.py
@@ -214,36 +214,19 @@ def _result(
     quality: quality_profile.QualityEvidence,
     quality_blocks: tuple[str, ...],
 ) -> reporting.EvaluationResult:
-    if any(
-        contract_path in {item.change.old_path, item.change.new_path}
-        for item in analyzed.assessments
-    ):
-        return reporting.EvaluationResult(
-            identity,
-            contract_path,
-            blob.object_sha,
-            policy.sha256,
-            policy.production_paths,
-            policy.high_risk_paths,
-            _gate_coverage(policy),
-            analyzed.assessments,
-            (),
-            (),
-            (),
-            (
-                "CANDIDATE_CONTRACT_CHANGE",
-                *gate_policy.contract_change_blocks(policy, candidate_policy),
-            ),
-            "BLOCK",
-            _versions(identity),
-            tuple(records),
-            (),
-            structured_review,
-            policy.language,
-            architecture,
-            quality_profile=quality,
+    candidate_blocks = (
+        (
+            "CANDIDATE_CONTRACT_CHANGE",
+            *gate_policy.contract_change_blocks(policy, candidate_policy),
         )
+        if any(
+            contract_path in {item.change.old_path, item.change.new_path}
+            for item in analyzed.assessments
+        )
+        else ()
+    )
     policy_blocks = (
+        *candidate_blocks,
         *gate_policy.evaluate_contract(policy, analyzed.assessments),
         *architecture.blocks,
         *modularity.blocks,
@@ -436,11 +419,7 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
                 candidate_policy = contract.parse_contract(candidate_blob.content)
             except (contract.ContractError, git_changes.GitError):
                 candidate_policy = None
-        analyzed = (
-            _AnalyzedChanges(assessments, (), {})
-            if contract_changed
-            else _analyze_changes(repository, identity, policy, assessments, records)
-        )
+        analyzed = _analyze_changes(repository, identity, policy, assessments, records)
         architecture_gate = next(
             (
                 gate

--- a/src/supportability_gate/cli.py
+++ b/src/supportability_gate/cli.py
@@ -250,30 +250,6 @@ def _result(
         *review_blocks,
         *quality_blocks,
     )
-    if policy_blocks:
-        return reporting.EvaluationResult(
-            identity,
-            contract_path,
-            blob.object_sha,
-            policy.sha256,
-            policy.production_paths,
-            policy.high_risk_paths,
-            _gate_coverage(policy),
-            analyzed.assessments,
-            (),
-            (),
-            (),
-            policy_blocks,
-            "BLOCK",
-            _versions(identity),
-            tuple(records),
-            (),
-            structured_review,
-            policy.language,
-            architecture,
-            modularity,
-            quality,
-        )
     base_definitions = _all_definitions(analyzed.analyses, "base")
     head_definitions = _all_definitions(analyzed.analyses, "head")
     base_metrics = complexity_metrics.measure_definitions(base_definitions, policy.language)
@@ -294,7 +270,9 @@ def _result(
         head_metrics,
     )
     complexity_policy.validate_reporting(decisions, policy.maximum)
-    overall = "BLOCK" if any(item.decision == "BLOCK" for item in decisions) else "PASS"
+    overall = (
+        "BLOCK" if policy_blocks or any(item.decision == "BLOCK" for item in decisions) else "PASS"
+    )
     return reporting.EvaluationResult(
         identity,
         contract_path,
@@ -307,7 +285,7 @@ def _result(
         decisions,
         ruff.diagnostics,
         (),
-        (),
+        policy_blocks,
         overall,
         _versions(identity),
         tuple(records),

--- a/src/supportability_gate/codex_review.py
+++ b/src/supportability_gate/codex_review.py
@@ -703,6 +703,24 @@ def _observed_eyes(reactions: tuple[dict[str, Any], ...], request: FocusedReview
     )
 
 
+def _focused_acknowledgement_block(
+    requests: dict[str, FocusedReviewRequest],
+    stale: bool,
+    acknowledged: dict[str, int],
+) -> str | None:
+    missing = next((focus for focus in FOCUSES if focus not in requests), None)
+    if missing is not None:
+        prefix = "STALE" if stale and not requests else "MISSING"
+        return f"{prefix}_FOCUSED_CODEX_REVIEW_REQUEST_{missing}"
+    pending = next(
+        (focus for focus in FOCUSES if acknowledged.get(focus) != requests[focus].comment_id),
+        None,
+    )
+    if pending is None:
+        return None
+    return f"FOCUSED_CODEX_REVIEW_PENDING_{pending}"
+
+
 def require_focused_acknowledgements(
     repository: str,
     pull_number: int,
@@ -735,22 +753,10 @@ def require_focused_acknowledgements(
                     for reaction in reactions
                 ):
                     acknowledged[focus] = request.comment_id
-            missing = next((focus for focus in FOCUSES if focus not in requests), None)
-            if missing is not None:
-                prefix = "STALE" if stale and not requests else "MISSING"
-                last_code = f"{prefix}_FOCUSED_CODEX_REVIEW_REQUEST_{missing}"
-            else:
-                pending = next(
-                    (
-                        focus
-                        for focus in FOCUSES
-                        if acknowledged.get(focus) != requests[focus].comment_id
-                    ),
-                    None,
-                )
-                if pending is None:
-                    return tuple(requests[focus].comment_id for focus in FOCUSES)
-                last_code = f"FOCUSED_CODEX_REVIEW_PENDING_{pending}"
+            block = _focused_acknowledgement_block(requests, stale, acknowledged)
+            if block is None:
+                return tuple(requests[focus].comment_id for focus in FOCUSES)
+            last_code = block
         except CodexReviewError as error:
             if error.code == "GITHUB_CODEX_REVIEW_EVIDENCE_FAILURE":
                 raise

--- a/src/supportability_gate/codex_review.py
+++ b/src/supportability_gate/codex_review.py
@@ -16,15 +16,35 @@ CONNECTOR_ID = 199175422
 REQUESTER_ID = 229662739
 HEAD_PREFIX = "Codex-Review-Head: "
 RUN_PREFIX = "Codex-Review-Run: "
+FOCUS_PREFIX = "Codex-Review-Focus: "
 CLEAN_PREFIX = "Codex Review: Didn't find any major issues."
 OBSERVER_JOB = "Observe Codex Review"
 OBSERVER_MARKER = "CODEX_REVIEW_ACKNOWLEDGED:"
+FOCUSED_OBSERVER_MARKER = "CODEX_FOCUSED_REVIEW_ACKNOWLEDGED:"
 WORKFLOW_NAME = "Organization Required Supportability Gate"
 SHA = re.compile(r"[0-9a-f]{40}\Z")
 REVIEWED_COMMIT = re.compile(r"(?m)^\*\*Reviewed commit:\*\* `([0-9a-f]{10})`$")
 MAX_PAGES = 10
 POLL_ATTEMPTS = 30
 POLL_SECONDS = 15
+FOCUSED_POLL_ATTEMPTS = 120
+FOCUSED_REVIEWS = (
+    (
+        "2",
+        "@codex review for mixed responsibilities or unclear single ownership in changed code only",
+    ),
+    (
+        "4",
+        "@codex review for weak domain ownership, low cohesion, avoidable coupling, "
+        "or unjustified module boundaries only",
+    ),
+    (
+        "8",
+        "@codex review for unsupported, contradictory, stale, incomplete, or misleading "
+        "handoff claims about change, boundaries, validation, risk, or gate coverage only",
+    ),
+)
+FOCUSES = tuple(item[0] for item in FOCUSED_REVIEWS)
 
 
 class CodexReviewError(ValueError):
@@ -63,6 +83,24 @@ class ReviewRequest:
 
     comment_id: int
     created_at: datetime
+
+
+@dataclass(frozen=True)
+class FocusedReviewRequest:
+    """One immutable focused request for the exact head and run."""
+
+    focus: str
+    comment_id: int
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class CompletionArtifact:
+    """One trusted connector completion artifact."""
+
+    kind: str
+    artifact_id: int
+    completed_at: datetime
 
 
 def _timestamp(value: object) -> datetime:
@@ -198,6 +236,25 @@ def _observer_comment_id(
     return next(iter(identifiers), None)
 
 
+def _focused_observer_comment_ids(
+    repository: str, run_id: int, head_sha: str, token: str, opener: Any
+) -> tuple[int, ...] | None:
+    results: set[tuple[int, ...]] = set()
+    focuses = "|".join(FOCUSES)
+    pattern = re.compile(rf"(?m)^\S+ {FOCUSED_OBSERVER_MARKER}({focuses}):([1-9][0-9]*)\r?$")
+    for job in _observer_jobs(repository, run_id, head_sha, token, opener):
+        job_id = job.get("id")
+        if type(job_id) is not int:
+            raise CodexReviewError("GITHUB_CODEX_REVIEW_EVIDENCE_FAILURE")
+        matches = pattern.findall(_observer_log(repository, job_id, token, opener))
+        if len(matches) != len(FOCUSES) or tuple(item[0] for item in matches) != FOCUSES:
+            raise CodexReviewError("GITHUB_CODEX_REVIEW_EVIDENCE_FAILURE")
+        results.add(tuple(int(item[1]) for item in matches))
+    if len(results) > 1:
+        raise CodexReviewError("GITHUB_CODEX_REVIEW_EVIDENCE_FAILURE")
+    return next(iter(results), None)
+
+
 def _request_values(body: object) -> tuple[str, int] | None:
     if not isinstance(body, str):
         return None
@@ -222,6 +279,92 @@ def _request_values(body: object) -> tuple[str, int] | None:
     ):
         raise CodexReviewError("MALFORMED_CODEX_REVIEW_REQUEST")
     return heads[0], int(runs[0])
+
+
+def _focused_request_values(body: object) -> tuple[str, str, int] | None:
+    if not isinstance(body, str):
+        return None
+    lines = body.splitlines()
+    commands = [line.strip() for line in lines if line.strip().startswith("@codex review")]
+    heads = [line.removeprefix(HEAD_PREFIX) for line in lines if line.startswith(HEAD_PREFIX)]
+    runs = [line.removeprefix(RUN_PREFIX) for line in lines if line.startswith(RUN_PREFIX)]
+    focuses = [line.removeprefix(FOCUS_PREFIX) for line in lines if line.startswith(FOCUS_PREFIX)]
+    if not commands and not heads and not runs and not focuses:
+        return None
+    if (
+        len(commands) != 1
+        or len(heads) != 1
+        or SHA.fullmatch(heads[0]) is None
+        or len(runs) > 1
+        or (runs and (not runs[0].isdigit() or int(runs[0]) < 1))
+    ):
+        raise CodexReviewError("MALFORMED_FOCUSED_CODEX_REVIEW_REQUEST")
+    if commands[0] == "@codex review" and not focuses:
+        return "", heads[0], int(runs[0]) if runs else 0
+    if len(runs) != 1 or len(focuses) != 1:
+        raise CodexReviewError("MALFORMED_FOCUSED_CODEX_REVIEW_REQUEST")
+    commands_by_focus = dict(FOCUSED_REVIEWS)
+    if focuses[0] not in commands_by_focus or commands[0] != commands_by_focus[focuses[0]]:
+        raise CodexReviewError("MALFORMED_FOCUSED_CODEX_REVIEW_REQUEST")
+    return focuses[0], heads[0], int(runs[0])
+
+
+def _positive_id(item: dict[str, Any]) -> int:
+    identifier = item.get("id")
+    if type(identifier) is not int or identifier < 1:
+        raise CodexReviewError("MALFORMED_CODEX_REVIEW_EVIDENCE")
+    return identifier
+
+
+def _validate_focused_order(requests: dict[str, FocusedReviewRequest]) -> None:
+    present = tuple(focus for focus in FOCUSES if focus in requests)
+    if set(requests) != set(present) or present != FOCUSES[: len(present)]:
+        raise CodexReviewError("OUT_OF_ORDER_FOCUSED_CODEX_REVIEW_REQUEST")
+    ordered = tuple(requests[focus] for focus in present)
+    for previous, current in zip(ordered, ordered[1:], strict=False):
+        if previous.created_at >= current.created_at or previous.comment_id >= current.comment_id:
+            raise CodexReviewError("OUT_OF_ORDER_FOCUSED_CODEX_REVIEW_REQUEST")
+
+
+def _focused_review_requests(
+    comments: tuple[dict[str, Any], ...], head_sha: str, run_id: int
+) -> tuple[dict[str, FocusedReviewRequest], bool]:
+    requests: dict[str, FocusedReviewRequest] = {}
+    stale = False
+    for comment in comments:
+        if not _trusted_owner(comment):
+            continue
+        values = _focused_request_values(comment.get("body"))
+        if values is None:
+            continue
+        focus, requested_head, requested_run = values
+        if (requested_head, requested_run) != (head_sha, run_id):
+            stale = True
+            continue
+        if focus not in FOCUSES:
+            raise CodexReviewError("UNFOCUSED_CODEX_REVIEW_REQUEST")
+        created_at = _timestamp(comment.get("created_at"))
+        if created_at != _timestamp(comment.get("updated_at")) or focus in requests:
+            raise CodexReviewError("MALFORMED_FOCUSED_CODEX_REVIEW_REQUEST")
+        requests[focus] = FocusedReviewRequest(focus, _positive_id(comment), created_at)
+    _validate_focused_order(requests)
+    return requests, stale
+
+
+def _required_focused_requests(
+    comments: tuple[dict[str, Any], ...], head_sha: str, run_id: int
+) -> tuple[FocusedReviewRequest, ...]:
+    requests, stale = _focused_review_requests(comments, head_sha, run_id)
+    missing = next((focus for focus in FOCUSES if focus not in requests), None)
+    if missing is not None:
+        prefix = "STALE" if stale and not requests else "MISSING"
+        raise CodexReviewError(f"{prefix}_FOCUSED_CODEX_REVIEW_REQUEST_{missing}")
+    return tuple(requests[focus] for focus in FOCUSES)
+
+
+def _trusted_owner(item: dict[str, Any]) -> bool:
+    user = item.get("user")
+    return isinstance(user, dict) and user.get("id") == REQUESTER_ID
 
 
 def _review_request(
@@ -271,6 +414,109 @@ def _clean_summary(item: dict[str, Any], request: ReviewRequest, head_sha: str) 
         and match.group(1) == head_sha[:10]
         and _timestamp(item.get("created_at")) >= request.created_at
     )
+
+
+def _in_focus_window(
+    completed_at: datetime,
+    request: FocusedReviewRequest,
+    completed_before: datetime | None,
+) -> bool:
+    return request.created_at < completed_at and (
+        completed_before is None or completed_at < completed_before
+    )
+
+
+def _reaction_artifact(
+    item: dict[str, Any],
+    request: FocusedReviewRequest,
+    completed_before: datetime | None,
+) -> CompletionArtifact | None:
+    if not _trusted_user(item) or item.get("content") != "+1":
+        return None
+    completed_at = _timestamp(item.get("created_at"))
+    if not _in_focus_window(completed_at, request, completed_before):
+        return None
+    return CompletionArtifact("reaction", _positive_id(item), completed_at)
+
+
+def _summary_artifact(
+    item: dict[str, Any],
+    request: FocusedReviewRequest,
+    head_sha: str,
+    completed_before: datetime | None,
+) -> CompletionArtifact | None:
+    body = item.get("body")
+    match = REVIEWED_COMMIT.search(body) if isinstance(body, str) else None
+    if (
+        not _trusted_user(item)
+        or not isinstance(body, str)
+        or not body.startswith(CLEAN_PREFIX)
+        or match is None
+        or match.group(1) != head_sha[:10]
+    ):
+        return None
+    completed_at = _timestamp(item.get("created_at"))
+    if completed_at != _timestamp(item.get("updated_at")):
+        raise CodexReviewError("MALFORMED_CODEX_REVIEW_EVIDENCE")
+    if not _in_focus_window(completed_at, request, completed_before):
+        return None
+    return CompletionArtifact("comment", _positive_id(item), completed_at)
+
+
+def _submitted_review_artifact(
+    item: dict[str, Any],
+    request: FocusedReviewRequest,
+    head_sha: str,
+    completed_before: datetime | None,
+) -> CompletionArtifact | None:
+    if not _trusted_user(item) or item.get("commit_id") != head_sha:
+        return None
+    if item.get("state") not in {"APPROVED", "CHANGES_REQUESTED", "COMMENTED"}:
+        return None
+    completed_at = _timestamp(item.get("submitted_at"))
+    if not _in_focus_window(completed_at, request, completed_before):
+        return None
+    return CompletionArtifact("review", _positive_id(item), completed_at)
+
+
+def _one_artifact(artifacts: list[CompletionArtifact]) -> CompletionArtifact | None:
+    if len(artifacts) > 1:
+        raise CodexReviewError("AMBIGUOUS_FOCUSED_CODEX_REVIEW_COMPLETION")
+    return artifacts[0] if artifacts else None
+
+
+def _focused_completion_artifact(
+    request: FocusedReviewRequest,
+    head_sha: str,
+    comments: tuple[dict[str, Any], ...],
+    reactions: tuple[dict[str, Any], ...],
+    reviews: tuple[dict[str, Any], ...],
+    acknowledged: bool,
+    completed_before: datetime | None,
+) -> CompletionArtifact | None:
+    direct = [
+        artifact
+        for item in reactions
+        if (artifact := _reaction_artifact(item, request, completed_before)) is not None
+    ]
+    if direct:
+        return _one_artifact(direct)
+    if not acknowledged or any(
+        _trusted_user(reaction) and reaction.get("content") == "eyes" for reaction in reactions
+    ):
+        return None
+    artifacts = [
+        artifact
+        for item in comments
+        if (artifact := _summary_artifact(item, request, head_sha, completed_before)) is not None
+    ]
+    artifacts.extend(
+        artifact
+        for item in reviews
+        if (artifact := _submitted_review_artifact(item, request, head_sha, completed_before))
+        is not None
+    )
+    return _one_artifact(artifacts)
 
 
 def _completed(
@@ -392,6 +638,145 @@ def require_completion(
     for attempt in range(attempts):
         try:
             block = _state(
+                repository,
+                pull_number,
+                head_sha,
+                run_id,
+                token,
+                opener,
+            )
+        except CodexReviewError as error:
+            last_code = error.code
+        else:
+            if block is None:
+                return
+            last_code = block
+        if attempt + 1 < attempts:
+            sleeper(delay)
+    raise CodexReviewError(last_code)
+
+
+def _focused_state(
+    repository: str,
+    pull_number: int,
+    head_sha: str,
+    run_id: int,
+    token: str,
+    opener: Any,
+) -> str | None:
+    root = f"https://api.github.com/repos/{repository}"
+    comments = _pages(f"{root}/issues/{pull_number}/comments", token, opener)
+    requests = _required_focused_requests(comments, head_sha, run_id)
+    acknowledged = _focused_observer_comment_ids(repository, run_id, head_sha, token, opener)
+    if acknowledged is None:
+        return "FOCUSED_CODEX_REVIEW_PENDING_2"
+    if acknowledged != tuple(item.comment_id for item in requests):
+        raise CodexReviewError("GITHUB_CODEX_REVIEW_EVIDENCE_FAILURE")
+    reviews = _pages(f"{root}/pulls/{pull_number}/reviews", token, opener)
+    artifacts: list[CompletionArtifact] = []
+    for index, request in enumerate(requests):
+        reactions = _pages(f"{root}/issues/comments/{request.comment_id}/reactions", token, opener)
+        completed_before = requests[index + 1].created_at if index + 1 < len(requests) else None
+        artifact = _focused_completion_artifact(
+            request,
+            head_sha,
+            comments,
+            reactions,
+            reviews,
+            True,
+            completed_before,
+        )
+        if artifact is None:
+            return f"FOCUSED_CODEX_REVIEW_PENDING_{request.focus}"
+        artifacts.append(artifact)
+    if len({(item.kind, item.artifact_id) for item in artifacts}) != len(FOCUSES):
+        raise CodexReviewError("REUSED_FOCUSED_CODEX_REVIEW_EVIDENCE")
+    return None
+
+
+def _observed_eyes(reactions: tuple[dict[str, Any], ...], request: FocusedReviewRequest) -> bool:
+    return any(
+        _trusted_user(reaction)
+        and reaction.get("content") == "eyes"
+        and _timestamp(reaction.get("created_at")) >= request.created_at
+        for reaction in reactions
+    )
+
+
+def require_focused_acknowledgements(
+    repository: str,
+    pull_number: int,
+    head_sha: str,
+    run_id: int,
+    token: str,
+    *,
+    attempts: int = FOCUSED_POLL_ATTEMPTS,
+    delay: int = POLL_SECONDS,
+    opener: Any = urllib.request.urlopen,
+    sleeper: Any = time.sleep,
+) -> tuple[int, ...]:
+    """Observe connector acknowledgement on each serial focused request."""
+    root = f"https://api.github.com/repos/{repository}"
+    acknowledged: dict[str, int] = {}
+    last_code = "MISSING_FOCUSED_CODEX_REVIEW_REQUEST_2"
+    for attempt in range(attempts):
+        try:
+            durable = _focused_observer_comment_ids(repository, run_id, head_sha, token, opener)
+            if durable is not None:
+                return durable
+            comments = _pages(f"{root}/issues/{pull_number}/comments", token, opener)
+            requests, stale = _focused_review_requests(comments, head_sha, run_id)
+            for focus, request in requests.items():
+                reactions = _pages(
+                    f"{root}/issues/comments/{request.comment_id}/reactions", token, opener
+                )
+                if _observed_eyes(reactions, request) or any(
+                    _reaction_artifact(reaction, request, None) is not None
+                    for reaction in reactions
+                ):
+                    acknowledged[focus] = request.comment_id
+            missing = next((focus for focus in FOCUSES if focus not in requests), None)
+            if missing is not None:
+                prefix = "STALE" if stale and not requests else "MISSING"
+                last_code = f"{prefix}_FOCUSED_CODEX_REVIEW_REQUEST_{missing}"
+            else:
+                pending = next(
+                    (
+                        focus
+                        for focus in FOCUSES
+                        if acknowledged.get(focus) != requests[focus].comment_id
+                    ),
+                    None,
+                )
+                if pending is None:
+                    return tuple(requests[focus].comment_id for focus in FOCUSES)
+                last_code = f"FOCUSED_CODEX_REVIEW_PENDING_{pending}"
+        except CodexReviewError as error:
+            if error.code == "GITHUB_CODEX_REVIEW_EVIDENCE_FAILURE":
+                raise
+            last_code = error.code
+        if attempt + 1 < attempts:
+            sleeper(delay)
+    raise CodexReviewError(last_code)
+
+
+def require_focused_completion(
+    repository: str,
+    pull_number: int,
+    head_sha: str,
+    run_id: int,
+    token: str,
+    *,
+    attempts: int = POLL_ATTEMPTS,
+    delay: int = POLL_SECONDS,
+    opener: Any = urllib.request.urlopen,
+    sleeper: Any = time.sleep,
+) -> None:
+    """Require three distinct observer-bound focused connector completions."""
+    last_code = "FOCUSED_CODEX_REVIEW_PENDING_2"
+    for attempt in range(attempts):
+        try:
+            block = _focused_state(
                 repository,
                 pull_number,
                 head_sha,

--- a/src/supportability_gate/refactor_policy.py
+++ b/src/supportability_gate/refactor_policy.py
@@ -585,7 +585,6 @@ def main(argv: list[str] | None = None) -> int:
         run_id = os.environ.get("GITHUB_RUN_ID")
         if not token or not run_id or not run_id.isdigit() or int(run_id) < 1:
             raise RefactorPolicyError("GITHUB_AUTHORIZATION_EVIDENCE_FAILURE")
-        codex_review.require_completion(repository_name, pull_number, head_sha, int(run_id), token)
         comments = _github_comments(repository_name, pull_number, token)
         _, base_sha, _, _ = _event_values(event)
         predecessor, predecessor_block = _predecessor_authorization(
@@ -600,6 +599,13 @@ def main(argv: list[str] | None = None) -> int:
             predecessor_block,
         )
         _write_result(Path(arguments.output), result)
+        codex_review.require_focused_completion(
+            repository_name,
+            pull_number,
+            head_sha,
+            int(run_id),
+            token,
+        )
     except Exception as error:  # fail closed at hosted-job boundary
         print(getattr(error, "code", "TECHNICAL_FAILURE"))
         return 2

--- a/tests/test_codex_review.py
+++ b/tests/test_codex_review.py
@@ -127,20 +127,23 @@ def _focused_request(
     *,
     comment_id: int | None = None,
     created_at: str | None = None,
+    head: str = HEAD,
+    run_id: int = RUN_ID,
     updated_at: str | None = None,
+    user_id: int = codex_review.REQUESTER_ID,
 ) -> dict[str, object]:
     requested_at = created_at or FOCUS_REQUEST_TIMES[focus]
     return {
         "body": (
             f"{dict(codex_review.FOCUSED_REVIEWS)[focus]}\n\n"
             f"Codex-Review-Focus: {focus}\n"
-            f"Codex-Review-Head: {HEAD}\n"
-            f"Codex-Review-Run: {RUN_ID}"
+            f"Codex-Review-Head: {head}\n"
+            f"Codex-Review-Run: {run_id}"
         ),
         "created_at": requested_at,
         "id": comment_id or FOCUS_REQUEST_IDS[focus],
         "updated_at": updated_at or requested_at,
-        "user": {"id": codex_review.REQUESTER_ID},
+        "user": {"id": user_id},
     }
 
 
@@ -479,12 +482,15 @@ def test_legacy_head_only_request_does_not_override_exact_run_request() -> None:
     _verify(_opener([_legacy_request(), _request(comment_id=2)], [_reaction()]))
 
 
-def test_api_failure_blocks() -> None:
+@pytest.mark.parametrize("verify", [_verify, _verify_focused], ids=("single", "focused"))
+def test_api_failure_blocks(
+    verify: Callable[[Callable[..., _Reply]], None],
+) -> None:
     def fail(*args: object, **kwargs: object) -> _Reply:
         raise urllib.error.URLError("offline")
 
     with pytest.raises(codex_review.CodexReviewError, match="GITHUB_CODEX_REVIEW_EVIDENCE_FAILURE"):
-        _verify(fail)
+        verify(fail)
 
 
 def test_paginated_exact_head_request_is_found() -> None:
@@ -494,13 +500,51 @@ def test_paginated_exact_head_request_is_found() -> None:
     _verify(_opener(comments, [_reaction()]))
 
 
-def test_three_distinct_focused_requests_and_artifacts_pass() -> None:
+def test_clean_reaction_and_finding_review_completions_pass() -> None:
     requests = [_focused_request(focus) for focus in codex_review.FOCUSES]
-    reactions = {
-        FOCUS_REQUEST_IDS[focus]: [_focused_reaction(focus)] for focus in codex_review.FOCUSES
-    }
+    comments = [*requests, _focused_summary("2")]
+    reactions = {FOCUS_REQUEST_IDS["4"]: [_focused_reaction("4")]}
 
-    _verify_focused(_focused_opener(requests, reactions=reactions))
+    _verify_focused(_focused_opener(comments, reactions=reactions, reviews=[_focused_review("8")]))
+
+
+@pytest.mark.parametrize(
+    ("head", "run_id"),
+    [(OLD_HEAD, RUN_ID), (HEAD, RUN_ID - 1)],
+    ids=("head", "run"),
+)
+def test_stale_focused_requests_block(head: str, run_id: int) -> None:
+    requests = [_focused_request(focus, head=head, run_id=run_id) for focus in codex_review.FOCUSES]
+
+    with pytest.raises(
+        codex_review.CodexReviewError,
+        match="STALE_FOCUSED_CODEX_REVIEW_REQUEST_2",
+    ):
+        _verify_focused(_focused_opener(requests))
+
+
+@pytest.mark.parametrize(
+    ("case", "code"),
+    [
+        ("mutable", "MALFORMED_FOCUSED_CODEX_REVIEW_REQUEST"),
+        ("spoofed", "MISSING_FOCUSED_CODEX_REVIEW_REQUEST_2"),
+        ("malformed", "MALFORMED_FOCUSED_CODEX_REVIEW_REQUEST"),
+    ],
+)
+def test_untrusted_or_mutable_focused_requests_block(case: str, code: str) -> None:
+    request = _focused_request("2")
+    if case == "mutable":
+        request["updated_at"] = COMPLETED
+    elif case == "spoofed":
+        request["user"] = {"id": 1}
+    else:
+        request["body"] = str(request["body"]).replace(
+            dict(codex_review.FOCUSED_REVIEWS)["2"],
+            "@codex review for an unrecognized focus",
+        )
+
+    with pytest.raises(codex_review.CodexReviewError, match=code):
+        _verify_focused(_focused_opener([request]))
 
 
 @pytest.mark.parametrize(
@@ -541,6 +585,53 @@ def test_one_artifact_cannot_satisfy_multiple_focuses() -> None:
         match="REUSED_FOCUSED_CODEX_REVIEW_EVIDENCE",
     ):
         _verify_focused(_focused_opener(requests, reactions=reactions))
+
+
+def test_multiple_valid_focused_artifacts_are_ambiguous() -> None:
+    requests = [_focused_request(focus) for focus in codex_review.FOCUSES]
+    comments = [*requests, _focused_summary("2")]
+    reactions = {FOCUS_REQUEST_IDS[focus]: [_focused_reaction(focus)] for focus in ("4", "8")}
+
+    with pytest.raises(
+        codex_review.CodexReviewError,
+        match="AMBIGUOUS_FOCUSED_CODEX_REVIEW_COMPLETION",
+    ):
+        _verify_focused(
+            _focused_opener(comments, reactions=reactions, reviews=[_focused_review("2")])
+        )
+
+
+def test_paginated_focused_requests_are_found() -> None:
+    comments: list[dict[str, object]] = [{"body": "ordinary", "id": item} for item in range(100)]
+    comments.extend(_focused_request(focus) for focus in codex_review.FOCUSES)
+    reactions = {
+        FOCUS_REQUEST_IDS[focus]: [_focused_reaction(focus)] for focus in codex_review.FOCUSES
+    }
+
+    _verify_focused(_focused_opener(comments, reactions=reactions))
+
+
+def test_focused_completion_timeout_blocks() -> None:
+    delays: list[int] = []
+    requests = [_focused_request(focus) for focus in codex_review.FOCUSES]
+
+    with pytest.raises(
+        codex_review.CodexReviewError,
+        match="FOCUSED_CODEX_REVIEW_PENDING_2",
+    ):
+        codex_review.require_focused_completion(
+            "example/repository",
+            7,
+            HEAD,
+            RUN_ID,
+            "token",
+            attempts=2,
+            delay=3,
+            opener=_focused_opener(requests),
+            sleeper=delays.append,
+        )
+
+    assert delays == [3]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_codex_review.py
+++ b/tests/test_codex_review.py
@@ -15,6 +15,18 @@ OLD_HEAD = "b" * 40
 REQUESTED = "2026-08-11T12:00:00Z"
 COMPLETED = "2026-08-11T12:01:00Z"
 RUN_ID = 12345
+FOCUS_REQUEST_TIMES = {
+    "2": "2026-08-11T12:00:00Z",
+    "4": "2026-08-11T12:02:00Z",
+    "8": "2026-08-11T12:04:00Z",
+}
+FOCUS_COMPLETION_TIMES = {
+    "2": "2026-08-11T12:01:00Z",
+    "4": "2026-08-11T12:03:00Z",
+    "8": "2026-08-11T12:05:00Z",
+}
+FOCUS_REQUEST_IDS = {"2": 21, "4": 22, "8": 23}
+FOCUS_ARTIFACT_IDS = {"2": 201, "4": 401, "8": 801}
 
 
 class _Reply:
@@ -108,6 +120,126 @@ def _summary(*, user_id: int = codex_review.CONNECTOR_ID, head: str = HEAD) -> d
         "updated_at": COMPLETED,
         "user": {"id": user_id},
     }
+
+
+def _focused_request(
+    focus: str,
+    *,
+    comment_id: int | None = None,
+    created_at: str | None = None,
+    updated_at: str | None = None,
+) -> dict[str, object]:
+    requested_at = created_at or FOCUS_REQUEST_TIMES[focus]
+    return {
+        "body": (
+            f"{dict(codex_review.FOCUSED_REVIEWS)[focus]}\n\n"
+            f"Codex-Review-Focus: {focus}\n"
+            f"Codex-Review-Head: {HEAD}\n"
+            f"Codex-Review-Run: {RUN_ID}"
+        ),
+        "created_at": requested_at,
+        "id": comment_id or FOCUS_REQUEST_IDS[focus],
+        "updated_at": updated_at or requested_at,
+        "user": {"id": codex_review.REQUESTER_ID},
+    }
+
+
+def _focused_reaction(
+    focus: str,
+    *,
+    artifact_id: int | None = None,
+    content: str = "+1",
+) -> dict[str, object]:
+    return {
+        "content": content,
+        "created_at": FOCUS_COMPLETION_TIMES[focus],
+        "id": artifact_id or FOCUS_ARTIFACT_IDS[focus],
+        "user": {"id": codex_review.CONNECTOR_ID},
+    }
+
+
+def _focused_summary(
+    focus: str,
+    *,
+    updated_at: str | None = None,
+) -> dict[str, object]:
+    completed_at = FOCUS_COMPLETION_TIMES[focus]
+    return {
+        "body": (
+            "Codex Review: Didn't find any major issues. Delightful!\n\n"
+            f"**Reviewed commit:** `{HEAD[:10]}`"
+        ),
+        "created_at": completed_at,
+        "id": FOCUS_ARTIFACT_IDS[focus],
+        "updated_at": updated_at or completed_at,
+        "user": {"id": codex_review.CONNECTOR_ID},
+    }
+
+
+def _focused_review(focus: str, *, state: str = "COMMENTED") -> dict[str, object]:
+    return {
+        "commit_id": HEAD,
+        "id": FOCUS_ARTIFACT_IDS[focus],
+        "state": state,
+        "submitted_at": FOCUS_COMPLETION_TIMES[focus],
+        "user": {"id": codex_review.CONNECTOR_ID},
+    }
+
+
+def _focused_log(
+    bindings: tuple[tuple[str, int], ...] | None = None,
+) -> bytes:
+    bound = bindings or tuple((focus, FOCUS_REQUEST_IDS[focus]) for focus in codex_review.FOCUSES)
+    return "".join(
+        f"2026-08-11T12:06:00Z {codex_review.FOCUSED_OBSERVER_MARKER}{focus}:{request_id}\n"
+        for focus, request_id in bound
+    ).encode()
+
+
+def _focused_opener(
+    comments: list[dict[str, object]],
+    *,
+    reactions: dict[int, list[dict[str, object]]] | None = None,
+    reviews: list[dict[str, object]] | None = None,
+    jobs: list[dict[str, object]] | None = None,
+    log: bytes | None = None,
+) -> Callable[..., _Reply]:
+    reaction_rows = reactions or {}
+    job_rows = [_observer()] if jobs is None else jobs
+
+    def open_request(request: Any, **kwargs: object) -> _Reply:
+        assert kwargs == {"timeout": 30}
+        url = urllib.parse.urlparse(request.full_url)
+        page = int(urllib.parse.parse_qs(url.query).get("page", ["1"])[0])
+        start = (page - 1) * 100
+        if url.path.endswith("logs"):
+            return _Reply(log or _focused_log())
+        if url.path.endswith("jobs"):
+            return _Reply(_jobs(job_rows[start : start + 100]))
+        if url.path.endswith("comments"):
+            return _Reply(comments[start : start + 100])
+        if url.path.endswith("reviews"):
+            return _Reply((reviews or [])[start : start + 100])
+        if url.path.endswith("reactions"):
+            comment_id = int(url.path.split("/")[-2])
+            return _Reply(reaction_rows.get(comment_id, [])[start : start + 100])
+        raise AssertionError(url.path)
+
+    return open_request
+
+
+def _verify_focused(opener: Callable[..., _Reply]) -> None:
+    codex_review.require_focused_completion(
+        "example/repository",
+        7,
+        HEAD,
+        RUN_ID,
+        "token",
+        attempts=1,
+        delay=0,
+        opener=opener,
+        sleeper=lambda _: None,
+    )
 
 
 def _opener(
@@ -360,3 +492,196 @@ def test_paginated_exact_head_request_is_found() -> None:
     comments.append(_request(comment_id=101))
 
     _verify(_opener(comments, [_reaction()]))
+
+
+def test_three_distinct_focused_requests_and_artifacts_pass() -> None:
+    requests = [_focused_request(focus) for focus in codex_review.FOCUSES]
+    reactions = {
+        FOCUS_REQUEST_IDS[focus]: [_focused_reaction(focus)] for focus in codex_review.FOCUSES
+    }
+
+    _verify_focused(_focused_opener(requests, reactions=reactions))
+
+
+@pytest.mark.parametrize(
+    ("case", "code"),
+    [
+        ("missing", "MISSING_FOCUSED_CODEX_REVIEW_REQUEST_8"),
+        ("duplicate", "MALFORMED_FOCUSED_CODEX_REVIEW_REQUEST"),
+        ("unfocused", "UNFOCUSED_CODEX_REVIEW_REQUEST"),
+        ("out_of_order", "OUT_OF_ORDER_FOCUSED_CODEX_REVIEW_REQUEST"),
+        ("same_second", "OUT_OF_ORDER_FOCUSED_CODEX_REVIEW_REQUEST"),
+    ],
+)
+def test_invalid_focused_request_sequences_block(case: str, code: str) -> None:
+    requests = [_focused_request(focus) for focus in codex_review.FOCUSES]
+    if case == "missing":
+        requests.pop()
+    elif case == "duplicate":
+        requests.append(_focused_request("2", comment_id=24))
+    elif case == "unfocused":
+        requests.append(_request(comment_id=24))
+    elif case == "out_of_order":
+        requests[1] = _focused_request("4", created_at="2026-08-11T11:59:00Z")
+    else:
+        requests[1] = _focused_request("4", created_at=FOCUS_REQUEST_TIMES["2"])
+
+    with pytest.raises(codex_review.CodexReviewError, match=code):
+        _verify_focused(_focused_opener(requests))
+
+
+def test_one_artifact_cannot_satisfy_multiple_focuses() -> None:
+    requests = [_focused_request(focus) for focus in codex_review.FOCUSES]
+    reactions = {
+        FOCUS_REQUEST_IDS[focus]: [_focused_reaction(focus, artifact_id=999)]
+        for focus in codex_review.FOCUSES
+    }
+    with pytest.raises(
+        codex_review.CodexReviewError,
+        match="REUSED_FOCUSED_CODEX_REVIEW_EVIDENCE",
+    ):
+        _verify_focused(_focused_opener(requests, reactions=reactions))
+
+
+@pytest.mark.parametrize(
+    "bindings",
+    [
+        (("4", 21), ("2", 22), ("8", 23)),
+        (("2", 99), ("4", 22), ("8", 23)),
+    ],
+)
+def test_observer_markers_bind_focus_and_request(
+    bindings: tuple[tuple[str, int], ...],
+) -> None:
+    requests = [_focused_request(focus) for focus in codex_review.FOCUSES]
+    reactions = {
+        FOCUS_REQUEST_IDS[focus]: [_focused_reaction(focus)] for focus in codex_review.FOCUSES
+    }
+
+    with pytest.raises(
+        codex_review.CodexReviewError,
+        match="GITHUB_CODEX_REVIEW_EVIDENCE_FAILURE",
+    ):
+        _verify_focused(_focused_opener(requests, reactions=reactions, log=_focused_log(bindings)))
+
+
+def test_edited_focused_summary_blocks() -> None:
+    requests = [_focused_request(focus) for focus in codex_review.FOCUSES]
+    comments = [
+        *requests,
+        _focused_summary("2", updated_at="2026-08-11T12:01:30Z"),
+    ]
+    reactions = {FOCUS_REQUEST_IDS[focus]: [_focused_reaction(focus)] for focus in ("4", "8")}
+    with pytest.raises(
+        codex_review.CodexReviewError,
+        match="MALFORMED_CODEX_REVIEW_EVIDENCE",
+    ):
+        _verify_focused(_focused_opener(comments, reactions=reactions))
+
+
+def test_dismissed_focused_review_blocks() -> None:
+    requests = [_focused_request(focus) for focus in codex_review.FOCUSES]
+    reactions = {FOCUS_REQUEST_IDS[focus]: [_focused_reaction(focus)] for focus in ("4", "8")}
+    with pytest.raises(
+        codex_review.CodexReviewError,
+        match="FOCUSED_CODEX_REVIEW_PENDING_2",
+    ):
+        _verify_focused(
+            _focused_opener(
+                requests,
+                reactions=reactions,
+                reviews=[_focused_review("2", state="DISMISSED")],
+            )
+        )
+
+
+def test_focused_observer_is_get_only_and_tracks_serial_acknowledgements() -> None:
+    requests: list[Any] = []
+    comment_poll = 0
+
+    def opener(request: Any, **kwargs: object) -> _Reply:
+        nonlocal comment_poll
+        requests.append(request)
+        assert kwargs == {"timeout": 30}
+        path = urllib.parse.urlparse(request.full_url).path
+        if path.endswith("jobs"):
+            return _Reply(_jobs())
+        if path.endswith("comments"):
+            comment_poll += 1
+            comments = [_focused_request("2")]
+            if comment_poll >= 3:
+                comments.append(_focused_request("4"))
+            if comment_poll >= 5:
+                comments.append(_focused_request("8"))
+            return _Reply(comments)
+        if path.endswith("reviews"):
+            return _Reply([])
+        if path.endswith("reactions"):
+            comment_id = int(path.split("/")[-2])
+            focus = next(
+                item for item, identifier in FOCUS_REQUEST_IDS.items() if identifier == comment_id
+            )
+            first_seen = {"2": 1, "4": 3, "8": 5}
+            if comment_poll == first_seen[focus]:
+                return _Reply([_focused_reaction(focus, content="eyes")])
+            if comment_poll > first_seen[focus]:
+                return _Reply([_focused_reaction(focus)])
+            return _Reply([])
+        raise AssertionError(path)
+
+    comment_ids = codex_review.require_focused_acknowledgements(
+        "example/repository",
+        7,
+        HEAD,
+        RUN_ID,
+        "token",
+        attempts=5,
+        delay=0,
+        opener=opener,
+        sleeper=lambda _: None,
+    )
+
+    assert comment_ids == tuple(FOCUS_REQUEST_IDS[focus] for focus in codex_review.FOCUSES)
+    assert comment_poll == 5
+    assert all(request.get_method() == "GET" for request in requests)
+
+
+def test_focused_completion_waits_for_final_eyes_to_clear() -> None:
+    requests = [_focused_request(focus) for focus in codex_review.FOCUSES]
+    polls = 0
+
+    def opener(request: Any, **kwargs: object) -> _Reply:
+        nonlocal polls
+        assert kwargs == {"timeout": 30}
+        path = urllib.parse.urlparse(request.full_url).path
+        if path.endswith("comments"):
+            polls += 1
+            return _Reply(requests)
+        if path.endswith("jobs"):
+            return _Reply(_jobs([_observer()]))
+        if path.endswith("logs"):
+            return _Reply(_focused_log())
+        if path.endswith("reviews"):
+            return _Reply([])
+        if path.endswith("reactions"):
+            comment_id = int(path.split("/")[-2])
+            focus = next(
+                item for item, identifier in FOCUS_REQUEST_IDS.items() if identifier == comment_id
+            )
+            content = "eyes" if focus == "8" and polls == 1 else "+1"
+            return _Reply([_focused_reaction(focus, content=content)])
+        raise AssertionError(path)
+
+    codex_review.require_focused_completion(
+        "example/repository",
+        7,
+        HEAD,
+        RUN_ID,
+        "token",
+        attempts=2,
+        delay=0,
+        opener=opener,
+        sleeper=lambda _: None,
+    )
+
+    assert polls == 2

--- a/tests/test_evaluate_complexity.py
+++ b/tests/test_evaluate_complexity.py
@@ -747,18 +747,29 @@ class Widget:
     ]
 
 
-def test_candidate_contract_change_blocks(tmp_path: Path) -> None:
+def test_candidate_contract_change_and_complexity_block_are_reported_together(
+    tmp_path: Path,
+) -> None:
     repository = _initialize_repository(tmp_path)
     _write(repository / "src" / "sample.py", _function_source("existing", 1))
     base_sha = _commit(repository, "base")
-    _write(repository / ".supportability.toml", CONTRACT + "\n")
+    _write(
+        repository / ".supportability.toml",
+        CONTRACT.replace("maximum = 10", "maximum = 11"),
+    )
+    _write(repository / "src" / "sample.py", _function_source("existing", 11))
     head_sha = _commit(repository, "head")
 
     exit_code, result = _evaluate(repository, base_sha, head_sha, tmp_path / "result")
 
     assert exit_code == 1
     assert result["overall_result"] == "BLOCK"
-    assert result["policy_blocks"] == ["CANDIDATE_CONTRACT_CHANGE"]
+    assert result["policy_blocks"] == [
+        "CANDIDATE_CONTRACT_CHANGE",
+        "THRESHOLD_WEAKENING",
+    ]
+    assert result["functions"][0]["head"]["complexity"] == 11
+    assert result["functions"][0]["decision"] == "BLOCK"
 
 
 def test_policy_and_complexity_blocks_are_reported_together(tmp_path: Path) -> None:

--- a/tests/test_evaluate_complexity.py
+++ b/tests/test_evaluate_complexity.py
@@ -761,6 +761,23 @@ def test_candidate_contract_change_blocks(tmp_path: Path) -> None:
     assert result["policy_blocks"] == ["CANDIDATE_CONTRACT_CHANGE"]
 
 
+def test_policy_and_complexity_blocks_are_reported_together(tmp_path: Path) -> None:
+    policy = CONTRACT.replace("python.ruff-lint.v1", "python.unapproved.v1")
+    repository = _initialize_repository(tmp_path, policy)
+    _write(repository / "src" / "sample.py", _function_source("existing", 1))
+    base_sha = _commit(repository, "base")
+    _write(repository / "src" / "sample.py", _function_source("existing", 11))
+    head_sha = _commit(repository, "exceed complexity")
+
+    exit_code, result = _evaluate(repository, base_sha, head_sha, tmp_path / "result")
+
+    assert exit_code == 1
+    assert result["overall_result"] == "BLOCK"
+    assert "UNAPPROVED_ADAPTER:python.unapproved.v1" in result["policy_blocks"]
+    assert result["functions"][0]["decision"] == "BLOCK"
+    assert result["functions"][0]["head"]["complexity"] == 11
+
+
 def test_unapproved_gate_adapter_blocks(tmp_path: Path) -> None:
     policy = CONTRACT.replace("python.ruff-lint.v1", "python.unapproved.v1")
     repository = _initialize_repository(tmp_path, policy)

--- a/tests/test_refactor_policy.py
+++ b/tests/test_refactor_policy.py
@@ -570,3 +570,48 @@ def test_authorization_focus_and_sequence_are_exact(tmp_path: Path, defect: str,
     )
 
     assert code in result["policy_blocks"]
+
+
+def test_connector_failure_does_not_suppress_refactor_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = tmp_path / "refactor-result.json"
+    result = {"overall_result": "BLOCK", "policy_blocks": ["EXAMPLE_BLOCK"]}
+    monkeypatch.setenv("RUNNER_ENVIRONMENT", "github-hosted")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setenv("GITHUB_RUN_ID", "123")
+    monkeypatch.setattr(refactor_policy, "_read_json", lambda *args: ({}, b"{}"))
+    monkeypatch.setattr(
+        refactor_policy,
+        "_event_values",
+        lambda event: ("example/repository", "b" * 40, "a" * 40, 7),
+    )
+    monkeypatch.setattr(refactor_policy, "_github_comments", lambda *args: ())
+    monkeypatch.setattr(refactor_policy, "_predecessor_authorization", lambda *args: (None, None))
+    monkeypatch.setattr(refactor_policy, "verify_refactor", lambda *args: result)
+
+    def fail_completion(*args: object, **kwargs: object) -> None:
+        raise refactor_policy.codex_review.CodexReviewError("FOCUSED_CODEX_REVIEW_PENDING_2")
+
+    monkeypatch.setattr(
+        refactor_policy.codex_review,
+        "require_focused_completion",
+        fail_completion,
+    )
+
+    exit_code = refactor_policy.main(
+        [
+            "--repository",
+            str(tmp_path),
+            "--event",
+            str(tmp_path / "event.json"),
+            "--characterization-result",
+            str(tmp_path / "characterization.json"),
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert exit_code == 2
+    assert json.loads(output.read_text(encoding="utf-8")) == result


### PR DESCRIPTION
Closes #138

## Summary
- require three serial Codex reviews triggered by owner-authenticated focused requests for Supportability Standard items 2, 4, and 8
- bind each focus to exact head/run, request-specific connector acknowledgement, serial request windows, bounded final polling, and unique connector artifact identity
- keep one required aggregate Gate; policy and candidate-contract failures no longer suppress independently computable complexity results, and connector failure no longer suppresses the refactor-policy result

## Responsibilities and boundary
- `codex_review` owns bounded GitHub evidence reads and focused request/completion verification; it does not post requests, make review judgments, run target code, or resolve review threads
- `refactor_policy` owns deterministic authorization evidence and invokes the connector boundary only after writing its result
- `_result` lost its candidate-contract early return and now uses one aggregation path; current C901 complexity is 3
- C901 ceiling remains 10; no threshold changed

## Verification
Local Python 3.12.13 exact-lock proof:

- `python -m ruff check src tests --no-cache` — passed
- `python -m ruff format --check src tests --no-cache` — passed
- `python -m ruff check src --select C901 --config "lint.mccabe.max-complexity = 10" --no-cache` — passed
- `python -m mypy --strict src` — passed, 19 source files
- `lint-imports --no-cache` — passed, 1 contract kept
- `python -m pytest -q` — 212 passed, 2 skipped
- `python -m compileall -q src tests` — passed
- `python -m build --wheel --no-isolation --outdir <temporary-directory>` — passed
- exact `requirements-dev.lock` installed in a fresh environment; built wheel installed with `--no-deps`; installed `supportability-gate --help` — passed
- `python -m pytest -q tests/test_evaluate_complexity.py::test_standard_hash_change_fails_source_validation` — passed
- `git diff --check 7e30ad045efc13187e7a38084296e51ca4f574d5 15f791e50bb8c992db19195637821931b7e9dd85 -- . ":(exclude)docs/supportability_standard.md"` — passed
- immutable Standard SHA-256 — `81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2`
- exact-head hosted Source Validation: [run 32688222080](https://github.com/mbh-solutions/supportability-gate/actions/runs/32688222080) — passed

## Gate coverage
Changed files:

- production: `src/supportability_gate/cli.py`, `src/supportability_gate/codex_review.py`, `src/supportability_gate/refactor_policy.py`
- tests: `tests/test_codex_review.py`, `tests/test_evaluate_complexity.py`, `tests/test_refactor_policy.py`
- workflow/evidence/instructions: `.github/workflows/organization-required.yml`, `.supportability-review.toml`, `AGENTS.md`

Coverage:

- all changed production files: Ruff lint/format/C901, strict mypy, import-linter, pytest, compileall, wheel build/install, Gate architecture/modularity/quality evaluation
- all changed tests: Ruff lint/format, pytest, compileall
- workflow: exercised by this exact-head required run; diff whitespace checked
- review TOML: parsed and enforced by Gate; instructions/config/docs: diff whitespace checked
- excluded changed or high-risk production files: none
- threshold changes: none
- gate-scope narrowing or moved-out-of-scope files: none

## Risks
- Codex review remains nondeterministic and is not exhaustive assurance
- clean summaries and submitted reviews do not expose their triggering request ID; attribution therefore uses request-specific eyes acknowledgement, serial request windows, bounded final polling, and unique artifact identity

## Deployment
This source PR exercises the new focused protocol on its exact head/run. After normal merge, pin only DC Training to the merge commit, run the focused never-merge canary, roll back that pin on failure, then update the remaining live consumers only after canary success.

