### PR TITLE
S00: migrate execution authority to Project 10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,9 @@
 
 ## Product boundary
 
-- Execute Enforcement Milestone 10 only under `docs/enforcement_milestone_10.md`.
+- Execute only the single slice marked `In progress` in the
+  [Supportability Gate Qualification and Advisory Review](https://github.com/orgs/mbh-solutions/projects/10)
+  project under its repository issue.
 - Never import or execute target repository code.
 - Git and Ruff use fixed argument vectors, finite timeouts, captured output, and no shell.
 - Do not add commands, executable paths, environment controls, exclusions, waivers, or threshold
@@ -121,8 +123,10 @@ Stop condition:
 Before editing:
 
 1. Identify the single slice marked `In progress` in the
-   [Semantic Review Retirement and Gate Simplification](https://github.com/orgs/mbh-solutions/projects/9)
-   project. Projects #2, #3, #6, and #8 are historical and must not be changed.
+   [Supportability Gate Qualification and Advisory Review](https://github.com/orgs/mbh-solutions/projects/10)
+   project. Projects #2, #3, #6, and #8 are historical and must not be changed. Project #9 becomes
+   historical through the exact S00 retirement transaction and must not be used as successor
+   authority.
 2. Read its milestone issue completely.
 3. State:
    - terminal capability;
@@ -140,7 +144,9 @@ Before editing:
    - Evidence is Complete;
    - Scope is On scope;
    - Stop confirmed is Yes.
-9. Do not automatically begin the next milestone.
+9. For Project #10 S00-S11 only, activate the immediate successor automatically after its issue is
+   refreshed and the predecessor's protected merge, ledger, issue, and Project readback prove
+   `Done / Complete / On scope / Yes`. Otherwise do not begin the successor.
 
 ## Required source proof
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ isolated GitHub-hosted jobs.
 Current product status, authorized work, milestone evidence, and remaining work are recorded only
 in the [Product Completion Contract](docs/product_completion_contract.md).
 
-The [Supportability Standard Enforcement](https://github.com/orgs/mbh-solutions/projects/3)
-organization project is successor execution authority. Project #2 is historical.
+The [Supportability Gate Qualification and Advisory Review](https://github.com/orgs/mbh-solutions/projects/10)
+organization project is successor execution authority. Projects #2, #3, #6, and #8 are historical;
+Project #9 becomes historical through the S00 retirement transaction.
 
 ## Requirements
 

--- a/docs/product_completion_contract.md
+++ b/docs/product_completion_contract.md
@@ -12,8 +12,9 @@ Global skills, memory, prior chats, former Governance repositories, unrelated re
 agent assumptions are not product requirement sources.
 
 Successor execution authority is
-[Supportability Standard Enforcement](https://github.com/orgs/mbh-solutions/projects/3). Historical
-Project #2 remains unchanged and is not authority for successor enforcement work.
+[Supportability Gate Qualification and Advisory Review](https://github.com/orgs/mbh-solutions/projects/10).
+Projects #2, #3, #6, and #8 are historical and remain unchanged. Project #9 becomes historical
+through the exact S00 retirement transaction and is not authority for successor work.
 
 ## Final product objective
 
@@ -1273,8 +1274,8 @@ workflow, check-run, ruleset, or GitHub state supports them.
 Historical deterministic gate deployable to target repositories: YES
 Full Supportability Standard enforcement deployable to target repositories: YES
 Full Supportability Standard runtime: YES
-Current authorized work: NONE — Project #9 S07 is complete; stop
-Next milestone authorized: NO — no successor work is authorized
+Current authorized work: Project #10 S00 issue #143 is the sole active slice
+Next milestone authorized: S01 only after exact protected S00 completion and transition readback
 ```
 
 ## Milestone transition rules
@@ -1286,8 +1287,11 @@ Next milestone authorized: NO — no successor work is authorized
 - A milestone status changes to `COMPLETE` only after direct evidence satisfies its active execution
   directive.
 - Completion evidence must be recorded in this contract before the milestone is considered closed.
-- After a milestone reaches `COMPLETE`, stop.
-- The next milestone may begin only after the owner provides and authorizes its execution directive.
+- After a Project #10 slice completes its transition transaction and activates any permitted
+  immediate successor, stop without implementing successor work in the same session.
+- For Project #10 S00-S11 only, owner authorization covers sequential activation. Refresh and
+  activate only the immediate successor after the predecessor's protected merge, ledger, issue,
+  and Project readback prove `Done / Complete / On scope / Yes`; otherwise no successor begins.
 - Do not add cleanup, hardening, future-proofing, abstractions, adapters, infrastructure, or
   follow-up work outside the active directive.
 
@@ -1411,3 +1415,30 @@ Do not create a new terminal label not authorized by an active milestone directi
   synchronization then sets S07 to `Done / Complete / On scope / Yes`, closes issue #138 and Project
   #9, and authorizes no successor work.
 - Remaining work: None. Stop; no successor milestone is authorized.
+
+## Project #10 S00 authority migration
+
+- Terminal result recorded by this protected ledger transaction: Status `COMPLETE`; Evidence
+  `Complete`; Scope `On scope`; Stop confirmed `Yes`. It becomes canonical only after the S00 pull
+  request merges normally and every required direct-proof and transition readback succeeds.
+- Authority: private Project #10 `PVT_kwDOEmzFKc4BhXlK` and repository issue #143. Owner
+  authorization covers automatic sequential S00-S11 activation only after each predecessor's exact
+  protected completion.
+- Project setup: Project #10 is private and open, links this repository, and contains twelve ordered
+  durable issues #143-#154. Execution view `PVTV_lADOEmzFKc4BhXlKzgLautY` exposes Title, Status,
+  Linked pull requests, Evidence, Scope, and Stop confirmed. Initial readback showed S00 alone
+  `In progress / Missing / On scope / No` and S01-S11 `Backlog / Missing / On scope / No`.
+- Prototype preservation: PR #142 closed unmerged at head
+  `08f10730f0d9dc01e677da8ea92a38a6fa632849`; remote branch
+  `codex/eight-supportability-checks`, conversations, runs, and evidence remain available.
+- Authorized source change: only `AGENTS.md`, `README.md`, and this ledger migrate live authority to
+  Project #10. The immutable Standard, frozen roadmap, production source, workflows, rulesets,
+  target repositories, and historical evidence remain unchanged.
+- Protected completion: the S00 pull request must pass the full Python 3.12 source proof and current
+  required checks, bind distinct trusted exact-head/run completions for transitional focuses
+  `2 -> 4 -> 8`, resolve every conversation, and merge normally without bypass. Exact pull-request,
+  run, request, completion, head, and merge identities are recorded in issue #143 after they exist.
+- Closure transaction: after protected merge/readback, retire only Project #9 S08 exactly as issue
+  #143 directs, set S00 `Done / Complete / On scope / Yes`, refresh S01 with current evidence, and
+  activate S01 alone. If any condition lacks direct proof, S01 remains inactive.
+- Remaining work: complete the protected S00 delivery and exact GitHub transition above; then stop.


### PR DESCRIPTION
## Summary

- migrate live execution authority to private Project #10
- preserve the transitional 2 -> 4 -> 8 review contract unchanged
- record the prospective S00 closure and exact transition boundary

## Scope

Only `AGENTS.md`, `README.md`, and `docs/product_completion_contract.md` change. The immutable Standard, frozen roadmap, production source, workflows, rulesets, and target repositories are unchanged.

## Local proof

Python 3.12.13: Ruff lint/format/C901, strict mypy, Import Linter, 212 tests with 2 skips, compileall, wheel build, fresh exact-lock environment, installed CLI help, immutable-Standard tamper test, exact diff check, and cleanup all passed on head `7d055ab17a2ca5ae2d39e4279e564ad94aac8ae8` against base `d591d66989a5b0a51e6e7cf6ce6ad683bbe603d0`.

Closes #143