### PR TITLE
S02: isolate Supportability gate results

### DIFF
--- a/.github/workflows/organization-required.yml
+++ b/.github/workflows/organization-required.yml
@@ -10,66 +10,6 @@ permissions:
   pull-requests: read
 
 jobs:
-  observe-codex-review:
-    name: Observe Codex Review
-    permissions:
-      actions: read
-      contents: read
-      issues: read
-      pull-requests: read
-    runs-on: ubuntu-latest
-    timeout-minutes: 70
-    steps:
-      - name: Check out exact gate source
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: mbh-solutions/supportability-gate
-          ref: ${{ github.workflow_sha }}
-          persist-credentials: false
-          path: gate
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-
-      - name: Observe serial focused connector reviews
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PULL_NUMBER: ${{ github.event.pull_request.number }}
-          PYTHONPATH: ${{ github.workspace }}/gate/src
-        run: |
-          python -P -c 'import os; from supportability_gate.codex_review import FOCUSED_OBSERVER_MARKER, FOCUSES, require_focused_acknowledgements; comment_ids = require_focused_acknowledgements(os.environ["GITHUB_REPOSITORY"], int(os.environ["PULL_NUMBER"]), os.environ["HEAD_SHA"], int(os.environ["GITHUB_RUN_ID"]), os.environ["GITHUB_TOKEN"]); print("\n".join(f"{FOCUSED_OBSERVER_MARKER}{focus}:{comment_id}" for focus, comment_id in zip(FOCUSES, comment_ids, strict=True)))'
-
-  collect-codex-review:
-    name: Collect Codex Review
-    needs: observe-codex-review
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Check out exact gate source
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: mbh-solutions/supportability-gate
-          ref: ${{ github.workflow_sha }}
-          persist-credentials: false
-          path: gate
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-
-      - name: Collect one-time focused connector completions
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PULL_NUMBER: ${{ github.event.pull_request.number }}
-          PYTHONPATH: ${{ github.workspace }}/gate/src
-        run: |
-          python -P -c 'import os; from supportability_gate.codex_review import FOCUSED_COMPLETION_MARKER, require_focused_completion; evidence = require_focused_completion(os.environ["GITHUB_REPOSITORY"], int(os.environ["PULL_NUMBER"]), os.environ["HEAD_SHA"], int(os.environ["GITHUB_RUN_ID"]), os.environ["GITHUB_TOKEN"]); print("\n".join(f"{FOCUSED_COMPLETION_MARKER}{item.focus}:{item.request_id}:{item.completion.kind}:{item.completion.artifact_id}" for item in evidence))'
-
   characterize-base:
     name: Characterize Base
     runs-on: ubuntu-latest
@@ -233,6 +173,7 @@ jobs:
     outputs:
       artifact-digest: ${{ steps.upload.outputs.artifact-digest }}
       artifact-id: ${{ steps.upload.outputs.artifact-id }}
+      capture-outcome: ${{ steps.capture.outcome }}
       capture-sha256: ${{ steps.capture.outputs.sha256 }}
     steps:
       - name: Check out exact target head
@@ -267,6 +208,7 @@ jobs:
 
       - name: Capture fixed stack-native quality profile
         id: capture
+        continue-on-error: true
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -284,12 +226,14 @@ jobs:
             --run-id "$GITHUB_RUN_ID" \
             --run-attempt "$GITHUB_RUN_ATTEMPT" \
             --output "$RUNNER_TEMP/quality/quality-gates.json"
-          echo "status=$?" >> "$GITHUB_OUTPUT"
+          status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
           echo "sha256=$(sha256sum "$RUNNER_TEMP/quality/quality-gates.json" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
-          exit 0
+          exit "$status"
 
       - name: Upload authenticated quality evidence
         id: upload
+        if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: quality-profile-${{ github.run_id }}-${{ github.run_attempt }}
@@ -302,6 +246,10 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      artifact-digest: ${{ steps.upload_evidence.outputs.artifact-digest }}
+      artifact-id: ${{ steps.upload_evidence.outputs.artifact-id }}
+      review-required: ${{ steps.standard_results.outputs.review-required }}
     steps:
       - name: Check out target pull-request head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -374,8 +322,8 @@ jobs:
             "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID" \
             --output "$RUNNER_TEMP/quality/artifact-metadata.json"
 
-      - name: Verify exact behavior and refactor policy
-        id: refactor_policy
+      - name: Verify exact behavior characterization
+        id: characterization
         if: >-
           steps.install.outcome == 'success' &&
           steps.download_base.outcome == 'success' &&
@@ -390,7 +338,6 @@ jobs:
           HEAD_ARTIFACT_ID: ${{ needs.characterize-head.outputs.artifact-id }}
           HEAD_CAPTURE_SHA256: ${{ needs.characterize-head.outputs.capture-sha256 }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUNNER_ENVIRONMENT: ${{ runner.environment }}
         working-directory: ${{ runner.temp }}
         run: |
@@ -413,17 +360,30 @@ jobs:
             --head-artifact-digest "$HEAD_ARTIFACT_DIGEST" \
             --head-capture-sha256 "$HEAD_CAPTURE_SHA256" \
             --output "$RUNNER_TEMP/evidence/characterization-result.json"
-          characterization_status=$?
+          status=$?
           cat "$RUNNER_TEMP/evidence/characterization-result.json"
+          exit "$status"
+
+      - name: Enforce refactor policy
+        id: refactor_policy
+        if: >-
+          steps.install.outcome == 'success' &&
+          steps.download_base.outcome == 'success' &&
+          steps.download_head.outcome == 'success'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: ${{ runner.temp }}
+        run: |
+          set +e
           "$RUNNER_TEMP/gate-venv/bin/python" -P -m supportability_gate.refactor_policy \
             --repository "$GITHUB_WORKSPACE/target" \
             --event "$GITHUB_EVENT_PATH" \
             --characterization-result "$RUNNER_TEMP/evidence/characterization-result.json" \
             --output "$RUNNER_TEMP/evidence/refactor-policy-result.json"
-          refactor_status=$?
+          status=$?
           cat "$RUNNER_TEMP/evidence/refactor-policy-result.json"
-          if [ "$characterization_status" -ne 0 ]; then exit "$characterization_status"; fi
-          exit "$refactor_status"
+          exit "$status"
 
       - name: Evaluate immutable pull-request commits
         id: evaluate
@@ -462,6 +422,46 @@ jobs:
           cat "$RUNNER_TEMP/evidence/complexity-result.json"
           exit "$status"
 
+      - name: Compose eight independently enforceable results
+        id: standard_results
+        if: always()
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PYTHONPATH: ${{ github.workspace }}/gate/src
+        run: |
+          set +e
+          review_required=$(python -P -m supportability_gate.standard_results_producer \
+            --repository "$GITHUB_REPOSITORY" \
+            --repository-id "$GITHUB_REPOSITORY_ID" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --workflow-sha "$GITHUB_WORKFLOW_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --install-outcome "${{ steps.install.outcome }}" \
+            --complexity-outcome "${{ steps.evaluate.outcome }}" \
+            --characterization-outcome "${{ steps.characterization.outcome }}" \
+            --refactor-outcome "${{ steps.refactor_policy.outcome }}" \
+            --quality-outcome "${{ needs.quality-profile.outputs.capture-outcome }}" \
+            --expected-quality-artifact-id "${{ needs.quality-profile.outputs.artifact-id }}" \
+            --expected-quality-artifact-digest "${{ needs.quality-profile.outputs.artifact-digest }}" \
+            --expected-quality-capture-sha256 "${{ needs.quality-profile.outputs.capture-sha256 }}" \
+            --complexity-result "$RUNNER_TEMP/evidence/complexity-result.json" \
+            --characterization-result "$RUNNER_TEMP/evidence/characterization-result.json" \
+            --refactor-result "$RUNNER_TEMP/evidence/refactor-policy-result.json" \
+            --quality-provenance "$RUNNER_TEMP/evidence/quality-provenance.json" \
+            --output "$RUNNER_TEMP/evidence/standard-results.json")
+          status=$?
+          if [ "$status" -ne 0 ]; then exit "$status"; fi
+          case "$review_required" in
+            true|false) ;;
+            *) echo "INVALID_REVIEW_REQUIRED_OUTPUT"; exit 2 ;;
+          esac
+          echo "review-required=$review_required" >> "$GITHUB_OUTPUT"
+          cat "$RUNNER_TEMP/evidence/standard-results.json"
+
       - name: Upload authoritative supportability evidence
         id: upload_evidence
         if: always()
@@ -472,44 +472,196 @@ jobs:
           path: ${{ runner.temp }}/evidence
           if-no-files-found: error
 
-      - name: Enforce aggregate result
+      - name: Require authoritative result artifact
         if: always()
         env:
-          BASE_RESULT: ${{ needs.characterize-base.result }}
-          HEAD_RESULT: ${{ needs.characterize-head.result }}
-          QUALITY_RESULT: ${{ needs.quality-profile.result }}
-          INSTALL_OUTCOME: ${{ steps.install.outcome }}
-          BASE_DOWNLOAD_OUTCOME: ${{ steps.download_base.outcome }}
-          HEAD_DOWNLOAD_OUTCOME: ${{ steps.download_head.outcome }}
-          QUALITY_DOWNLOAD_OUTCOME: ${{ steps.download_quality.outcome }}
-          METADATA_OUTCOME: ${{ steps.artifact_metadata.outcome }}
-          REFACTOR_OUTCOME: ${{ steps.refactor_policy.outcome }}
-          EVALUATE_OUTCOME: ${{ steps.evaluate.outcome }}
+          ARTIFACT_DIGEST: ${{ steps.upload_evidence.outputs.artifact-digest }}
+          ARTIFACT_ID: ${{ steps.upload_evidence.outputs.artifact-id }}
+          REVIEW_REQUIRED: ${{ steps.standard_results.outputs.review-required }}
+          STANDARD_RESULTS_OUTCOME: ${{ steps.standard_results.outcome }}
           UPLOAD_OUTCOME: ${{ steps.upload_evidence.outcome }}
         run: |
           status=0
-          for result in "$BASE_RESULT" "$HEAD_RESULT" "$QUALITY_RESULT" \
-            "$INSTALL_OUTCOME" "$BASE_DOWNLOAD_OUTCOME" "$HEAD_DOWNLOAD_OUTCOME" \
-            "$QUALITY_DOWNLOAD_OUTCOME" "$METADATA_OUTCOME" "$REFACTOR_OUTCOME" \
-            "$EVALUATE_OUTCOME" "$UPLOAD_OUTCOME"; do
+          for result in "$STANDARD_RESULTS_OUTCOME" "$UPLOAD_OUTCOME"; do
             if [ "$result" != "success" ]; then status=1; fi
           done
+          case "$REVIEW_REQUIRED" in true|false) ;; *) status=1 ;; esac
+          if ! [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]; then status=1; fi
+          if ! [[ "$ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ ]]; then status=1; fi
           exit "$status"
+
+  observe-codex-review:
+    name: Observe Codex Review
+    needs: deterministic-evidence
+    if: needs.deterministic-evidence.outputs.review-required == 'true'
+    permissions:
+      actions: read
+      contents: read
+      issues: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    steps:
+      - name: Check out exact gate source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: mbh-solutions/supportability-gate
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          path: gate
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Observe serial focused connector reviews
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PULL_NUMBER: ${{ github.event.pull_request.number }}
+          PYTHONPATH: ${{ github.workspace }}/gate/src
+        run: |
+          python -P -c 'import os; from supportability_gate.codex_review import FOCUSED_OBSERVER_MARKER, FOCUSES, require_focused_acknowledgements; comment_ids = require_focused_acknowledgements(os.environ["GITHUB_REPOSITORY"], int(os.environ["PULL_NUMBER"]), os.environ["HEAD_SHA"], int(os.environ["GITHUB_RUN_ID"]), os.environ["GITHUB_TOKEN"]); print("\n".join(f"{FOCUSED_OBSERVER_MARKER}{focus}:{comment_id}" for focus, comment_id in zip(FOCUSES, comment_ids, strict=True)))'
+
+  collect-codex-review:
+    name: Collect Codex Review
+    needs: [deterministic-evidence, observe-codex-review]
+    if: >-
+      needs.deterministic-evidence.outputs.review-required == 'true' &&
+      needs.observe-codex-review.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out exact gate source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: mbh-solutions/supportability-gate
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          path: gate
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Collect one-time focused connector completions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PULL_NUMBER: ${{ github.event.pull_request.number }}
+          PYTHONPATH: ${{ github.workspace }}/gate/src
+        run: |
+          python -P -c 'import os; from supportability_gate.codex_review import FOCUSED_COMPLETION_MARKER, require_focused_completion; evidence = require_focused_completion(os.environ["GITHUB_REPOSITORY"], int(os.environ["PULL_NUMBER"]), os.environ["HEAD_SHA"], int(os.environ["GITHUB_RUN_ID"]), os.environ["GITHUB_TOKEN"]); print("\n".join(f"{FOCUSED_COMPLETION_MARKER}{item.focus}:{item.request_id}:{item.completion.kind}:{item.completion.artifact_id}" for item in evidence))'
+
+  standard-results:
+    name: ${{ matrix.context }}
+    needs: deterministic-evidence
+    if: always()
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - standard: 1
+            context: Supportability 1 - Cyclomatic Complexity
+          - standard: 2
+            context: Supportability 2 - Separation of Concerns
+          - standard: 3
+            context: Supportability 3 - Dependency Direction
+          - standard: 4
+            context: Supportability 4 - Domain Modularity
+          - standard: 5
+            context: Supportability 5 - Characterization
+          - standard: 6
+            context: Supportability 6 - Incremental Refactor
+          - standard: 7
+            context: Supportability 7 - Quality Gates
+          - standard: 8
+            context: Supportability 8 - Review Handoff
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out exact gate source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: mbh-solutions/supportability-gate
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          path: gate
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Download exact authoritative evidence artifact
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          artifact-ids: ${{ needs.deterministic-evidence.outputs.artifact-id }}
+          path: ${{ runner.temp }}/evidence
+
+      - name: Enforce one Standard result
+        if: always()
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PYTHONPATH: ${{ github.workspace }}/gate/src
+          STANDARD: ${{ matrix.standard }}
+        run: |
+          if [ "$DOWNLOAD_OUTCOME" != "success" ]; then
+            echo "MISSING_STANDARD_RESULTS_ARTIFACT"
+            exit 2
+          fi
+          python -P -m supportability_gate.standard_results_enforcer \
+            --repository "$GITHUB_REPOSITORY" \
+            --repository-id "$GITHUB_REPOSITORY_ID" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --workflow-sha "$GITHUB_WORKFLOW_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --input "$RUNNER_TEMP/evidence/standard-results.json" \
+            --standard "$STANDARD"
 
   supportability-gate:
     name: Supportability Gate
-    needs: [collect-codex-review, deterministic-evidence]
+    needs:
+      [deterministic-evidence, observe-codex-review, collect-codex-review, standard-results]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Enforce separated connector and deterministic results
+      - name: Enforce deterministic lanes and conditional connector results
         env:
-          CONNECTOR_RESULT: ${{ needs.collect-codex-review.result }}
+          ARTIFACT_DIGEST: ${{ needs.deterministic-evidence.outputs.artifact-digest }}
+          ARTIFACT_ID: ${{ needs.deterministic-evidence.outputs.artifact-id }}
+          COLLECTOR_RESULT: ${{ needs.collect-codex-review.result }}
           DETERMINISTIC_RESULT: ${{ needs.deterministic-evidence.result }}
+          OBSERVER_RESULT: ${{ needs.observe-codex-review.result }}
+          REVIEW_REQUIRED: ${{ needs.deterministic-evidence.outputs.review-required }}
+          STANDARD_RESULTS_RESULT: ${{ needs.standard-results.result }}
         run: |
           status=0
-          for result in "$CONNECTOR_RESULT" "$DETERMINISTIC_RESULT"; do
+          for result in "$DETERMINISTIC_RESULT" "$STANDARD_RESULTS_RESULT"; do
             if [ "$result" != "success" ]; then status=1; fi
           done
+          if ! [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]; then status=1; fi
+          if ! [[ "$ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ ]]; then status=1; fi
+          case "$REVIEW_REQUIRED" in
+            true)
+              if [ "$OBSERVER_RESULT" != "success" ] || [ "$COLLECTOR_RESULT" != "success" ]; then
+                status=1
+              fi
+              ;;
+            false)
+              if [ "$OBSERVER_RESULT" != "skipped" ] || [ "$COLLECTOR_RESULT" != "skipped" ]; then
+                status=1
+              fi
+              ;;
+            *) status=1 ;;
+          esac
           exit "$status"

--- a/.github/workflows/organization-required.yml
+++ b/.github/workflows/organization-required.yml
@@ -387,10 +387,7 @@ jobs:
 
       - name: Evaluate immutable pull-request commits
         id: evaluate
-        if: >-
-          steps.install.outcome == 'success' &&
-          steps.download_quality.outcome == 'success' &&
-          steps.artifact_metadata.outcome == 'success'
+        if: ${{ always() && steps.install.outcome == 'success' }}
         continue-on-error: true
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -444,7 +441,7 @@ jobs:
             --complexity-outcome "${{ steps.evaluate.outcome }}" \
             --characterization-outcome "${{ steps.characterization.outcome }}" \
             --refactor-outcome "${{ steps.refactor_policy.outcome }}" \
-            --quality-outcome "${{ needs.quality-profile.outputs.capture-outcome }}" \
+            --quality-outcome "${{ needs.quality-profile.outputs.capture-outcome != 'success' && needs.quality-profile.outputs.capture-outcome || steps.download_quality.outcome != 'success' && steps.download_quality.outcome || steps.artifact_metadata.outcome }}" \
             --expected-quality-artifact-id "${{ needs.quality-profile.outputs.artifact-id }}" \
             --expected-quality-artifact-digest "${{ needs.quality-profile.outputs.artifact-digest }}" \
             --expected-quality-capture-sha256 "${{ needs.quality-profile.outputs.capture-sha256 }}" \

--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -35,6 +35,16 @@
     },
     {
       "covers": [
+        "src/supportability_gate/standard_block_ownership.py",
+        "src/supportability_gate/standard_results.py",
+        "src/supportability_gate/standard_results_enforcer.py",
+        "src/supportability_gate/standard_results_producer.py"
+      ],
+      "id": "standard-results-boundary",
+      "kind": "regression"
+    },
+    {
+      "covers": [
         "src/supportability_gate/quality_profile.py",
         "src/supportability_gate/reporting.py"
       ],

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -1,54 +1,79 @@
 schema_version = "1.0"
 
 [behavior]
-intended_behavior = "Project #10 S01 separates advisory Codex connector collection from deterministic evidence ownership, requires eight exact-head and exact-run focuses in strict order with unique trusted completions, permits a same-focus retry only after the deterministic 450-second timeout, rejects review after a successful lifecycle, and reuses that completed lifecycle only for an owner-authorized exact reviewed-head/current-head and reviewed-run/current-run remediation scope proved by GitHub compare."
-proof = "tests/test_codex_review.py::{test_eight_serial_focuses_return_distinct_completion_evidence,test_active_focus_cannot_retry_before_timeout,test_timed_out_focus_may_retry_before_success,test_successful_focus_cannot_be_requested_again,test_completed_review_lifecycle_is_reused_after_remediation,test_remediation_authorization_fails_closed,test_second_review_after_remediation_blocks}; tests/test_standard_results.py"
+intended_behavior = "Project #10 S02 makes each deterministic Standard lane own its applicability, evidence, policy blocks, technical errors, and result. A lane-specific poison changes only its owning lane, simultaneous poisons remain independent, and only a named validated dependency failure may affect its exact dependent lane set. One authenticated added documentation line may use NOT_APPLICABLE_SHORT_TASK; uncertain or broader changes use the full process."
+proof = "tests/test_standard_results.py::{test_gate_three_cycle_blocks_only_gate_three,test_quality_provenance_binding_mismatch_is_gate_seven_technical_only,test_simultaneous_gate_three_and_gate_seven_poisons_remain_independent,test_malformed_shared_review_document_names_only_affected_lanes,test_one_added_document_line_is_authenticated_short_task,test_forged_short_results_are_rejected_by_applicability_evidence,test_install_failure_suppresses_all_derived_source_errors}; tests/characterization/standard-results-boundary.characterization.py; tests/characterization/standard-results-boundary.golden.json"
 
 [characterization]
-captured_behavior = "The Codex review boundary remains read-only and exact-head and exact-run bound; focused_review.py contains only the fixed focus contract and completion evidence types; refactor-policy result production is independent of connector completion; workflow tests bind independent connector and deterministic job results."
-proof = "tests/characterization/codex-review-boundary.characterization.py; tests/characterization/focused-review-contract.characterization.py; tests/characterization/focused-review-contract.golden.json; tests/test_codex_review.py; tests/test_refactor_policy.py::test_refactor_result_is_independent_of_connector_completion; tests/test_standard_results.py; exact reviewed head e9547f89f579473dd5b61f8048760da4c3a39731 passed Source Validation run 32805881161 job 97675771503 and required run 32805881163 base/head characterization jobs 97675772054 and 97675771893"
+captured_behavior = "The standard-results boundary freezes clean full-process output, isolated gate-3 and gate-7 poison, simultaneous independent poison, explicit complexity and review shared dependencies, and authenticated one-line documentation short-task output. Focused tests also freeze malformed, missing, duplicate, stale, spoofed, and misbound input rejection plus exact per-lane enforcement exits."
+proof = ".supportability-characterization.json scenario standard-results-boundary; tests/characterization/standard-results-boundary.characterization.py; tests/characterization/standard-results-boundary.golden.json; tests/test_standard_results.py"
 
 [separation_of_concerns]
-before = "codex_review.py owned GitHub transport, the fixed focus contract, connector lifecycle evaluation, and connector evidence types while deterministic refactor evaluation also consumed connector completion state."
-after = "focused_review.py owns only the fixed focus contract and connector evidence types; codex_review.py owns read-only GitHub lifecycle collection and exact remediation reuse binding; refactor_policy.py owns deterministic refactor evaluation without connector input; the workflow binds their separate results."
+before = "The aggregate result path flattened deterministic blocks and technical failures into one workflow result, so one source failure could obscure unaffected lane outcomes and eligible short work had no authenticated per-lane NOT_APPLICABLE result."
+after = "standard_block_ownership.py owns exact block and shared-dependency lane mapping; standard_results.py owns canonical lane composition plus exact identity and schema validation; standard_results_producer.py owns strict artifact loading and canonical output; standard_results_enforcer.py owns strict input reading, delegates validation to standard_results.py, and translates one selected lane result to its exit; organization-required.yml wires the independent matrix and requests advisory review only when deterministic applicability requires it."
 
 [architecture]
-dependency_direction = "contract.py and focused_review.py are leaf boundaries imported by codex_review.py for repository-path validation and focused evidence; refactor_policy.py does not import or consume connector state; organization-required.yml consumes separate connector and deterministic result channels. Import Linter now names focused_review.py because review finding 3849306257 proved that omission left the new dependency outside the enforced sibling layer."
+dependency_direction = "standard_results_producer.py and standard_results_enforcer.py depend only on standard_results.py; standard_results.py depends on the leaf clause_inventory.py and standard_block_ownership.py boundaries. The workflow invokes producer and enforcer as command modules and cannot decide a lane result. Import Linter names all four new production modules and enforces this direction."
 reviewed_paths = [
-    ".supportability-review.toml",
     ".github/workflows/organization-required.yml",
+    ".supportability-characterization.json",
+    ".supportability-review.toml",
+    "docs/product_completion_contract.md",
     "pyproject.toml",
-    "src/supportability_gate/codex_review.py",
-    "src/supportability_gate/focused_review.py",
-    "src/supportability_gate/refactor_policy.py",
+    "src/supportability_gate/standard_block_ownership.py",
+    "src/supportability_gate/standard_results.py",
+    "src/supportability_gate/standard_results_enforcer.py",
+    "src/supportability_gate/standard_results_producer.py",
+    "tests/characterization/standard-results-boundary.characterization.py",
+    "tests/characterization/standard-results-boundary.golden.json",
+    "tests/test_standard_results.py",
 ]
 
 [responsibility_boundary]
-path = "src/supportability_gate/focused_review.py"
-owns = "The fixed eight-focus command contract plus immutable request acknowledgement and completion evidence value types shared by connector collection and workflow binding."
-does_not_own = "GitHub API access, polling, lifecycle decisions, deterministic refactor policy, workflow orchestration, target repository execution, or connector judgment."
+path = "src/supportability_gate/standard_results.py"
+owns = "Canonical standard-results.v2 composition, exact schema and identity validation, authenticated applicability, per-lane policy and technical state, explicit shared-dependency representation, and the deterministic review-required decision."
+does_not_own = "Block-family ownership data, filesystem or command-line input handling, source-artifact generation, workflow orchestration, Codex connector judgment, GitHub mutation, target repository import, or target repository execution."
 
 [incremental_refactor]
-target = "Complete only Project #10 S01 connector lifecycle separation and eight-focus lifecycle enforcement without starting S02 or changing organization ruleset targets."
-completed_step = "One runnable slice extracted the fixed focus contract into focused_review.py, made deterministic refactor results connector-independent, bound separate results in organization-required.yml, added direct characterization, and obtained eight serial trusted focused completions on exact reviewed head e9547f89f579473dd5b61f8048760da4c3a39731 and run 32805881163. Supported findings are implemented, the unsupported boundary move is rejected with evidence, all nine source conversations are resolved, and protected Python and frontend qualification completed without changing production target branches."
+target = "Complete only Project #10 S02 independent lane applicability, evidence, block, technical-error, and result ownership plus explicit genuine shared-dependency behavior; do not begin S03 or change production target code or rulesets."
+completed_step = "One runnable slice adds the four named standard-results responsibilities, converts the required workflow to an independent eight-lane matrix, conditionally requests advisory review, and adds focused plus regression characterization for isolated, simultaneous, shared, malformed, and authenticated short-task cases."
 
 [review_handoff]
-summary = "Issue #144 owner-authorizes S01 and PR #156 is the bounded implementation PR that closes it. Exact reviewed head e9547f89f579473dd5b61f8048760da4c3a39731 passed Source Validation run 32805881161 and required run 32805881163; observer 97675772077, collector 97680836811, and Gate 97680878501 bound eight serial owner requests to eight unique trusted completions. Findings 3849306257, 3849387591, 3849435888, 3849435895, 3849452409, 3849464474, 3849464478, and 3849473345 were supported and fixed; 3849420817 was rejected because FocusedReviewRequest is connector transport state rather than the output-only shared contract. Every source thread has an owner reply and is resolved. Protected Python PR mbh-solutions/supportability-audit#7 merged only to its disposable base as a057efa74c33fd1a600e567c5399fbdad6a3a5d8; protected frontend PR mbh-solutions/dc_training#49 merged only to its disposable base as 800412eea299e2ade2098f526bd4717a772f7b48. Both final heads reused their original eight reviews, passed deterministic and stack-native validation, removed temporary rulesets/refs/worktrees, and left production target mains unchanged. Exact final source hosted proof, normal merge, terminal Project readback, and S02 activation remain transactionally unclaimed."
+summary = "Issue #145 owner-authorizes this bounded S02 slice. Changed responsibilities implement deterministic lane isolation and explicit shared dependencies; focused tests and standard-results-boundary characterization name the required clean, poisoned, simultaneous, shared, and short-task outcomes. This repository evidence does not claim its own immutable final head, hosted runs, eight focused completions, protected target qualification, normal merge, or terminal Project readback; those identities are recorded only after direct proof."
 remaining_risks = [
-    "This commit does not claim its own exact hosted source run, owner remediation/refactor authorizations, workflow reuse, deterministic final-head rerun, or normal merge; those identities require the immutable commit and are recorded in issue #144 after protected completion.",
-    "Normal merge, terminal issue and Project readback, and conditional S02 activation are outside this commit's evidence claim and require post-merge synchronization.",
-    "Frontend findings 3849779647 and 3849820612 remain explicit plan-conflicting assurance limits: the disposable proof did not add pixel-level PNG characterization or directly register the historical end-to-end script.",
+    "Exact final-head source validation, eight serial focused completions, finding disposition, zero unresolved threads, and normal merge remain unclaimed until protected GitHub evidence exists.",
+    "Protected clean and poisoned Python and frontend qualification plus the real eligible short-task run remain unclaimed until their exact runs, jobs, artifacts, lane JSON, ruleset state, and cleanup are read back.",
+    "The authenticated short-task rule is deliberately narrow: exactly one added nonproduction documentation file with one positive changed head line. Uncertain, modified, deleted, renamed, production, immutable, frozen-roadmap, or ledger changes use the full process.",
+    "Only genuinely multi-lane common identity, aggregate, characterization, installation, or structured-review document and section dependencies may be shared; refactor evidence is owned only by Gate 6. Unmapped, generic, copied, malformed, stale, spoofed, duplicate, or misbound evidence fails closed.",
     "Codex judgment remains probabilistic and non-exhaustive even when eight focused completions are required.",
 ]
 
 [human_review]
-naming = "focused_review names the exact shared contract; codex_review remains the GitHub connector and lifecycle owner; refactor_policy remains the deterministic policy owner."
-cohesion = "Each changed production boundary has one named responsibility; the focused-review characterization freezes the extracted contract, and focused tests exercise connector sequencing, exact retry timeout, owner-authorized remediation reuse, deterministic independence, and final result binding."
-intended_behavior = "Owner-authorized issue #144 limits PR #156 to S01 connector separation and eight-focus lifecycle enforcement; S02 and later milestones, organization ruleset targets, target code import, and target execution remain excluded."
-reviewability = "The handoff names exact files, tests, reviewed commit, hosted run and job identities, finding dispositions, and unclaimed delivery evidence so reviewers can distinguish completed one-time review proof from remaining final-head and protected delivery proof."
+naming = "standard_block_ownership names ownership data; standard_results names canonical composition and validation; producer names artifact creation; enforcer names one-lane enforcement."
+cohesion = "Each new module has one self-owned responsibility, one enforced dependency direction, focused direct tests, and one shared standard-results-boundary characterization instead of a generalized framework."
+intended_behavior = "Owner-authorized issue #145 limits this change to S02 lane isolation and explicit shared dependencies. S03-S11, package additions, target-product changes, target code import or execution, weakened thresholds, and production ruleset changes remain excluded."
+reviewability = "Reviewed paths enumerate every planned S02 source, workflow, focused test, characterization, contract, and terminal-ledger change; handoff text distinguishes code evidence from still-unclaimed hosted and protected-target proof."
 
 [[module_boundaries]]
-path = "src/supportability_gate/focused_review.py"
-owner_path = "src/supportability_gate/focused_review.py"
+path = "src/supportability_gate/standard_block_ownership.py"
+owner_path = "src/supportability_gate/standard_block_ownership.py"
 basis = "responsibility"
-justification = "This new location owns the cohesive, dependency-free eight-focus command contract and immutable connector evidence value types; keeping them outside codex_review.py prevents the GitHub transport and lifecycle module from also owning the shared workflow-facing contract."
+justification = "This dependency-free leaf owns the exact mapping from deterministic block families, review fields, and technical source failures to their owning lane sets and named shared dependencies."
+
+[[module_boundaries]]
+path = "src/supportability_gate/standard_results.py"
+owner_path = "src/supportability_gate/standard_results.py"
+basis = "responsibility"
+justification = "This module owns canonical standard-results.v2 composition and validation so workflow wiring, artifact loading, and one-lane process exits cannot independently reinterpret lane outcomes."
+
+[[module_boundaries]]
+path = "src/supportability_gate/standard_results_enforcer.py"
+owner_path = "src/supportability_gate/standard_results_enforcer.py"
+basis = "responsibility"
+justification = "This command module owns strict reading of one canonical standard-results artifact, delegates exact identity and schema validation to standard_results.py, and translates one selected lane result to its process exit."
+
+[[module_boundaries]]
+path = "src/supportability_gate/standard_results_producer.py"
+owner_path = "src/supportability_gate/standard_results_producer.py"
+basis = "responsibility"
+justification = "This command module owns strict deterministic source-artifact loading, source-outcome capture, canonical composition invocation, and one standard-results artifact write."

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -2,10 +2,10 @@ schema_version = "1.0"
 
 [behavior]
 intended_behavior = "Project #10 S02 makes each deterministic Standard lane own its applicability, evidence, policy blocks, technical errors, and result. A lane-specific poison changes only its owning lane, simultaneous poisons remain independent, and only a named validated dependency failure may affect its exact dependent lane set. One authenticated added documentation line may use NOT_APPLICABLE_SHORT_TASK; uncertain or broader changes use the full process."
-proof = "tests/test_standard_results.py::{test_gate_three_cycle_blocks_only_gate_three,test_quality_provenance_binding_mismatch_is_gate_seven_technical_only,test_simultaneous_gate_three_and_gate_seven_poisons_remain_independent,test_malformed_shared_review_document_names_only_affected_lanes,test_one_added_document_line_is_authenticated_short_task,test_forged_short_results_are_rejected_by_applicability_evidence,test_install_failure_suppresses_all_derived_source_errors}; tests/characterization/standard-results-boundary.characterization.py; tests/characterization/standard-results-boundary.golden.json"
+proof = "tests/test_standard_results.py::{test_gate_three_cycle_blocks_only_gate_three,test_quality_provenance_binding_mismatch_is_gate_seven_technical_only,test_simultaneous_gate_three_and_gate_seven_poisons_remain_independent,test_malformed_shared_review_document_names_only_affected_lanes,test_cli_captures_one_added_document_line_without_broadening_other_files,test_unmapped_aggregate_analyzer_error_stays_with_aggregate_owners,test_completed_passing_source_requires_success_outcome,test_blocked_refactor_source_requires_failure_and_remains_a_policy_block,test_failed_quality_capture_without_gate_seven_block_is_malformed,test_short_task_ignores_irrelevant_characterization_and_refactor_outcomes,test_forged_short_results_are_rejected_by_applicability_evidence,test_install_failure_suppresses_all_derived_source_errors}; tests/test_evaluate_complexity.py::test_syntax_error_is_technical_failure; tests/characterization/standard-results-boundary.characterization.py; tests/characterization/standard-results-boundary.golden.json"
 
 [characterization]
-captured_behavior = "The standard-results boundary freezes clean full-process output, isolated gate-3 and gate-7 poison, simultaneous independent poison, explicit complexity and review shared dependencies, and authenticated one-line documentation short-task output. Focused tests also freeze malformed, missing, duplicate, stale, spoofed, and misbound input rejection plus exact per-lane enforcement exits."
+captured_behavior = "The standard-results boundary freezes clean full-process output, isolated gate-3 and gate-7 poison, simultaneous independent poison, explicit complexity and review shared dependencies, authenticated one-line documentation short-task output, authentic source outcomes, and the producer's exact review-required stdout. Focused tests also freeze malformed, missing, duplicate, stale, spoofed, misbound, partial-technical, and outcome-contradictory input handling plus exact per-lane enforcement exits."
 proof = ".supportability-characterization.json scenario standard-results-boundary; tests/characterization/standard-results-boundary.characterization.py; tests/characterization/standard-results-boundary.golden.json; tests/test_standard_results.py"
 
 [separation_of_concerns]
@@ -18,14 +18,17 @@ reviewed_paths = [
     ".github/workflows/organization-required.yml",
     ".supportability-characterization.json",
     ".supportability-review.toml",
+    "AGENTS.md",
     "docs/product_completion_contract.md",
     "pyproject.toml",
+    "src/supportability_gate/cli.py",
     "src/supportability_gate/standard_block_ownership.py",
     "src/supportability_gate/standard_results.py",
     "src/supportability_gate/standard_results_enforcer.py",
     "src/supportability_gate/standard_results_producer.py",
     "tests/characterization/standard-results-boundary.characterization.py",
     "tests/characterization/standard-results-boundary.golden.json",
+    "tests/test_evaluate_complexity.py",
     "tests/test_standard_results.py",
 ]
 
@@ -39,9 +42,9 @@ target = "Complete only Project #10 S02 independent lane applicability, evidence
 completed_step = "One runnable slice adds the four named standard-results responsibilities, converts the required workflow to an independent eight-lane matrix, conditionally requests advisory review, and adds focused plus regression characterization for isolated, simultaneous, shared, malformed, and authenticated short-task cases."
 
 [review_handoff]
-summary = "Issue #145 owner-authorizes this bounded S02 slice. Changed responsibilities implement deterministic lane isolation and explicit shared dependencies; focused tests and standard-results-boundary characterization name the required clean, poisoned, simultaneous, shared, and short-task outcomes. This repository evidence does not claim its own immutable final head, hosted runs, eight focused completions, protected target qualification, normal merge, or terminal Project readback; those identities are recorded only after direct proof."
+summary = "Issue #145 owner-authorizes this bounded S02 slice. Frozen deterministic-green full-process head 51e5a824d64eb91c03a413fefef643ad00b71974 and required run 32824078342 completed one serial eight-focus lifecycle with unique trusted completions. The owner recorded supported findings 3850712993, 3850713003, 3850822052, 3850965961, 3851067418, and the contract inconsistency in 3851109632 for remediation; findings 3850713009, 3850860315, 3850898748, and 3851014643 were rejected with evidence. Successful focuses will not be rerun. This evidence does not claim the final remediation head or authorization, final source or protected-target proof, normal merge, or terminal Project readback."
 remaining_risks = [
-    "Exact final-head source validation, eight serial focused completions, finding disposition, zero unresolved threads, and normal merge remain unclaimed until protected GitHub evidence exists.",
+    "The reviewed lifecycle and finding disposition are recorded, but the exact final remediation head, immutable reviewed-to-final authorization, final-head source validation, supported remediation proof, zero unresolved threads, and normal merge remain unclaimed until protected GitHub evidence exists.",
     "Protected clean and poisoned Python and frontend qualification plus the real eligible short-task run remain unclaimed until their exact runs, jobs, artifacts, lane JSON, ruleset state, and cleanup are read back.",
     "The authenticated short-task rule is deliberately narrow: exactly one added nonproduction documentation file with one positive changed head line. Uncertain, modified, deleted, renamed, production, immutable, frozen-roadmap, or ledger changes use the full process.",
     "Only genuinely multi-lane common identity, aggregate, characterization, installation, or structured-review document and section dependencies may be shared; refactor evidence is owned only by Gate 6. Unmapped, generic, copied, malformed, stale, spoofed, duplicate, or misbound evidence fails closed.",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,21 +100,36 @@ Stop condition:
 
 ## Codex review completion
 
-- For every pull-request head and required-workflow run, post exactly three owner-authenticated
-  comments, one at a time in focus order `2`, `4`, then `8`.
+- Only a frozen full-process pull-request head and required-workflow run with every deterministic
+  lane green and authenticated advisory-review applicability invokes Codex review. Short-task and
+  deterministic-failure runs do not invoke advisory review.
+- For that exact reviewed head and run, post exactly eight owner-authenticated comments, one at a
+  time in focus order `1` through `8`.
 - Each comment must contain the exact focus command below plus
   `Codex-Review-Focus: <focus>`, `Codex-Review-Head: <40-character-head-sha>`, and
   `Codex-Review-Run: <workflow-run-id>` on separate lines:
+  - `1`: `@codex review for maze-like control flow, misleading extraction, or helpers that lower measured complexity without improving readability, testability, or naming in changed code only`
   - `2`: `@codex review for mixed responsibilities or unclear single ownership in changed code only`
+  - `3`: `@codex review for unclear, inverted, cyclic, or unjustified dependency direction across changed boundaries only`
   - `4`: `@codex review for weak domain ownership, low cohesion, avoidable coupling, or unjustified module boundaries only`
+  - `5`: `@codex review for missing, weak, misleading, or nondeterministic characterization of behavior at risk from this change only`
+  - `6`: `@codex review for oversized, non-runnable, big-bang, or insufficiently bounded refactor steps in this change only`
+  - `7`: `@codex review for validation evidence that omits changed or high-risk behavior, weakens scope or thresholds, hides failures, or overstates what ran only`
   - `8`: `@codex review for unsupported, contradictory, stale, incomplete, or misleading handoff claims about change, boundaries, validation, risk, or gate coverage only`
-- Post the next focus only after the connector completes the prior focus. A generic request, an
+- Post the next focus only after the connector completes the prior focus. A failed or timed-out
+  focus may be retried until it receives one successful terminal review. A generic request, an
   out-of-order request, or one completion artifact reused across focuses does not count.
-- A new push requires a new exact-head request. Do not merge while the required Gate is waiting for
-  any trusted focused completion.
+- Bind one unique successful completion artifact to each focus's strict serial time window. Never
+  rerun a successfully completed focus, including after remediation.
 - A clean summary or submitted review counts only after the exact-run observer job logged that
   focus and request comment ID while connector eyes were present; the required Gate must then bind
   one unique completion artifact to that focus's strict serial time window.
+- After all eight complete, assess the findings together, implement supported advice, reject
+  unsupported or plan-conflicting advice with evidence, and resolve every inline conversation.
+- A final remediation head may reuse that exact completed reviewed lifecycle only through one
+  immutable owner remediation authorization that binds the reviewed head and run, final head and
+  run, pull request, repository, and exact reviewed-to-final scope. Rerun deterministic gates on
+  the final head; do not post new advisory-review requests.
 - Resolve every inline finding before merge; GitHub's required review-thread resolution remains the
   enforcement boundary for unresolved findings.
 

--- a/docs/product_completion_contract.md
+++ b/docs/product_completion_contract.md
@@ -1274,8 +1274,8 @@ workflow, check-run, ruleset, or GitHub state supports them.
 Historical deterministic gate deployable to target repositories: YES
 Full Supportability Standard enforcement deployable to target repositories: YES
 Full Supportability Standard runtime: YES
-Current authorized work: Project #10 S01 issue #144 is the sole active slice
-Next milestone authorized: S02 only after exact protected S01 completion and transition readback
+Current authorized work: Project #10 S02 issue #145 is the sole active slice
+Next milestone authorized: S03 only after exact protected S02 completion and transition readback
 ```
 
 ## Milestone transition rules
@@ -1551,3 +1551,220 @@ Do not create a new terminal label not authorized by an active milestone directi
   evidence, and activates S02 alone.
 - Remaining work: pass final-ledger local and hosted source proof, merge PR #156 normally without
   bypass, complete issue/Project readback, refresh and activate S02 only, then stop S01.
+
+## Project #10 S02 applicability and gate failure isolation
+
+- Terminal result recorded by this protected ledger transaction: Status `COMPLETE`; Evidence
+  `Complete`; Scope `On scope`; Stop confirmed `Yes`. It becomes canonical only after PR #157
+  merges normally and every final-head, merge, issue, and Project readback succeeds.
+- Authority: private Project #10 `PVT_kwDOEmzFKc4BhXlK`, item
+  `PVTI_lADOEmzFKc4BhXlKzg33gPw`, repository issue #145, and PR #157. Protected-main base was
+  `460297834393d766b1fa439be9366f73b0e0566b`. The owner authorized automatic S03 activation only
+  after this exact protected completion.
+- Responsibility boundary: each deterministic Standard lane independently owns applicability,
+  evidence, policy blocks, technical errors, and result. Shared failure is permitted only for a
+  named, validated common dependency required by every affected lane. The Gate never imports or
+  executes target repository code; advisory Codex review remains separate from deterministic
+  enforcement.
+- Frozen source review: reviewed head `51e5a824d64eb91c03a413fefef643ad00b71974` passed Source
+  Validation run/job `32824078300`/`97728202697` and required run `32824078342` attempt 4. Base/head
+  characterization `97730946162`/`97730946131`, quality `97730945905`, deterministic evidence
+  `97731083002`, observer `97731193586`, collector `97740977435`, and Gate `97741047312` passed.
+  Gate jobs 1-8 were `97731193708`, `97731193662`, `97731193671`, `97731193660`,
+  `97731193901`, `97731193727`, `97731193703`, and `97731193723`. Exact refactor authorization
+  `5407318897` enabled the successful reviewed-head transaction.
+  Artifacts were `9554531197`, `9554535606`, `9554536052`, and authoritative evidence
+  `9554549186` with digest
+  `14a66c84817265dfe0473d0040fd7a89c9e02b96f2023e1595930378721ec7ff`.
+- Source advisory lifecycle: the observer and collector bound eight exact serial triples:
+  `5407391925 / 403592961 / 5407432507`,
+  `5407441552 / 403595521 / review 5016408070`,
+  `5407484907 / 403597770 / review 5016453971`,
+  `5407529403 / 403600242 / review 5016496980`,
+  `5407572671 / 403602665 / review 5016571444`,
+  `5407644153 / 403606464 / review 5016625086`,
+  `5407692851 / 403609138 / review 5016684783`, and
+  `5407748703 / 403612075 / review 5016732912`. Exactly eight owner requests remain; no terminal
+  head received a new review request. The middle eyes-reaction IDs were captured live; reactions are
+  now removed, while durable observer/collector logs bind the request and completion identities.
+- Source findings: findings `3850712993`, `3850713003`, `3850822052`, `3850965961`,
+  `3851067418`, and `3851109632` were supported and fixed. Findings `3850713009`, `3850860315`,
+  `3850898748`, and `3851014643` were rejected with evidence as unsupported or plan-conflicting.
+  Owner replies were `3851526485`, `3851526749`, `3851527050`, `3851527334`, `3851527634`,
+  `3851527925`, `3851228652`, `3851228673`, `3851228654`, and `3851228666`. All ten threads read
+  resolved and unresolved-thread readback was zero before the terminal source transaction.
+- Reviewed-head remediation: runtime head
+  `50e4d80735fa4f848195ba8a231372111c648386` corrects real documentation-line authentication,
+  partial technical-result ownership, common-evidence validation, source-outcome reconciliation,
+  trusted quality provenance, central ownership mapping, workflow outcome fallback, producer-output
+  characterization, and the eight-focus lifecycle contract. Direct failures and contract alignment
+  proved `cli.py`, `AGENTS.md`, `pyproject.toml`, `.supportability-review.toml`,
+  `.supportability-characterization.json`, the characterization driver/golden pair, and
+  `tests/test_evaluate_complexity.py` necessary outside issue #145's primary file list. The
+  immutable Standard remained unchanged.
+- Qualification runtime binding: contemporaneous authenticated API readbacks in the execution
+  transcript recorded temporary Python, frontend, and short-task rulesets `21406060`, `21406336`,
+  and `21408276` as active, strict, and zero-bypass; no standalone pre-deletion ruleset snapshots
+  were retained. Target artifacts independently bind every accepted run below to exact workflow
+  `50e4d80735fa4f848195ba8a231372111c648386`; merge rule suites prove temporary protection was
+  enforced. Current ruleset readback returns `404`, so historical configuration is not independently
+  reproducible from the API now. The terminal source commit adds only this ledger relative to that
+  qualified runtime, so its local and hosted proof verifies the ledger-only delta without changing
+  target-qualified executable code.
+- Protected Python clean proof: `mbh-solutions/supportability-audit` PR #10 used disposable base
+  `4ae53cdabce3ae1c4bc902d577203fb91ff9bc38` and reviewed/final head
+  `8ca289a7b371320d98abf1bc55603bc0283befe7`. Native Validate run/job
+  `32839876665`/`97776797217` and required run `32839876691` passed. Observer `97777052549`,
+  collector `97783082705`, Gate `97783143510`, and artifacts `9560083894`, `9560071077`,
+  `9560067186`, and `9560066010` proved `FULL_PROCESS`, all eight lanes `PASS`, no blocks/errors,
+  and no shared failure. Base/head characterization jobs were `97776797198`/`97776797505`, quality
+  was `97776797307`, deterministic evidence was `97776946812`, and Gate jobs 1-8 were
+  `97777052801`, `97777052806`, `97777052727`, `97777052730`, `97777052773`, `97777052757`,
+  `97777052765`, and `97777052836`.
+- Python advisory and delivery: PR #10 bound eight serial request/completion pairs
+  `5409406998/5409423844`, `5409426579/review 5018122509`, `5409453403/5409470953`,
+  `5409472824/5409499241`, `5409501245/review 5018193213`, `5409541538/5409563835`,
+  `5409566714/review 5018248526`, and `5409600789/review 5018284029`. Findings `3852317478`,
+  `3852378291`, `3852419065`, and `3852445061` received evidence replies `3852457193`,
+  `3852457441`, `3852457686`, and `3852457873`; all threads resolved. Normal two-parent merge
+  `9598f9251a2518130dc5c1c1e59541f9a38ae25a` changed only the disposable base. Rule suite
+  `3811375326` passed required status, workflow, pull-request, non-fast-forward, and deletion rules.
+- Python isolated and shared proof: PR #12 final head
+  `784e462a9fae51cdab4170fa0011c8d903317e1b` passed native run `32843577380`; required run
+  `32843577484` and artifact `9561446309` made Gate 3 alone block with
+  `IMPORT_CYCLE:src/supportability_audit/validate_repository.py:201:supportability_audit`, while
+  Gates 1, 2, and 4-8 passed and `shared_failures` was empty. Its characterization, quality,
+  deterministic, Gate 1-8, and final Gate jobs were `97788198280`, `97788198735`, `97788198639`,
+  `97788339740`, `97788481328`, `97788481243`, `97788481309`, `97788481280`, `97788481208`,
+  `97788481314`, `97788481233`, `97788481217`, and `97788528249`; artifacts were `9561446309`,
+  `9561430443`, `9561427597`, and `9561426859`. PR #13 head
+  `8e6d8a6951c3fbd2aac03ba1dd286802a9b8a7d2` passed native run `32843837879`; required run
+  `32843837890` and artifact `9561540180` made Gates 1-6 and 8 block only on
+  `MALFORMED_REVIEW_EVIDENCE:document`, Gate 7 pass, and recorded dependency
+  `structured-review-document` with exact affected lanes `[1,2,3,4,5,6,8]`. Its characterization,
+  quality, deterministic, Gate 1-8, and final Gate jobs were `97788997395`, `97788997668`,
+  `97788997717`, `97789116796`, `97789255555`, `97789255716`, `97789255790`, `97789255694`,
+  `97789255505`, `97789255803`, `97789255584`, `97789255476`, and `97789313115`; artifacts were
+  `9561540180`, `9561523486`, `9561522670`, and `9561521893`. Both required Gates failed; owner merge
+  commands returned `base branch policy prohibits the merge`, and both PRs are now closed unmerged
+  with zero unresolved threads.
+- Python simultaneous-independent proof: PR #14 used production snapshot base
+  `4ae53cdabce3ae1c4bc902d577203fb91ff9bc38` and head
+  `9bb94dd9a0ddd5aeec6d4ba4a4671592e80afb59`. Pre-deletion ruleset `21422812` read back active with
+  `bypass=[]`, exact repository/base-ref targeting, strict `Supportability Gate` and `Validate`
+  checks, review-thread resolution, and workflow pin
+  `50e4d80735fa4f848195ba8a231372111c648386`. Authorization `5410185141` bound the two-path scope
+  and exact step-3 predecessor. Required run `32846241157` attempt 2 and artifact `9562542772`
+  made Gate 3 block only on
+  `IMPORT_CYCLE:src/supportability_audit/validate_repository.py:201:supportability_audit`, Gate 7
+  block only on `QUALITY_GATE_FAILED:python.pytest.v1`, and Gates 1, 2, 4, 5, 6, and 8 pass with
+  `technical_errors=[]` and `shared_failures=[]`.
+- Simultaneous run identities: head/base characterization, quality, and deterministic jobs were
+  `97797364377`, `97797364820`, `97797364723`, and `97797520666`; Gate jobs 1-8 were
+  `97797679188`, `97797679232`, `97797679195`, `97797679096`, `97797679118`, `97797679150`,
+  `97797679125`, and `97797679142`; observer/collector `97797680659`/`97797680555` skipped and
+  Gate `97797735857` failed. Artifacts were `9562542772`, `9562522648`, `9562522751`, and
+  `9562520869`. Native Validate run/job `32846241132`/`97796477042` failed only from the deliberate
+  pytest poison. Attempt-1 artifact `9562436980` is now unavailable (`404`); durable Gate 6 job
+  `97796811074` logged diagnostic `INVALID_STRANGLER_SEQUENCE` from stale sequence step 1. Finding
+  `3852826765` received reply `3852846298` and its thread resolved. The
+  protected merge command returned `base branch policy prohibits the merge`; PR #14 closed
+  unmerged. Ruleset `21422812` now returns `404`, its base/head refs and worktree are absent,
+  production main/ruleset are unchanged, and target open-PR readback is zero.
+- Python diagnostic boundary: PR #11 artifact `9561024668` is retained only as falsification proof,
+  not isolation evidence. It explicitly recorded common dependency `complexity-result` and
+  `MALFORMED_COMPLEXITY_RESULT` for all eight lanes. Superseded PR #8 and PR #12 intermediate runs
+  remain non-qualification diagnostics. Current readback shows temporary ruleset `21406060` absent,
+  all GUID-specific Python qualification refs/branches and worktrees absent, only the clean production
+  worktree remaining, and temporary evidence downloads removed. Production main remained
+  `4ae53cdabce3ae1c4bc902d577203fb91ff9bc38`; production ruleset `20917183` remained active,
+  strict, zero-bypass, and pinned to workflow
+  `519bdee34a78f50b54bedf8a597f255b727ac173`.
+- Protected frontend clean proof: `mbh-solutions/dc_training` PR #51 used disposable base
+  `4ec4b5fb060632ea4c44feb8349743982d34f14e`, reviewed head
+  `aba31b8774190ad907e79aeabd95c211389e97ab`, reviewed run `32836708782`, and final head
+  `75881fd02ea22c1d8bc081b95da5c39f0195ed86` with a one-file reviewed-to-final compare. The
+  reviewed run passed observer `97767436832`, collector `97777395407`, Gate `97777478890`, and
+  artifacts `9558919561`, `9558903112`, `9558900644`, and `9558895537`. Final required run
+  `32840209583` passed quality
+  `97777815155`, deterministic evidence `97779328006`, observer `97779468951`, collector
+  `97779540303`, and Gate `97779595338`. Artifacts `9560363356`, `9560346250`, `9560191917`, and
+  `9560190552` proved all eight lanes `PASS` and target-native install, lint, format, complexity,
+  typecheck, test/coverage, build, and dependency checks exited zero. Head/base characterization
+  jobs were `97777815291`/`97777815486`; Gate jobs 1-8 were `97779469247`, `97779469258`,
+  `97779469429`, `97779469414`, `97779469277`, `97779469435`, `97779469282`, and `97779469286`.
+- Frontend advisory and delivery: PR #51 bound exact triples
+  `5409038630/403670205/5409055541`, `5409071438/403671909/5409096403`,
+  `5409106797/403673590/5409130004`, `5409146817/403675508/5409170385`,
+  `5409191628/403677758/review 5017951631`, `5409249903/403680713/5409276198`,
+  `5409297505/403683147/review 5018048684`, and
+  `5409381666/403687504/review 5018089725`. Finding `3852166830` was technically valid but
+  plan-conflicting; findings `3852252053` and `3852288625` were fixed by the one-file descendant.
+  The middle eyes-reaction IDs were captured live; reactions are now removed, while durable
+  observer/collector logs bind requests and completions. All three threads resolved. Authorization
+  `5409428524` bound the exact remediation. Normal merge
+  `0ae357efe448cfb346fbc4cc008728b6c20ba3a3` changed only the disposable base; rule suite
+  `3811208721` passed every temporary protection rule. Final refactor authorization `5409430948`
+  bound the exact base-to-final scope.
+- Frontend isolated proof: PR #53 used base `4ec4b5fb060632ea4c44feb8349743982d34f14e`, head
+  `78f29dd8722429b397c5f9aa786fc446c7d6d9d3`, authorization `5409098447`, required run
+  `32837432267`, and artifact `9559191233` to make Gate 3 alone block on
+  `IMPORT_CYCLE:src/WorkoutTracer.tsx:7:./workout-domain.js` and
+  `IMPORT_CYCLE:src/workout-domain.ts:3:./WorkoutTracer.js`, while Gates 1, 2, and 4-8 passed with
+  no shared failure. Quality, base/head characterization, deterministic, Gate 1-8, and final Gate
+  jobs were `97769329140`, `97769329377`, `97769329452`, `97769558447`, `97769670291`,
+  `97769670290`, `97769670347`, `97769670328`, `97769670294`, `97769670276`, `97769670292`,
+  `97769670271`, and `97769717562`; artifacts were `9559191233`, `9559177196`, `9559175684`, and
+  `9559169779`. Rule suite `3810798774` rejected normal merge; the PR closed unmerged. Current
+  readback shows ruleset `21406336`, every GUID-specific frontend qualification ref/branch and
+  worktree, and temporary evidence downloads absent. Production main remained
+  `999bfce6153745205a95432e9555fcc69fed6e04`; production ruleset `20588739` remained active,
+  strict, zero-bypass, review-thread protected, and pinned to workflow
+  `519bdee34a78f50b54bedf8a597f255b727ac173`.
+- Protected short-task proof: `mbh-solutions/dc_training` PR #52 used base
+  `999bfce6153745205a95432e9555fcc69fed6e04` and head
+  `9faa1ff1c70c3c6bc1a269e6f3c8285a709b0131` containing exactly one added line in eligible path
+  `docs/s02-short-qualification-6bb8d2e2.md`. Required run `32836657437` attempt 1, evidence artifact
+  `9558903429`, quality artifact `9558884378`, and Gate `97767357916` authenticated `SHORT_TASK`:
+  Gates 1-6 and 8 emitted
+  `NOT_APPLICABLE_SHORT_TASK`, Gate 7 passed, and no review was requested. Normal merge
+  `7f914a2ea43e109efe9a6c150d26ac692062e074` changed only the disposable base; rule suite
+  `3810687064` passed. Head/base characterization, quality, deterministic, Gate 1-8, observer, and
+  collector jobs were `97766914345`, `97766914676`, `97766914659`, `97767138134`, `97767302772`,
+  `97767302781`, `97767302748`, `97767302788`, `97767302840`, `97767302825`, `97767302721`,
+  `97767302755`, `97767303820`, and `97767303952`; artifacts were `9558903429`, `9558884378`,
+  `9558882550`, and `9558880609`. The approved target stack had no Markdown-specific adapter, so the
+  bounded proof is exact classifier authentication of the added path and line `[1]` plus all nine
+  existing TypeScript quality adapters exiting zero; it does not claim Markdown-content linting.
+  Current readback shows temporary ruleset `21408276` returns `404`; remote refs
+  `refs/heads/codex/s02-short-base-6bb8d2e2` and
+  `refs/heads/codex/s02-short-head-6bb8d2e2`, local branch
+  `codex/s02-short-head-6bb8d2e2`, and both remote-tracking refs are absent. No local base branch was
+  created. Worktree `C:\repos\dc_training-s02-short-6bb8d2e2` and evidence roots
+  `C:\Users\mheck\AppData\Local\Temp\s02-short-final-6bb8d2e2` and
+  `C:\Users\mheck\AppData\Local\Temp\s02-short-diagnostic-6bb8d2e2` are absent; production main
+  and ruleset remained unchanged.
+- Final source proof: the terminal final-ledger head must pass Python 3.12 exact-lock Ruff
+  lint/format/C901, strict mypy, Import Linter, full pytest, compileall, wheel build, fresh exact-lock
+  installation, installed CLI help, focused S02 tests, immutable-Standard tamper proof, and exact
+  source diff check. Generated output and caches must be absent; Standard SHA-256 must remain
+  `81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2`.
+- Final reviewed-to-terminal transaction: one immutable owner remediation authorization must bind
+  reviewed head/run, terminal head/run, PR #157, repository, and the exact GitHub-compare scope.
+  Final Source Validation and required Gate must rerun deterministic evidence only, reuse exactly
+  the eight reviewed completions, post zero new review requests, pass with zero unresolved threads,
+  and merge normally without bypass. Exact terminal head, run, job, artifact, authorization, merge,
+  and rule-suite identities belong in issue #145 after they exist.
+- Enforcement readback: source ruleset `19767613` remains active, strict, zero-bypass,
+  review-thread protected, and requires Source Validation plus Gate App `15368`. Production target
+  rulesets `20588739` and `20917183` remain unchanged. Temporary qualification rulesets are absent,
+  target production mains are unchanged, and target open-PR readback is zero.
+- Assurance limit: connector judgment remains advisory, probabilistic, and non-exhaustive.
+  Deterministic enforcement, native target validation, exact artifact binding, and native
+  unresolved-thread protection remain separate. Qualification proves S02 lane isolation and
+  explicit shared dependency only; it does not complete S03-S11.
+- Closure transaction: this protected ledger merge makes S02 canonical. Immediate issue/Project
+  synchronization then records final source identities, sets S02 `Done / Complete / On scope / Yes`,
+  refreshes issue #146 with exact predecessor and remaining-limit evidence, and activates S03 alone.
+- Remaining work: pass final-ledger local and hosted source proof, merge PR #157 normally without
+  bypass, complete issue/Project readback, refresh and activate S03 only, then stop S02.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ root_package = "supportability_gate"
 name = "Supportability gate dependency direction"
 type = "layers"
 layers = [
+    "supportability_gate.standard_results_producer | supportability_gate.standard_results_enforcer",
+    "supportability_gate.standard_results",
     "supportability_gate.__main__",
     "supportability_gate.cli",
     "supportability_gate.reporting",
@@ -73,5 +75,5 @@ layers = [
     "supportability_gate.codex_review",
     "supportability_gate.function_changes",
     "supportability_gate.characterization",
-    "supportability_gate.clause_inventory | supportability_gate.contract | supportability_gate.focused_review | supportability_gate.git_changes | supportability_gate.review_evidence",
+    "supportability_gate.clause_inventory | supportability_gate.contract | supportability_gate.focused_review | supportability_gate.git_changes | supportability_gate.review_evidence | supportability_gate.standard_block_ownership",
 ]

--- a/src/supportability_gate/cli.py
+++ b/src/supportability_gate/cli.py
@@ -78,6 +78,15 @@ def _classify_changes(
             (base_production and _is_profile_source(change.old_path, policy.language))
             or (head_production and _is_profile_source(change.new_path, policy.language))
         )
+        short_document = bool(
+            change.status == "ADDED"
+            and change.old_path is None
+            and change.new_path
+            and (
+                change.new_path == "README.md"
+                or (change.new_path.startswith("docs/") and change.new_path.endswith(".md"))
+            )
+        )
         lines = (
             git_changes.changed_head_lines(
                 repository,
@@ -86,7 +95,7 @@ def _classify_changes(
                 change.new_path,
                 records,
             )
-            if profile_source and change.new_path
+            if (profile_source or short_document) and change.new_path
             else ()
         )
         assessments.append(
@@ -198,13 +207,165 @@ def _architecture_sources(
     }
 
 
+def _complexity_evidence(
+    repository: Path,
+    identity: git_changes.RepositoryIdentity,
+    policy: contract.Contract,
+    assessments: tuple[function_changes.ChangedFileAssessment, ...],
+    records: list[git_changes.CommandRecord],
+    ruff_records: list[complexity_metrics.RuffCommandRecord],
+    errors: list[Exception],
+) -> tuple[
+    tuple[complexity_policy.FunctionDecision, ...],
+    tuple[complexity_metrics.RuffDiagnostic, ...],
+]:
+    try:
+        analyzed = _analyze_changes(repository, identity, policy, assessments, records)
+        base_definitions = _all_definitions(analyzed.analyses, "base")
+        head_definitions = _all_definitions(analyzed.analyses, "head")
+        base_metrics = complexity_metrics.measure_definitions(base_definitions, policy.language)
+        head_metrics = complexity_metrics.measure_definitions(head_definitions, policy.language)
+        ruff = (
+            complexity_metrics.run_ruff(analyzed.head_sources, head_definitions)
+            if policy.language == "python"
+            else complexity_metrics.RuffResult((), None)
+        )
+        if ruff.command:
+            ruff_records.append(ruff.command)
+        if policy.language == "python":
+            complexity_metrics.verify_ruff_parity(head_metrics, ruff.diagnostics)
+        decisions = complexity_policy.decide_functions(
+            policy,
+            _all_deltas(analyzed.analyses),
+            base_metrics,
+            head_metrics,
+        )
+        complexity_policy.validate_reporting(decisions, policy.maximum)
+        return decisions, ruff.diagnostics
+    except (function_changes.PythonSourceError, git_changes.GitError) as error:
+        code = (
+            "COMPLEXITY_SOURCE_UNAVAILABLE"
+            if isinstance(error, git_changes.GitError)
+            else f"COMPLEXITY_{error.code}"
+        )
+        errors.append(function_changes.PythonSourceError(code, str(error)))
+    except (complexity_metrics.MetricsError, complexity_policy.ComplexityPolicyError) as error:
+        errors.append(error)
+    return (), ()
+
+
+def _architecture_evidence(
+    repository: Path,
+    identity: git_changes.RepositoryIdentity,
+    policy: contract.Contract,
+    records: list[git_changes.CommandRecord],
+    errors: list[Exception],
+) -> architecture_policy.ArchitectureResult | None:
+    try:
+        sources = _architecture_sources(repository, identity.head_sha, policy, records)
+        gate = next(
+            (
+                item
+                for item in policy.gates
+                if item.adapter == architecture_policy.ARCHITECTURE_ADAPTERS[policy.language]
+            ),
+            None,
+        )
+        return architecture_policy.evaluate_architecture(policy, sources, gate)
+    except (function_changes.PythonSourceError, git_changes.GitError) as error:
+        code = (
+            error.code if error.code.startswith("ARCHITECTURE_") else f"ARCHITECTURE_{error.code}"
+        )
+        errors.append(function_changes.PythonSourceError(code, str(error)))
+        return None
+
+
+def _quality_evidence(
+    arguments: argparse.Namespace,
+    repository: Path,
+    identity: git_changes.RepositoryIdentity,
+    policy: contract.Contract,
+    assessments: tuple[function_changes.ChangedFileAssessment, ...],
+    records: list[git_changes.CommandRecord],
+    errors: list[Exception],
+) -> tuple[quality_profile.QualityEvidence | None, tuple[str, ...]]:
+    try:
+        sources = quality_profile.production_files(repository, identity.head_sha, policy, records)
+        path = Path(arguments.quality_evidence)
+        if not path.is_absolute():
+            raise quality_profile.QualityProfileError(
+                "RELATIVE_QUALITY_EVIDENCE", "quality evidence path must be absolute"
+            )
+        evidence = quality_profile.verify_evidence_binding(
+            path,
+            metadata_path=Path(arguments.quality_artifact_metadata),
+            repository=str(arguments.quality_repository),
+            repository_id=str(arguments.quality_repository_id),
+            run_id=str(arguments.quality_run_id),
+            run_attempt=str(arguments.quality_run_attempt),
+            job=str(arguments.quality_job),
+            artifact_id=str(arguments.quality_artifact_id),
+            artifact_digest=str(arguments.quality_artifact_digest),
+            capture_sha256=str(arguments.quality_capture_sha256),
+        )
+        blocks = quality_profile.evidence_blocks(
+            evidence,
+            policy,
+            identity,
+            assessments,
+            sources,
+            str(arguments.workflow_sha),
+        )
+        return evidence, blocks
+    except quality_profile.QualityProfileError as error:
+        errors.append(error)
+    except git_changes.GitError as error:
+        errors.append(quality_profile.QualityProfileError(f"QUALITY_{error.code}", str(error)))
+    return None, ()
+
+
+def _modularity_evidence(
+    policy: contract.Contract,
+    assessments: tuple[function_changes.ChangedFileAssessment, ...],
+    structured_review: review_evidence.ReviewEvidence | None,
+    architecture: architecture_policy.ArchitectureResult | None,
+    quality: quality_profile.QualityEvidence | None,
+) -> modularity_policy.ModularityResult | None:
+    if architecture is None or quality is None:
+        return None
+    return modularity_policy.evaluate_modularity(
+        policy, assessments, structured_review, architecture, quality
+    )
+
+
+def _contract_blocks(
+    contract_path: str,
+    policy: contract.Contract,
+    candidate_policy: contract.Contract | None,
+    assessments: tuple[function_changes.ChangedFileAssessment, ...],
+) -> tuple[str, ...]:
+    candidate = (
+        (
+            "CANDIDATE_CONTRACT_CHANGE",
+            *gate_policy.contract_change_blocks(policy, candidate_policy),
+        )
+        if any(
+            contract_path in {item.change.old_path, item.change.new_path} for item in assessments
+        )
+        else ()
+    )
+    return (*candidate, *gate_policy.evaluate_contract(policy, assessments))
+
+
 def _result(
     identity: git_changes.RepositoryIdentity,
     contract_path: str,
     blob: git_changes.GitBlob,
     policy: contract.Contract,
-    candidate_policy: contract.Contract | None,
-    analyzed: _AnalyzedChanges,
+    contract_blocks: tuple[str, ...],
+    assessments: tuple[function_changes.ChangedFileAssessment, ...],
+    decisions: tuple[complexity_policy.FunctionDecision, ...],
+    ruff_diagnostics: tuple[complexity_metrics.RuffDiagnostic, ...],
     records: list[git_changes.CommandRecord],
     ruff_records: list[complexity_metrics.RuffCommandRecord],
     structured_review: review_evidence.ReviewEvidence | None,
@@ -214,45 +375,13 @@ def _result(
     quality: quality_profile.QualityEvidence,
     quality_blocks: tuple[str, ...],
 ) -> reporting.EvaluationResult:
-    candidate_blocks = (
-        (
-            "CANDIDATE_CONTRACT_CHANGE",
-            *gate_policy.contract_change_blocks(policy, candidate_policy),
-        )
-        if any(
-            contract_path in {item.change.old_path, item.change.new_path}
-            for item in analyzed.assessments
-        )
-        else ()
-    )
     policy_blocks = (
-        *candidate_blocks,
-        *gate_policy.evaluate_contract(policy, analyzed.assessments),
+        *contract_blocks,
         *architecture.blocks,
         *modularity.blocks,
         *review_blocks,
         *quality_blocks,
     )
-    base_definitions = _all_definitions(analyzed.analyses, "base")
-    head_definitions = _all_definitions(analyzed.analyses, "head")
-    base_metrics = complexity_metrics.measure_definitions(base_definitions, policy.language)
-    head_metrics = complexity_metrics.measure_definitions(head_definitions, policy.language)
-    ruff = (
-        complexity_metrics.run_ruff(analyzed.head_sources, head_definitions)
-        if policy.language == "python"
-        else complexity_metrics.RuffResult((), None)
-    )
-    if ruff.command:
-        ruff_records.append(ruff.command)
-    if policy.language == "python":
-        complexity_metrics.verify_ruff_parity(head_metrics, ruff.diagnostics)
-    decisions = complexity_policy.decide_functions(
-        policy,
-        _all_deltas(analyzed.analyses),
-        base_metrics,
-        head_metrics,
-    )
-    complexity_policy.validate_reporting(decisions, policy.maximum)
     overall = (
         "BLOCK" if policy_blocks or any(item.decision == "BLOCK" for item in decisions) else "PASS"
     )
@@ -264,9 +393,9 @@ def _result(
         policy.production_paths,
         policy.high_risk_paths,
         _gate_coverage(policy),
-        analyzed.assessments,
+        assessments,
         decisions,
-        ruff.diagnostics,
+        ruff_diagnostics,
         (),
         policy_blocks,
         overall,
@@ -285,6 +414,7 @@ def _read_review_evidence(
     repository: Path,
     head_sha: str,
     records: list[git_changes.CommandRecord],
+    errors: list[Exception],
 ) -> tuple[review_evidence.ReviewEvidence | None, tuple[str, ...]]:
     try:
         blob = git_changes.read_regular_blob(
@@ -298,7 +428,8 @@ def _read_review_evidence(
             return review_evidence.evaluate_review_evidence(None)
         if error.code == "SYMLINK_OR_NONFILE":
             return None, ("MALFORMED_REVIEW_EVIDENCE:document",)
-        raise
+        errors.append(function_changes.PythonSourceError("REVIEW_EVIDENCE_UNAVAILABLE", str(error)))
+        return None, ()
     return review_evidence.evaluate_review_evidence(blob.content)
 
 
@@ -310,10 +441,29 @@ def _technical_result(
     blob: git_changes.GitBlob | None,
     policy: contract.Contract | None,
     assessments: tuple[function_changes.ChangedFileAssessment, ...],
-    error: Exception,
+    decisions: tuple[complexity_policy.FunctionDecision, ...],
+    ruff_diagnostics: tuple[complexity_metrics.RuffDiagnostic, ...],
+    contract_blocks: tuple[str, ...],
+    structured_review: review_evidence.ReviewEvidence | None,
+    review_blocks: tuple[str, ...],
+    architecture: architecture_policy.ArchitectureResult | None,
+    modularity: modularity_policy.ModularityResult | None,
+    quality: quality_profile.QualityEvidence | None,
+    quality_blocks: tuple[str, ...],
+    errors: tuple[Exception, ...],
 ) -> reporting.EvaluationResult:
-    code = getattr(error, "code", "UNEXPECTED_ERROR")
-    message = str(error) if code != "UNEXPECTED_ERROR" else type(error).__name__
+    technical_errors: list[reporting.TechnicalError] = []
+    for error in errors:
+        code = getattr(error, "code", "UNEXPECTED_ERROR")
+        message = str(error) if code != "UNEXPECTED_ERROR" else type(error).__name__
+        technical_errors.append(reporting.TechnicalError(str(code), message))
+    policy_blocks = (
+        *contract_blocks,
+        *(architecture.blocks if architecture else ()),
+        *(modularity.blocks if modularity else ()),
+        *review_blocks,
+        *quality_blocks,
+    )
     return reporting.EvaluationResult(
         identity,
         contract_path,
@@ -323,17 +473,19 @@ def _technical_result(
         policy.high_risk_paths if policy else (),
         _gate_coverage(policy) if policy else (),
         assessments,
-        (),
-        (),
-        (reporting.TechnicalError(str(code), message),),
-        (),
+        decisions,
+        ruff_diagnostics,
+        tuple(technical_errors),
+        policy_blocks,
         "TECHNICAL_FAILURE",
         _versions(identity),
         tuple(records),
         tuple(ruff_records),
-        None,
+        structured_review,
         policy.language if policy else None,
-        None,
+        architecture,
+        modularity,
+        quality,
     )
 
 
@@ -344,9 +496,16 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
     blob: git_changes.GitBlob | None = None
     policy: contract.Contract | None = None
     assessments: tuple[function_changes.ChangedFileAssessment, ...] = ()
-    candidate_policy: contract.Contract | None = None
+    decisions: tuple[complexity_policy.FunctionDecision, ...] = ()
+    ruff_diagnostics: tuple[complexity_metrics.RuffDiagnostic, ...] = ()
+    contract_blocks: tuple[str, ...] = ()
     structured_review: review_evidence.ReviewEvidence | None = None
     review_blocks: tuple[str, ...] = ()
+    architecture: architecture_policy.ArchitectureResult | None = None
+    modularity: modularity_policy.ModularityResult | None = None
+    quality: quality_profile.QualityEvidence | None = None
+    quality_blocks: tuple[str, ...] = ()
+    evidence_errors: list[Exception] = []
     contract_path = str(arguments.contract_path)
     try:
         contract_path = contract.validate_contract_path(contract_path)
@@ -371,40 +530,13 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
             records,
         )
         assessments = _classify_changes(repository, identity, policy, changes, records)
-        architecture_sources = _architecture_sources(repository, identity.head_sha, policy, records)
-        quality_sources = quality_profile.production_files(
-            repository, identity.head_sha, policy, records
-        )
-        quality_path = Path(arguments.quality_evidence)
-        if not quality_path.is_absolute():
-            raise quality_profile.QualityProfileError(
-                "RELATIVE_QUALITY_EVIDENCE", "quality evidence path must be absolute"
-            )
-        quality = quality_profile.verify_evidence_binding(
-            quality_path,
-            metadata_path=Path(arguments.quality_artifact_metadata),
-            repository=str(arguments.quality_repository),
-            repository_id=str(arguments.quality_repository_id),
-            run_id=str(arguments.quality_run_id),
-            run_attempt=str(arguments.quality_run_attempt),
-            job=str(arguments.quality_job),
-            artifact_id=str(arguments.quality_artifact_id),
-            artifact_digest=str(arguments.quality_artifact_digest),
-            capture_sha256=str(arguments.quality_capture_sha256),
-        )
-        quality_blocks = quality_profile.evidence_blocks(
-            quality,
-            policy,
-            identity,
-            assessments,
-            quality_sources,
-            str(arguments.workflow_sha),
-        )
         structured_review, review_blocks = _read_review_evidence(
             repository,
             identity.head_sha,
             records,
+            evidence_errors,
         )
+        candidate_policy: contract.Contract | None = None
         contract_changed = any(
             contract_path in {item.change.old_path, item.change.new_path} for item in assessments
         )
@@ -419,34 +551,61 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
                 candidate_policy = contract.parse_contract(candidate_blob.content)
             except (contract.ContractError, git_changes.GitError):
                 candidate_policy = None
-        analyzed = _analyze_changes(repository, identity, policy, assessments, records)
-        architecture_gate = next(
-            (
-                gate
-                for gate in policy.gates
-                if gate.adapter == architecture_policy.ARCHITECTURE_ADAPTERS[policy.language]
-            ),
-            None,
-        )
-        architecture = architecture_policy.evaluate_architecture(
-            policy,
-            architecture_sources,
-            architecture_gate,
-        )
-        modularity = modularity_policy.evaluate_modularity(
+        contract_blocks = _contract_blocks(contract_path, policy, candidate_policy, assessments)
+        decisions, ruff_diagnostics = _complexity_evidence(
+            repository,
+            identity,
             policy,
             assessments,
-            structured_review,
-            architecture,
-            quality,
+            records,
+            ruff_records,
+            evidence_errors,
         )
+        architecture = _architecture_evidence(
+            repository, identity, policy, records, evidence_errors
+        )
+        quality, quality_blocks = _quality_evidence(
+            arguments,
+            repository,
+            identity,
+            policy,
+            assessments,
+            records,
+            evidence_errors,
+        )
+        modularity = _modularity_evidence(
+            policy, assessments, structured_review, architecture, quality
+        )
+        if evidence_errors:
+            return _technical_result(
+                identity,
+                contract_path,
+                records,
+                ruff_records,
+                blob,
+                policy,
+                assessments,
+                decisions,
+                ruff_diagnostics,
+                contract_blocks,
+                structured_review,
+                review_blocks,
+                architecture,
+                modularity,
+                quality,
+                quality_blocks,
+                tuple(evidence_errors),
+            )
+        assert architecture is not None and modularity is not None and quality is not None
         return _result(
             identity,
             contract_path,
             blob,
             policy,
-            candidate_policy,
-            analyzed,
+            contract_blocks,
+            assessments,
+            decisions,
+            ruff_diagnostics,
             records,
             ruff_records,
             structured_review,
@@ -457,6 +616,7 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
             quality_blocks,
         )
     except Exception as error:  # fail closed at the CLI trust boundary
+        evidence_errors.append(error)
         return _technical_result(
             identity,
             contract_path,
@@ -465,7 +625,16 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
             blob,
             policy,
             assessments,
-            error,
+            decisions,
+            ruff_diagnostics,
+            contract_blocks,
+            structured_review,
+            review_blocks,
+            architecture,
+            modularity,
+            quality,
+            quality_blocks,
+            tuple(evidence_errors),
         )
 
 

--- a/src/supportability_gate/standard_block_ownership.py
+++ b/src/supportability_gate/standard_block_ownership.py
@@ -1,0 +1,344 @@
+"""Map every emitted policy-block family to its deterministic Standard owner."""
+
+from __future__ import annotations
+
+import re
+
+BLOCK_FAMILIES = (
+    ("FUNCTION_COMPLEXITY:",),
+    (),
+    (
+        "ARCHITECTURE_GATE_NOT_EXECUTED",
+        "ARCHITECTURE_PRODUCTION_COVERAGE:",
+        "DEPENDENCY_INVERSION:",
+        "FORBIDDEN_DOMAIN_DEPENDENCY:",
+        "IMPORT_CYCLE:",
+    ),
+    (
+        "INVALID_NEW_LOCATION_JUSTIFICATION:",
+        "MISSING_NEW_LOCATION_JUSTIFICATION:",
+        "NEW_LOCATION_GATE_COVERAGE:",
+        "NEW_MODULE_OWNER_NOT_PREEXISTING:",
+        "PARALLEL_PACKAGE:",
+        "UNRESOLVED_MODULE_OWNER:",
+        "VAGUE_PRODUCTION_LOCATION:",
+    ),
+    (
+        "BASE_CAPTURE_DIGEST_MISMATCH",
+        "CHANGED_CHARACTERIZATION_DEFINITION:",
+        "CHANGED_GOLDEN_OUTPUT:",
+        "CHARACTERIZATION_DEFINITION_MISMATCH:",
+        "CHARACTERIZATION_DRIVER_IDENTITY_MISMATCH:",
+        "CHARACTERIZATION_EXECUTION_FAILED:",
+        "CHARACTERIZATION_FINGERPRINT_MISMATCH",
+        "CHARACTERIZATION_REPLAY_DRIFT:",
+        "GOLDEN_ARTIFACT_IDENTITY_MISMATCH:",
+        "GOLDEN_BEHAVIOR_MISMATCH:",
+        "HEAD_CAPTURE_DIGEST_MISMATCH",
+        "HEAD_ONLY_CHARACTERIZATION_CLAIM",
+        "INCOMPATIBLE_POST_CHANGE_BEHAVIOR:",
+        "INCOMPLETE_CHARACTERIZATION_EVIDENCE",
+        "INVALID_ARTIFACT_IDENTITY",
+        "MISSING_BASELINE",
+        "MISSING_CHARACTERIZATION_COVERAGE:",
+        "REMOVED_CHARACTERIZATION_SCENARIO:",
+        "STALE_BASELINE_ARTIFACT",
+        "STALE_POST_CHANGE_ARTIFACT",
+        "UNAUTHENTICATED_CHARACTERIZATION_EVIDENCE",
+    ),
+    (
+        "AUTHORIZATION_REPOSITORY_MISMATCH",
+        "BROAD_AUTHORIZATION_REQUIRED",
+        "GITHUB_AUTHORIZATION_EVIDENCE_FAILURE",
+        "INVALID_STRANGLER_SEQUENCE",
+        "MALFORMED_OWNER_AUTHORIZATION",
+        "MISSING_BOUNDED_PRODUCTION_TARGET",
+        "MISSING_OWNER_AUTHORIZATION",
+        "MISSING_RUNNABILITY_COVERAGE",
+        "NON_RUNNABLE_LOGICAL_STEP",
+        "STALE_OWNER_AUTHORIZATION",
+        "STALE_RUNNABILITY_EVIDENCE",
+        "UNAUTHENTICATED_OWNER_AUTHORIZATION",
+        "UNAUTHENTICATED_RUNNABILITY_EVIDENCE",
+        "UNFOCUSED_DIFF_SCOPE",
+        "UNVERIFIABLE_BOUNDED_TARGET",
+    ),
+    (
+        "CANDIDATE_CONTRACT_CHANGE",
+        "CHANGED_FILE_GATE_COVERAGE:",
+        "DECLARED_TOOL_NOT_EXECUTED:",
+        "GATE_SCOPE_NARROWING",
+        "HIGH_RISK_FILE_GATE_COVERAGE:",
+        "MAXIMUM_EXCEEDS_APPROVED_THRESHOLD",
+        "MISSING_QUALITY_COMMAND:",
+        "MISSING_REQUIRED_ADAPTER:",
+        "PRODUCTION_PATH_MOVED_OUTSIDE_SCOPE:",
+        "PROFILE_SOURCE_MISMATCH:",
+        "QUALITY_CHANGED_FILE_COVERAGE:",
+        "QUALITY_CHANGED_FILE_NOT_ATTESTED:",
+        "QUALITY_COMMAND_VECTOR_MISMATCH:",
+        "QUALITY_COVERAGE_MAPPING_MISMATCH",
+        "QUALITY_EXCLUSION_ADDED:",
+        "QUALITY_GATE_FAILED:",
+        "QUALITY_HIGH_RISK_FILE_COVERAGE:",
+        "QUALITY_HIGH_RISK_FILE_NOT_ATTESTED:",
+        "QUALITY_PRODUCTION_MANIFEST_MISMATCH",
+        "QUALITY_PROOF_KIND_MISMATCH:",
+        "QUALITY_SCOPE_NARROWING",
+        "QUALITY_THRESHOLD_MISMATCH",
+        "QUALITY_THRESHOLD_WEAKENING",
+        "THRESHOLD_WEAKENING",
+        "UNAPPROVED_ADAPTER:",
+        "UNAPPROVED_QUALITY_COMMAND:",
+        "UNTESTED_AREA:",
+    ),
+    (),
+)
+
+REVIEW_FIELD_OWNERS = {
+    "architecture.dependency_direction": frozenset({3}),
+    "architecture.reviewed_paths": frozenset({3}),
+    "behavior.intended_behavior": frozenset({5}),
+    "behavior.proof": frozenset({5}),
+    "characterization.captured_behavior": frozenset({5}),
+    "characterization.proof": frozenset({5}),
+    "human_review.cohesion": frozenset({4}),
+    "human_review.intended_behavior": frozenset({5}),
+    "human_review.naming": frozenset({1}),
+    "human_review.reviewability": frozenset({1}),
+    "incremental_refactor.completed_step": frozenset({6}),
+    "incremental_refactor.target": frozenset({6}),
+    "responsibility_boundary.does_not_own": frozenset({4}),
+    "responsibility_boundary.owns": frozenset({4}),
+    "responsibility_boundary.path": frozenset({4}),
+    "review_handoff.remaining_risks": frozenset({8}),
+    "review_handoff.summary": frozenset({8}),
+    "separation_of_concerns.after": frozenset({2}),
+    "separation_of_concerns.before": frozenset({2}),
+}
+
+_REVIEW_PREFIXES = (
+    "MISSING_REVIEW_EVIDENCE:",
+    "MALFORMED_REVIEW_EVIDENCE:",
+    "INSUFFICIENT_REVIEW_EVIDENCE:",
+)
+_ALL_REVIEW_STANDARDS = frozenset({1, 2, 3, 4, 5, 6, 8})
+_REVIEW_SECTIONS = frozenset(field.partition(".")[0] for field in REVIEW_FIELD_OWNERS)
+_REVIEW_ROOT_FIELDS = frozenset({"schema_version", *_REVIEW_SECTIONS})
+_MODULE_BOUNDARY_FIELDS = frozenset({"basis", "justification", "owner_path", "path"})
+_MODULE_BOUNDARY_LOCATION = re.compile(r"module_boundaries\[(0|[1-9][0-9]*)\](?:\.(.*))?\Z")
+_QUALITY_TECHNICAL_PREFIXES = (
+    "DUPLICATE_QUALITY_",
+    "MALFORMED_QUALITY_",
+    "MISSING_QUALITY_",
+    "QUALITY_",
+    "RELATIVE_QUALITY_",
+    "SELF_DECLARED_QUALITY_",
+    "UNAPPROVED_QUALITY_",
+    "UNAUTHENTICATED_QUALITY_",
+    "UNTRUSTED_QUALITY_",
+)
+ALL_STANDARDS = frozenset(range(1, 9))
+COMPLEXITY_TECHNICAL_STANDARDS = frozenset({1, 2, 3, 4, 7, 8})
+_EXACT_TECHNICAL_DEPENDENCIES = {
+    "CHARACTERIZATION_RESULT_BINDING_MISMATCH": (
+        "characterization-result",
+        frozenset({5, 6}),
+    ),
+    "COMPLEXITY_RESULT_BINDING_MISMATCH": ("complexity-result", ALL_STANDARDS),
+    "GATE_INSTALL_FAILURE": ("gate-install", ALL_STANDARDS),
+    "MALFORMED_CHARACTERIZATION_RESULT": (
+        "characterization-result",
+        frozenset({5, 6}),
+    ),
+    "MALFORMED_COMPLEXITY_RESULT": ("complexity-result", ALL_STANDARDS),
+    "MALFORMED_QUALITY_PROVENANCE": (
+        "quality-profile:artifact-binding",
+        frozenset({7}),
+    ),
+    "MALFORMED_EXTERNAL_QUALITY_ARTIFACT": (
+        "quality-profile:artifact-binding",
+        frozenset({7}),
+    ),
+    "MALFORMED_QUALITY_RESULT_BINDING": (
+        "quality-profile:artifact-binding",
+        frozenset({7}),
+    ),
+    "MALFORMED_REFACTOR_RESULT": ("refactor-policy-result", frozenset({6})),
+    "MISSING_CHARACTERIZATION_RESULT": (
+        "characterization-result",
+        frozenset({5, 6}),
+    ),
+    "MISSING_COMPLEXITY_RESULT": ("complexity-result", ALL_STANDARDS),
+    "MISSING_QUALITY_PROVENANCE": (
+        "quality-profile:artifact-binding",
+        frozenset({7}),
+    ),
+    "MISSING_EXTERNAL_QUALITY_ARTIFACT": (
+        "quality-profile:artifact-binding",
+        frozenset({7}),
+    ),
+    "MISSING_REFACTOR_RESULT": ("refactor-policy-result", frozenset({6})),
+    "QUALITY_RESULT_BINDING_MISMATCH": (
+        "quality-profile:artifact-binding",
+        frozenset({7}),
+    ),
+    "QUALITY_ARTIFACT_IDENTITY_MISMATCH": (
+        "quality-profile:artifact-binding",
+        frozenset({7}),
+    ),
+    "REFACTOR_RESULT_BINDING_MISMATCH": (
+        "refactor-policy-result",
+        frozenset({6}),
+    ),
+}
+_SOURCE_BLOCK_ALLOWED = {
+    "characterization-result:policy-blocks": frozenset({5}),
+    "complexity-result:policy-blocks": ALL_STANDARDS,
+    "refactor-policy-result:policy-blocks": frozenset({6}),
+}
+_SOURCE_BLOCK_DEPENDENTS = {
+    "characterization-result:policy-blocks": frozenset({5, 6}),
+    "complexity-result:policy-blocks": ALL_STANDARDS,
+    "refactor-policy-result:policy-blocks": frozenset({6}),
+}
+
+
+def _matches(block: str, family: str) -> bool:
+    return block.startswith(family) if family.endswith(":") else block == family
+
+
+def _review_defect(block: str) -> tuple[str, str] | None:
+    prefix = next((item for item in _REVIEW_PREFIXES if block.startswith(item)), None)
+    return (prefix.partition("_")[0], block.removeprefix(prefix)) if prefix else None
+
+
+def _emitted_review_location(kind: str, location: str) -> bool:
+    if location == "document":
+        return kind in {"MISSING", "MALFORMED"}
+    if location == "schema_version":
+        return kind == "MALFORMED"
+    if location.startswith("review_evidence."):
+        root = location.removeprefix("review_evidence.")
+        if kind == "MISSING":
+            return root in _REVIEW_ROOT_FIELDS
+        return kind == "MALFORMED" and root not in {
+            *_REVIEW_ROOT_FIELDS,
+            "module_boundaries",
+        }
+    if location == "module_boundaries":
+        return kind == "MALFORMED"
+    if location == "module_boundaries.path":
+        return kind == "MALFORMED"
+    if match := _MODULE_BOUNDARY_LOCATION.fullmatch(location):
+        field = match.group(2)
+        return kind == "MALFORMED" if field not in _MODULE_BOUNDARY_FIELDS else True
+    section, separator, _ = location.partition(".")
+    if section not in _REVIEW_SECTIONS:
+        return False
+    if not separator:
+        return kind == "MALFORMED"
+    return kind == "MALFORMED" or location in REVIEW_FIELD_OWNERS
+
+
+def review_owners(block: str) -> frozenset[int]:
+    """Return exact owners for one structured-review defect."""
+    defect = _review_defect(block)
+    if defect is None or not _emitted_review_location(*defect):
+        return frozenset()
+    kind, location = defect
+    if location in {"document", "schema_version"}:
+        return _ALL_REVIEW_STANDARDS
+    if location.startswith("review_evidence."):
+        if kind == "MALFORMED":
+            return _ALL_REVIEW_STANDARDS
+        location = location.removeprefix("review_evidence.")
+    if location == "module_boundaries" or location.startswith("module_boundaries["):
+        return frozenset({4})
+    if location == "module_boundaries.path":
+        return frozenset({4})
+    if exact := REVIEW_FIELD_OWNERS.get(location):
+        return exact
+    section = location.partition(".")[0]
+    return frozenset(
+        owner
+        for field, owners_for_field in REVIEW_FIELD_OWNERS.items()
+        if field.startswith(f"{section}.")
+        for owner in owners_for_field
+    )
+
+
+def owners(block: str) -> frozenset[int]:
+    """Return every declared Standard owner for one emitted policy block."""
+    matches = {
+        standard
+        for standard, families in enumerate(BLOCK_FAMILIES, start=1)
+        if any(_matches(block, family) for family in families)
+    }
+    matches.update(review_owners(block))
+    return frozenset(matches)
+
+
+def shared_dependency(block: str) -> tuple[str, frozenset[int]] | None:
+    """Name an intentional multi-Standard structured-review dependency."""
+    block_owners = review_owners(block)
+    if len(block_owners) < 2:
+        return None
+    defect = _review_defect(block)
+    assert defect is not None
+    kind, location = defect
+    document = location in {"document", "schema_version"} or (
+        kind == "MALFORMED" and location.startswith("review_evidence.")
+    )
+    location = location.removeprefix("review_evidence.")
+    dependency = (
+        "structured-review-document"
+        if document
+        else f"structured-review-section:{location.partition('.')[0]}"
+    )
+    return dependency, block_owners
+
+
+def technical_owners(code: str) -> frozenset[int]:
+    """Return one lane for technical codes with stable, unique ownership."""
+    raw = code.removeprefix("COMPLEXITY_RESULT:")
+    if raw in {
+        "INCOMPLETE_REMAINING_GAP",
+        "MCCABE_GRAPH_MISMATCH",
+        "MISSING_FUNCTION_BODY",
+        "PROFILE_NODE_MISMATCH",
+    } or raw.startswith(("C901_", "RUFF_")):
+        return frozenset({1})
+    if raw.startswith("ARCHITECTURE_"):
+        return frozenset({3})
+    if raw == "INVALID_WORKFLOW_SHA" or raw.startswith(_QUALITY_TECHNICAL_PREFIXES):
+        return frozenset({7})
+    return frozenset()
+
+
+def expected_technical_dependency(code: str, dependency: str) -> tuple[str, frozenset[int]] | None:
+    """Derive the only valid dependency and affected lanes for one technical code."""
+    if exact := _EXACT_TECHNICAL_DEPENDENCIES.get(code):
+        return exact
+    if code.startswith("COMPLEXITY_RESULT:"):
+        return (
+            "complexity-result:technical-errors",
+            technical_owners(code) or COMPLEXITY_TECHNICAL_STANDARDS,
+        )
+    if code.startswith("UNKNOWN_STANDARD_BLOCK_OWNER:"):
+        block = code.removeprefix("UNKNOWN_STANDARD_BLOCK_OWNER:")
+        return ("standard-block-ownership", ALL_STANDARDS) if not owners(block) else None
+    if code.startswith("AMBIGUOUS_STANDARD_BLOCK_OWNER:"):
+        block = code.removeprefix("AMBIGUOUS_STANDARD_BLOCK_OWNER:")
+        return (
+            ("standard-block-ownership", ALL_STANDARDS)
+            if len(owners(block)) > 1 and shared_dependency(block) is None
+            else None
+        )
+    if code.startswith("STANDARD_BLOCK_SOURCE_MISMATCH:"):
+        block = code.removeprefix("STANDARD_BLOCK_SOURCE_MISMATCH:")
+        allowed = _SOURCE_BLOCK_ALLOWED.get(dependency)
+        block_owners = owners(block)
+        if allowed and block_owners and not block_owners.issubset(allowed):
+            return dependency, _SOURCE_BLOCK_DEPENDENTS[dependency] | block_owners
+    return None

--- a/src/supportability_gate/standard_block_ownership.py
+++ b/src/supportability_gate/standard_block_ownership.py
@@ -122,7 +122,7 @@ _REVIEW_PREFIXES = (
     "MALFORMED_REVIEW_EVIDENCE:",
     "INSUFFICIENT_REVIEW_EVIDENCE:",
 )
-_ALL_REVIEW_STANDARDS = frozenset({1, 2, 3, 4, 5, 6, 8})
+REVIEW_STANDARDS = frozenset({1, 2, 3, 4, 5, 6, 8})
 _REVIEW_SECTIONS = frozenset(field.partition(".")[0] for field in REVIEW_FIELD_OWNERS)
 _REVIEW_ROOT_FIELDS = frozenset({"schema_version", *_REVIEW_SECTIONS})
 _MODULE_BOUNDARY_FIELDS = frozenset({"basis", "justification", "owner_path", "path"})
@@ -248,10 +248,10 @@ def review_owners(block: str) -> frozenset[int]:
         return frozenset()
     kind, location = defect
     if location in {"document", "schema_version"}:
-        return _ALL_REVIEW_STANDARDS
+        return REVIEW_STANDARDS
     if location.startswith("review_evidence."):
         if kind == "MALFORMED":
-            return _ALL_REVIEW_STANDARDS
+            return REVIEW_STANDARDS
         location = location.removeprefix("review_evidence.")
     if location == "module_boundaries" or location.startswith("module_boundaries["):
         return frozenset({4})
@@ -303,6 +303,12 @@ def technical_owners(code: str) -> frozenset[int]:
     """Return one lane for technical codes with stable, unique ownership."""
     raw = code.removeprefix("COMPLEXITY_RESULT:")
     if raw in {
+        "COMPLEXITY_AMBIGUOUS_FUNCTION_IDENTITY",
+        "COMPLEXITY_EMPTY_FUNCTION_DELTA",
+        "COMPLEXITY_MISSING_AST_SPAN",
+        "COMPLEXITY_SOURCE_ENCODING",
+        "COMPLEXITY_SOURCE_UNAVAILABLE",
+        "COMPLEXITY_SYNTAX_ERROR",
         "INCOMPLETE_REMAINING_GAP",
         "MCCABE_GRAPH_MISMATCH",
         "MISSING_FUNCTION_BODY",
@@ -310,9 +316,11 @@ def technical_owners(code: str) -> frozenset[int]:
     } or raw.startswith(("C901_", "RUFF_")):
         return frozenset({1})
     if raw.startswith("ARCHITECTURE_"):
-        return frozenset({3})
+        return frozenset({3, 4})
+    if raw == "REVIEW_EVIDENCE_UNAVAILABLE":
+        return REVIEW_STANDARDS
     if raw == "INVALID_WORKFLOW_SHA" or raw.startswith(_QUALITY_TECHNICAL_PREFIXES):
-        return frozenset({7})
+        return frozenset({4, 7})
     return frozenset()
 
 

--- a/src/supportability_gate/standard_results.py
+++ b/src/supportability_gate/standard_results.py
@@ -251,6 +251,8 @@ class _S02Complexity:
     technical: tuple[str, ...]
     changed_files: tuple[dict[str, Any], ...]
     quality_adapters: tuple[str, ...]
+    quality_result: str | None
+    result: str
     source_sha256: str
 
 
@@ -330,8 +332,8 @@ def _s02_rows(
     return rows
 
 
-def _s02_changed(value: object, code: str) -> tuple[dict[str, Any], ...]:
-    rows = _s02_dict_list(value, code)
+def _s02_changed(value: object, code: str, required: bool = False) -> tuple[dict[str, Any], ...]:
+    rows = _s02_dict_list(value, code, required)
     for row in rows:
         lines = row.get("changed_head_lines")
         if (
@@ -403,7 +405,7 @@ def _s02_profile_command(row: dict[str, Any], code: str) -> str:
     return adapter
 
 
-def _s02_profile(value: object, identity: RunIdentity, code: str) -> tuple[str, ...]:
+def _s02_profile(value: object, identity: RunIdentity, code: str) -> tuple[tuple[str, ...], str]:
     row = _s02_exact(value, _S02_PROFILE_KEYS, code)
     actual = tuple(
         row[name] for name in ("base_sha", "head_sha", "repository_remote", "workflow_sha")
@@ -442,7 +444,12 @@ def _s02_profile(value: object, identity: RunIdentity, code: str) -> tuple[str, 
         "production_paths",
     ):
         _s02_strings(row[name], code)
-    return adapters
+    result = (
+        "BLOCK"
+        if any(not command["executed"] or command["exit_code"] for command in commands)
+        else "PASS"
+    )
+    return adapters, result
 
 
 def _s02_review_section(
@@ -472,12 +479,12 @@ def _s02_review_boundaries(value: object, code: str) -> None:
 
 
 def _s02_review(value: object, blocks: list[str], code: str) -> None:
-    review_block = any(standard_block_ownership.review_owners(block) for block in blocks)
+    owners = frozenset().union(*(standard_block_ownership.review_owners(block) for block in blocks))
     if value is None:
-        if review_block:
+        if owners == standard_block_ownership.REVIEW_STANDARDS:
             return
         raise StandardResultsError(code)
-    if review_block:
+    if owners:
         raise StandardResultsError(code)
     keys = {"module_boundaries", "schema_version", *_S02_REVIEW_SECTIONS}
     row = _s02_exact(value, keys, code)
@@ -629,6 +636,56 @@ def _s02_gate_coverage(value: object, code: str, required: bool) -> None:
         _s02_strings(row["paths"], code, True)
 
 
+def _s02_complexity_technical_standards(technical: list[str]) -> frozenset[int]:
+    return frozenset().union(
+        *(
+            standard_block_ownership.technical_owners(f"COMPLEXITY_RESULT:{item}")
+            or standard_block_ownership.COMPLEXITY_TECHNICAL_STANDARDS
+            for item in technical
+        )
+    )
+
+
+def _s02_complexity_components(
+    row: dict[str, Any],
+    blocks: list[str],
+    technical: list[str],
+    identity: RunIdentity,
+    code: str,
+) -> tuple[tuple[str, ...], str | None]:
+    affected = _s02_complexity_technical_standards(technical)
+    review_owners = frozenset().union(
+        *(standard_block_ownership.review_owners(block) for block in blocks)
+    )
+    if (
+        (row["architecture"] is None and 3 not in affected)
+        or (row["modularity"] is None and 4 not in affected)
+        or (row["quality_profile"] is None and 7 not in affected)
+        or (
+            row["review_evidence"] is None
+            and review_owners != standard_block_ownership.REVIEW_STANDARDS
+            and not standard_block_ownership.REVIEW_STANDARDS.issubset(affected)
+        )
+    ):
+        raise StandardResultsError(code)
+    if row["architecture"] is not None:
+        _s02_architecture(row["architecture"], blocks, code)
+    if row["modularity"] is not None:
+        _s02_modularity(row["modularity"], blocks, code)
+    if row["review_evidence"] is not None or review_owners:
+        _s02_review(row["review_evidence"], blocks, code)
+    profile = (
+        _s02_profile(row["quality_profile"], identity, code)
+        if row["quality_profile"] is not None
+        else ((), None)
+    )
+    if profile[1] == "BLOCK" and not any(
+        7 in standard_block_ownership.owners(block) for block in blocks
+    ):
+        raise StandardResultsError(code)
+    return profile
+
+
 def _s02_complexity(value: object, identity: RunIdentity) -> _S02Complexity:
     code = "MALFORMED_COMPLEXITY_RESULT"
     row = _s02_exact(value, _S02_COMPLEXITY_KEYS, code)
@@ -650,7 +707,9 @@ def _s02_complexity(value: object, identity: RunIdentity) -> _S02Complexity:
         for item in technical_rows
     ):
         raise StandardResultsError(code)
-    changed = _s02_changed(row["changed_files"], code)
+    affected = _s02_complexity_technical_standards(technical)
+    common_required = not technical or affected != standard_block_ownership.ALL_STANDARDS
+    changed = _s02_changed(row["changed_files"], code, common_required)
     result = "TECHNICAL_FAILURE" if technical else "BLOCK" if blocks or function_blocks else "PASS"
     if row["overall_result"] != result:
         raise StandardResultsError(code)
@@ -667,12 +726,11 @@ def _s02_complexity(value: object, identity: RunIdentity) -> _S02Complexity:
         )
     ):
         raise StandardResultsError(code)
-    _s02_architecture(row["architecture"], blocks, code)
-    _s02_modularity(row["modularity"], blocks, code)
-    _s02_review(row["review_evidence"], blocks, code)
-    _s02_commands(row["commands"], code, not technical)
-    _s02_gate_coverage(row["gate_coverage"], code, not technical)
-    quality_adapters = _s02_profile(row["quality_profile"], identity, code)
+    _s02_commands(row["commands"], code, True)
+    _s02_gate_coverage(row["gate_coverage"], code, common_required)
+    quality_adapters, quality_result = _s02_complexity_components(
+        row, blocks, technical, identity, code
+    )
     _s02_complexity_lists(row, code)
     _s02_ruff(row["ruff_diagnostics"], code)
     return _S02Complexity(
@@ -680,6 +738,8 @@ def _s02_complexity(value: object, identity: RunIdentity) -> _S02Complexity:
         tuple(technical),
         changed,
         quality_adapters,
+        quality_result,
+        result,
         hashlib.sha256(_canonical(row)).hexdigest(),
     )
 
@@ -688,8 +748,6 @@ def _s02_apply_block(
     state: _S02State,
     block: str,
     source: str,
-    allowed: frozenset[int],
-    dependents: frozenset[int],
 ) -> None:
     owners = standard_block_ownership.owners(block)
     shared = standard_block_ownership.shared_dependency(block)
@@ -705,12 +763,10 @@ def _s02_apply_block(
             "standard-block-ownership",
             standard_block_ownership.ALL_STANDARDS,
         )
-    elif not owners.issubset(allowed):
-        state.technical(
-            f"STANDARD_BLOCK_SOURCE_MISMATCH:{block}",
-            f"{source}:policy-blocks",
-            dependents | owners,
-        )
+    elif expected := standard_block_ownership.expected_technical_dependency(
+        f"STANDARD_BLOCK_SOURCE_MISMATCH:{block}", f"{source}:policy-blocks"
+    ):
+        state.technical(f"STANDARD_BLOCK_SOURCE_MISMATCH:{block}", expected[0], expected[1])
     elif shared:
         state.policy(block, shared[0], shared[1])
     else:
@@ -944,6 +1000,10 @@ def _s02_outcomes(value: object) -> dict[str, str]:
     return dict(value)
 
 
+def _s02_outcome_matches(outcome: str, result: str) -> bool:
+    return outcome == ("success" if result == "PASS" else "failure")
+
+
 def _s02_errors(value: object) -> dict[str, str]:
     if value is None:
         return {}
@@ -967,6 +1027,7 @@ def _s02_source_failure(state: _S02State, source: str, code: str) -> None:
     dependency = {
         "gate_install": "gate-install",
         "complexity": "complexity-result",
+        "complexity_technical": "complexity-result:technical-errors",
         "characterization": "characterization-result",
         "refactor": "refactor-policy-result",
         "quality_provenance": "quality-profile:artifact-binding",
@@ -1007,7 +1068,10 @@ def _s02_entries(state: _S02State) -> list[dict[str, object]]:
 
 
 def _s02_load_complexity(
-    value: object, identity: RunIdentity, errors: dict[str, str]
+    value: object,
+    identity: RunIdentity,
+    errors: dict[str, str],
+    outcomes: dict[str, str],
 ) -> tuple[_S02Complexity | None, str | None]:
     if "gate_install" in errors:
         return None, None
@@ -1015,7 +1079,10 @@ def _s02_load_complexity(
     if source_error is not None:
         return None, source_error
     try:
-        return _s02_complexity(value, identity), None
+        data = _s02_complexity(value, identity)
+        if not _s02_outcome_matches(outcomes["complexity"], data.result):
+            return None, "MALFORMED_COMPLEXITY_RESULT"
+        return data, None
     except StandardResultsError as error:
         return None, error.code
 
@@ -1039,26 +1106,15 @@ def _s02_add_complexity(
         _s02_source_failure(state, "gate_install", errors["gate_install"])
         return
     if source_error is not None:
-        state.technical(source_error, "complexity-result", standard_block_ownership.ALL_STANDARDS)
+        _s02_source_failure(state, "complexity", source_error)
         return
     if data is None:
         return
     for block in data.blocks:
-        _s02_apply_block(
-            state,
-            block,
-            "complexity-result",
-            standard_block_ownership.ALL_STANDARDS,
-            standard_block_ownership.ALL_STANDARDS,
-        )
+        _s02_apply_block(state, block, "complexity-result")
     for code in data.technical:
         rendered = f"COMPLEXITY_RESULT:{code}"
-        owners = standard_block_ownership.technical_owners(rendered)
-        state.technical(
-            rendered,
-            "complexity-result:technical-errors",
-            owners or standard_block_ownership.COMPLEXITY_TECHNICAL_STANDARDS,
-        )
+        _s02_source_failure(state, "complexity_technical", rendered)
 
 
 def _s02_add_behavior(
@@ -1067,43 +1123,61 @@ def _s02_add_behavior(
     refactor: object,
     identity: RunIdentity,
     errors: dict[str, str],
+    outcomes: dict[str, str],
     short: bool,
 ) -> None:
     if "gate_install" in errors or short:
         return
+    if not _s02_add_characterization(state, characterization, identity, errors, outcomes):
+        return
+    _s02_add_refactor(state, refactor, characterization, identity, errors, outcomes)
+
+
+def _s02_add_characterization(
+    state: _S02State,
+    characterization: object,
+    identity: RunIdentity,
+    errors: dict[str, str],
+    outcomes: dict[str, str],
+) -> bool:
     char_error = errors.get("characterization")
     if char_error is not None:
         _s02_source_failure(state, "characterization", char_error)
-        return
+        return False
     try:
         blocks = _s02_characterization(characterization, identity)
     except StandardResultsError as error:
-        state.technical(error.code, "characterization-result", frozenset({5, 6}))
-        return
+        _s02_source_failure(state, "characterization", error.code)
+        return False
+    if not _s02_outcome_matches(outcomes["characterization"], "BLOCK" if blocks else "PASS"):
+        _s02_source_failure(state, "characterization", "MALFORMED_CHARACTERIZATION_RESULT")
+        return False
     for block in blocks:
-        _s02_apply_block(
-            state,
-            block,
-            "characterization-result",
-            frozenset({5}),
-            frozenset({5, 6}),
-        )
+        _s02_apply_block(state, block, "characterization-result")
+    return True
+
+
+def _s02_add_refactor(
+    state: _S02State,
+    refactor: object,
+    characterization: object,
+    identity: RunIdentity,
+    errors: dict[str, str],
+    outcomes: dict[str, str],
+) -> None:
     if "refactor" in errors:
         _s02_source_failure(state, "refactor", errors["refactor"])
         return
     try:
         refactor_blocks = _s02_refactor(refactor, characterization, identity)
     except StandardResultsError as error:
-        state.technical(error.code, "refactor-policy-result", frozenset({6}))
+        _s02_source_failure(state, "refactor", error.code)
+        return
+    if not _s02_outcome_matches(outcomes["refactor"], "BLOCK" if refactor_blocks else "PASS"):
+        _s02_source_failure(state, "refactor", "MALFORMED_REFACTOR_RESULT")
         return
     for block in refactor_blocks:
-        _s02_apply_block(
-            state,
-            block,
-            "refactor-policy-result",
-            frozenset({6}),
-            frozenset({6}),
-        )
+        _s02_apply_block(state, block, "refactor-policy-result")
 
 
 def _s02_add_quality(
@@ -1113,12 +1187,24 @@ def _s02_add_quality(
     data: _S02Complexity | None,
     identity: RunIdentity,
     errors: dict[str, str],
+    outcomes: dict[str, str],
     complexity_error: str | None,
 ) -> dict[str, object] | None:
     if "gate_install" in errors or complexity_error is not None:
         return None
     if "quality_provenance" in errors:
         _s02_source_failure(state, "quality_provenance", errors["quality_provenance"])
+        return None
+    if data is not None and data.quality_result is None and data.technical:
+        if not state.errors[7]:
+            _s02_source_failure(state, "quality_provenance", "MALFORMED_QUALITY_PROVENANCE")
+        return None
+    if (
+        data is not None
+        and data.quality_result is not None
+        and not _s02_outcome_matches(outcomes["quality"], data.quality_result)
+    ):
+        _s02_source_failure(state, "quality_provenance", "MALFORMED_QUALITY_PROVENANCE")
         return None
     try:
         return _s02_quality_artifact(
@@ -1128,7 +1214,7 @@ def _s02_add_quality(
             identity,
         )
     except StandardResultsError as error:
-        state.technical(error.code, "quality-profile:artifact-binding", frozenset({7}))
+        _s02_source_failure(state, "quality_provenance", error.code)
         return None
 
 
@@ -1147,11 +1233,13 @@ def compose_results(
     _s02_identity(identity)
     outcomes = _s02_outcomes(source_outcomes)
     errors = _s02_errors(source_errors)
-    data, complexity_error = _s02_load_complexity(complexity, identity, errors)
+    if outcomes["install"] != "success":
+        errors = {"gate_install": "GATE_INSTALL_FAILURE"}
+    data, complexity_error = _s02_load_complexity(complexity, identity, errors, outcomes)
     short = _s02_authenticated_short(data)
     state = _S02State(frozenset({7}) if short else standard_block_ownership.ALL_STANDARDS)
     _s02_add_complexity(state, data, complexity_error, errors)
-    _s02_add_behavior(state, characterization, refactor, identity, errors, short)
+    _s02_add_behavior(state, characterization, refactor, identity, errors, outcomes, short)
     artifact = _s02_add_quality(
         state,
         quality_provenance,
@@ -1159,6 +1247,7 @@ def compose_results(
         data,
         identity,
         errors,
+        outcomes,
         complexity_error,
     )
     source_validated = bool(data and not data.technical)
@@ -1400,7 +1489,7 @@ def validate_payload(value: object, identity: RunIdentity | None = None) -> None
         or type(row["short_task"]) is not bool
     ):
         raise StandardResultsError("MALFORMED_STANDARD_RESULTS_ARTIFACT")
-    _s02_outcomes(row["source_outcomes"])
+    outcomes = _s02_outcomes(row["source_outcomes"])
     eligible_short = _s02_applicability(row["applicability_evidence"], row["short_task"])
     if not isinstance(row["entries"], list) or len(row["entries"]) != 8:
         raise StandardResultsError("MALFORMED_STANDARD_RESULTS_ARTIFACT")
@@ -1408,6 +1497,13 @@ def validate_payload(value: object, identity: RunIdentity | None = None) -> None
         _s02_entry(item, standard, row["short_task"])
         for standard, item in enumerate(row["entries"], start=1)
     ]
+    required_success = {"complexity", "install", "quality"}
+    if not row["short_task"]:
+        required_success.update({"characterization", "refactor"})
+    if all(entry["result"] in {"PASS", "NOT_APPLICABLE_SHORT_TASK"} for entry in entries) and any(
+        outcomes[source] != "success" for source in required_success
+    ):
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_SOURCE_OUTCOMES")
     shared = _s02_shared(row["shared_failures"])
     _s02_ownership(entries, shared)
     if row["short_task"] is not (eligible_short and not _s02_source_uncertain(entries)):

--- a/src/supportability_gate/standard_results.py
+++ b/src/supportability_gate/standard_results.py
@@ -1,0 +1,1438 @@
+"""Compose one independently owned result for each Supportability Standard."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from supportability_gate import clause_inventory, standard_block_ownership
+
+CHECK_CONTEXTS = (
+    "Supportability 1 - Cyclomatic Complexity",
+    "Supportability 2 - Separation of Concerns",
+    "Supportability 3 - Dependency Direction",
+    "Supportability 4 - Domain Modularity",
+    "Supportability 5 - Characterization",
+    "Supportability 6 - Incremental Refactor",
+    "Supportability 7 - Quality Gates",
+    "Supportability 8 - Review Handoff",
+)
+
+
+class StandardResultsError(ValueError):
+    """One fail-closed standard-result contract error."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class RunIdentity:
+    """Exact producer and pull-request identity."""
+
+    repository: str
+    repository_id: int
+    base_sha: str
+    head_sha: str
+    workflow_sha: str
+    run_id: int
+    run_attempt: int
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+
+
+def _string_list(value: object, code: str) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise StandardResultsError(code)
+    if len(value) != len(set(value)):
+        raise StandardResultsError(code)
+    return value
+
+
+# Deterministic S02 result contract.
+SCHEMA_VERSION = "standard-results.v2"
+RESULTS = frozenset({"PASS", "BLOCK", "TECHNICAL_FAILURE", "NOT_APPLICABLE_SHORT_TASK"})
+SOURCE_OUTCOMES = frozenset({"success", "failure", "cancelled", "skipped"})
+SOURCE_KEYS = ("install", "complexity", "characterization", "refactor", "quality")
+EVIDENCE_SOURCES = (
+    (
+        "complexity-result.json:functions",
+        "complexity-result.json:ruff_diagnostics",
+        "complexity-result.json:review_evidence.human_review",
+    ),
+    ("complexity-result.json:review_evidence.separation_of_concerns",),
+    (
+        "complexity-result.json:architecture",
+        "complexity-result.json:dependency_direction_explanation",
+        "complexity-result.json:review_evidence.architecture",
+    ),
+    (
+        "complexity-result.json:modularity",
+        "complexity-result.json:review_evidence.module_boundaries",
+        "complexity-result.json:review_evidence.responsibility_boundary",
+    ),
+    (
+        "characterization-result.json",
+        "complexity-result.json:review_evidence.behavior",
+        "complexity-result.json:review_evidence.characterization",
+    ),
+    (
+        "refactor-policy-result.json",
+        "complexity-result.json:review_evidence.incremental_refactor",
+    ),
+    (
+        "complexity-result.json:changed_files",
+        "complexity-result.json:gate_coverage",
+        "complexity-result.json:quality_profile",
+        "quality-provenance.json",
+    ),
+    (
+        "complexity-result.json:changed_files",
+        "complexity-result.json:review_evidence.review_handoff",
+    ),
+)
+_S02_SHA40 = re.compile(r"[0-9a-f]{40}\Z")
+_S02_SHA64 = re.compile(r"[0-9a-f]{64}\Z")
+_S02_SHORT_EXCLUSIONS = {
+    "docs/fixed_roadmap.md",
+    "docs/product_completion_contract.md",
+    "docs/supportability_standard.md",
+}
+_S02_SOURCE_CODES = {
+    "gate_install": {"GATE_INSTALL_FAILURE"},
+    "complexity": {"MISSING_COMPLEXITY_RESULT", "MALFORMED_COMPLEXITY_RESULT"},
+    "characterization": {
+        "MISSING_CHARACTERIZATION_RESULT",
+        "MALFORMED_CHARACTERIZATION_RESULT",
+    },
+    "refactor": {"MISSING_REFACTOR_RESULT", "MALFORMED_REFACTOR_RESULT"},
+    "quality_provenance": {
+        "MISSING_QUALITY_PROVENANCE",
+        "MALFORMED_QUALITY_PROVENANCE",
+    },
+}
+_S02_COMPLEXITY_KEYS = {
+    "architecture",
+    "base_contract_blob_sha",
+    "base_sha",
+    "base_tree_sha",
+    "changed_files",
+    "commands",
+    "contract_path",
+    "contract_sha256",
+    "dependency_direction_explanation",
+    "functions",
+    "gate_coverage",
+    "head_sha",
+    "head_tree_sha",
+    "high_risk_paths",
+    "language",
+    "modularity",
+    "overall_result",
+    "policy_blocks",
+    "production_paths",
+    "quality_profile",
+    "rename_bindings",
+    "repository_remote",
+    "review_evidence",
+    "review_evidence_path",
+    "ruff_diagnostics",
+    "schema_version",
+    "standard_sha256",
+    "technical_errors",
+    "tool_versions",
+    "touched_qualified_functions",
+}
+_S02_CHANGED_KEYS = {
+    "base_production",
+    "changed_head_lines",
+    "complexity_assessed",
+    "head_production",
+    "new_path",
+    "old_path",
+    "status",
+}
+_S02_CHARACTERIZATION_KEYS = {
+    "artifacts",
+    "base_sha",
+    "behavior_fingerprint",
+    "coverage",
+    "head_sha",
+    "manifest_blob_sha",
+    "manifest_sha256",
+    "overall_result",
+    "policy_blocks",
+    "repository",
+    "scenarios",
+    "schema_version",
+    "workflow_sha",
+}
+_S02_REFACTOR_KEYS = {
+    "applicable",
+    "authorization",
+    "authorization_comment_id",
+    "base_sha",
+    "characterization_sha256",
+    "changed_paths",
+    "head_sha",
+    "other_standard_clauses_waived",
+    "overall_result",
+    "policy_blocks",
+    "repository",
+    "schema_version",
+    "targets",
+    "unbounded_paths",
+}
+_S02_QUALITY_KEYS = {
+    "artifact_digest",
+    "artifact_id",
+    "capture_sha256",
+    "commands",
+    "job",
+    "repository",
+    "repository_id",
+    "run_attempt",
+    "run_id",
+    "runner_environment",
+}
+_S02_PROFILE_KEYS = {
+    "base_sha",
+    "changed_paths",
+    "commands",
+    "exclusions",
+    "head_sha",
+    "high_risk_paths",
+    "language",
+    "maximum_complexity",
+    "production_files",
+    "production_paths",
+    "repository_remote",
+    "schema_version",
+    "workflow_sha",
+}
+
+_S02_FUNCTION_KEYS = {
+    "base",
+    "decision",
+    "ending_complexity",
+    "head",
+    "next_target",
+    "remaining_debt",
+    "remaining_gap",
+    "starting_complexity",
+    "state",
+}
+_S02_METRIC_KEYS = {"complexity", "end_line", "path", "qualified_name", "start_line"}
+_S02_EDGE_KEYS = {"internal", "line", "source", "specifier", "target"}
+_S02_REVIEW_SECTIONS = {
+    "architecture": ({"dependency_direction"}, {"reviewed_paths"}),
+    "behavior": ({"intended_behavior", "proof"}, set()),
+    "characterization": ({"captured_behavior", "proof"}, set()),
+    "human_review": (
+        {"cohesion", "intended_behavior", "naming", "reviewability"},
+        set(),
+    ),
+    "incremental_refactor": ({"completed_step", "target"}, set()),
+    "responsibility_boundary": ({"does_not_own", "owns", "path"}, set()),
+    "review_handoff": ({"summary"}, {"remaining_risks"}),
+    "separation_of_concerns": ({"after", "before"}, set()),
+}
+
+
+@dataclass(frozen=True)
+class _S02Complexity:
+    blocks: tuple[str, ...]
+    technical: tuple[str, ...]
+    changed_files: tuple[dict[str, Any], ...]
+    quality_adapters: tuple[str, ...]
+    source_sha256: str
+
+
+class _S02State:
+    def __init__(self, applicable: frozenset[int]) -> None:
+        self.applicable = applicable
+        self.blocks: dict[int, set[str]] = {standard: set() for standard in range(1, 9)}
+        self.errors: dict[int, set[str]] = {standard: set() for standard in range(1, 9)}
+        self.shared: set[tuple[str, str, str, tuple[int, ...]]] = set()
+
+    def policy(self, code: str, dependency: str, affected: frozenset[int]) -> None:
+        active = affected & self.applicable
+        for standard in active:
+            self.blocks[standard].add(code)
+        if len(active) > 1:
+            self.shared.add(("POLICY_BLOCK", code, dependency, tuple(sorted(active))))
+
+    def technical(self, code: str, dependency: str, affected: frozenset[int]) -> None:
+        for standard in affected:
+            self.errors[standard].add(code)
+        if len(affected) > 1:
+            self.shared.add(("TECHNICAL_ERROR", code, dependency, tuple(sorted(affected))))
+
+
+def _s02_exact(value: object, keys: set[str], code: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise StandardResultsError(code)
+    return value
+
+
+def _s02_sha(value: object, pattern: re.Pattern[str]) -> bool:
+    return isinstance(value, str) and pattern.fullmatch(value) is not None
+
+
+def _s02_identity(identity: RunIdentity) -> None:
+    if (
+        not isinstance(identity.repository, str)
+        or identity.repository.count("/") != 1
+        or any(not part for part in identity.repository.split("/"))
+        or type(identity.repository_id) is not int
+        or identity.repository_id < 1
+        or not _s02_sha(identity.base_sha, _S02_SHA40)
+        or not _s02_sha(identity.head_sha, _S02_SHA40)
+        or not _s02_sha(identity.workflow_sha, _S02_SHA40)
+        or type(identity.run_id) is not int
+        or identity.run_id < 1
+        or type(identity.run_attempt) is not int
+        or identity.run_attempt < 1
+    ):
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_IDENTITY")
+
+
+def _s02_dict_list(value: object, code: str, required: bool = False) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise StandardResultsError(code)
+    if required and not value:
+        raise StandardResultsError(code)
+    return value
+
+
+def _s02_strings(value: object, code: str, required: bool = False) -> list[str]:
+    if (
+        not isinstance(value, list)
+        or (required and not value)
+        or any(not isinstance(item, str) or not item for item in value)
+    ):
+        raise StandardResultsError(code)
+    return value
+
+
+def _s02_rows(
+    value: object, keys: set[str], code: str, required: bool = False
+) -> list[dict[str, Any]]:
+    rows = _s02_dict_list(value, code, required)
+    if any(set(row) != keys for row in rows):
+        raise StandardResultsError(code)
+    return rows
+
+
+def _s02_changed(value: object, code: str) -> tuple[dict[str, Any], ...]:
+    rows = _s02_dict_list(value, code)
+    for row in rows:
+        lines = row.get("changed_head_lines")
+        if (
+            set(row) != _S02_CHANGED_KEYS
+            or row.get("status") not in {"ADDED", "DELETED", "MODIFIED", "RENAMED"}
+            or any(
+                path is not None and not isinstance(path, str)
+                for path in (row.get("old_path"), row.get("new_path"))
+            )
+            or any(
+                type(row.get(name)) is not bool
+                for name in ("base_production", "complexity_assessed", "head_production")
+            )
+            or not isinstance(lines, list)
+            or any(type(line) is not int or line < 1 for line in lines)
+        ):
+            raise StandardResultsError(code)
+    return tuple(rows)
+
+
+def _s02_short(changed: tuple[dict[str, Any], ...]) -> bool:
+    if len(changed) != 1:
+        return False
+    row = changed[0]
+    path = row["new_path"]
+    allowed = path == "README.md" or bool(
+        isinstance(path, str) and path.startswith("docs/") and path.endswith(".md")
+    )
+    return bool(
+        row["status"] == "ADDED"
+        and row["old_path"] is None
+        and row["base_production"] is False
+        and row["head_production"] is False
+        and allowed
+        and path not in _S02_SHORT_EXCLUSIONS
+        and len(row["changed_head_lines"]) == 1
+    )
+
+
+def _s02_commands(value: object, code: str, required: bool) -> None:
+    keys = {"arguments", "exit_code", "stderr_sha256", "stdout_sha256", "tool"}
+    rows = _s02_rows(value, keys, code, required)
+    for row in rows:
+        if (
+            row["tool"] not in {"git", "ruff"}
+            or not isinstance(row["arguments"], list)
+            or any(not isinstance(item, str) for item in row["arguments"])
+            or type(row["exit_code"]) is not int
+            or not _s02_sha(row["stderr_sha256"], _S02_SHA64)
+            or not _s02_sha(row["stdout_sha256"], _S02_SHA64)
+        ):
+            raise StandardResultsError(code)
+
+
+def _s02_profile_command(row: dict[str, Any], code: str) -> str:
+    adapter = row["adapter"]
+    if (
+        not isinstance(adapter, str)
+        or not adapter
+        or not isinstance(row["proof_kind"], str)
+        or not row["proof_kind"]
+        or type(row["executed"]) is not bool
+        or type(row["exit_code"]) is not int
+    ):
+        raise StandardResultsError(code)
+    _s02_strings(row["arguments"], code, True)
+    _s02_strings(row["observed_paths"], code)
+    _s02_strings(row["zero_statement_paths"], code)
+    return adapter
+
+
+def _s02_profile(value: object, identity: RunIdentity, code: str) -> tuple[str, ...]:
+    row = _s02_exact(value, _S02_PROFILE_KEYS, code)
+    actual = tuple(
+        row[name] for name in ("base_sha", "head_sha", "repository_remote", "workflow_sha")
+    )
+    expected = (
+        identity.base_sha,
+        identity.head_sha,
+        f"github.com/{identity.repository}",
+        identity.workflow_sha,
+    )
+    if row["language"] not in {"python", "typescript"}:
+        raise StandardResultsError(code)
+    command_keys = {
+        "adapter",
+        "arguments",
+        "executed",
+        "exit_code",
+        "observed_paths",
+        "proof_kind",
+        "zero_statement_paths",
+    }
+    commands = _s02_rows(row["commands"], command_keys, code, True)
+    adapters = tuple(_s02_profile_command(command, code) for command in commands)
+    if (
+        actual != expected
+        or row["schema_version"] != "quality-gates.v3"
+        or row["maximum_complexity"] != 10
+        or len(adapters) != len(set(adapters))
+    ):
+        raise StandardResultsError(code)
+    for name in (
+        "changed_paths",
+        "exclusions",
+        "high_risk_paths",
+        "production_files",
+        "production_paths",
+    ):
+        _s02_strings(row[name], code)
+    return adapters
+
+
+def _s02_review_section(
+    value: object, text_fields: set[str], list_fields: set[str], code: str
+) -> None:
+    row = _s02_exact(value, text_fields | list_fields, code)
+    if any(not isinstance(row[name], str) or not row[name].strip() for name in text_fields):
+        raise StandardResultsError(code)
+    for name in list_fields:
+        values = _s02_strings(row[name], code, True)
+        if any(not item.strip() for item in values):
+            raise StandardResultsError(code)
+
+
+def _s02_review_boundaries(value: object, code: str) -> None:
+    keys = {"basis", "justification", "owner_path", "path"}
+    rows = _s02_rows(value, keys, code)
+    paths: list[str] = []
+    for row in rows:
+        if row["basis"] not in {"domain", "responsibility"} or any(
+            not isinstance(row[name], str) or not row[name].strip() for name in keys
+        ):
+            raise StandardResultsError(code)
+        paths.append(row["path"])
+    if len(paths) != len(set(paths)):
+        raise StandardResultsError(code)
+
+
+def _s02_review(value: object, blocks: list[str], code: str) -> None:
+    review_block = any(standard_block_ownership.review_owners(block) for block in blocks)
+    if value is None:
+        if review_block:
+            return
+        raise StandardResultsError(code)
+    if review_block:
+        raise StandardResultsError(code)
+    keys = {"module_boundaries", "schema_version", *_S02_REVIEW_SECTIONS}
+    row = _s02_exact(value, keys, code)
+    if row["schema_version"] != "1.0":
+        raise StandardResultsError(code)
+    for name, (text_fields, list_fields) in _S02_REVIEW_SECTIONS.items():
+        _s02_review_section(row[name], text_fields, list_fields, code)
+    _s02_review_boundaries(row["module_boundaries"], code)
+
+
+def _s02_metric(value: object, code: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    row = _s02_exact(value, _S02_METRIC_KEYS, code)
+    if (
+        any(
+            type(row[name]) is not int or row[name] < 1
+            for name in ("complexity", "start_line", "end_line")
+        )
+        or row["end_line"] < row["start_line"]
+        or any(
+            not isinstance(row[name], str) or not row[name] for name in ("path", "qualified_name")
+        )
+    ):
+        raise StandardResultsError(code)
+    return row
+
+
+def _s02_function_expected(
+    base: dict[str, Any] | None, head: dict[str, Any] | None
+) -> tuple[str, str, int | None, int | None]:
+    if head is None:
+        return "DELETED", "DELETED", None, None
+    if base is None:
+        return "NEW", "PASS" if head["complexity"] <= 10 else "BLOCK", None, None
+    if base["complexity"] <= 10:
+        return "EXISTING", "PASS" if head["complexity"] <= 10 else "BLOCK", None, None
+    debt = max(0, head["complexity"] - 10)
+    if head["complexity"] <= 10:
+        return "EXISTING_LEGACY", "PASS", debt, 10
+    decision = "PASS_PROGRESSIVE" if head["complexity"] < base["complexity"] else "BLOCK"
+    return "EXISTING_LEGACY", decision, debt, 10
+
+
+def _s02_function_blocks(value: object, code: str) -> list[str]:
+    rows = _s02_rows(value, _S02_FUNCTION_KEYS, code)
+    blocks: list[str] = []
+    for row in rows:
+        base = _s02_metric(row["base"], code)
+        head = _s02_metric(row["head"], code)
+        if base is None and head is None:
+            raise StandardResultsError(code)
+        expected = _s02_function_expected(base, head)
+        actual = (row["state"], row["decision"], row["remaining_debt"], row["next_target"])
+        if (
+            actual != expected
+            or row["remaining_gap"] != row["remaining_debt"]
+            or row["starting_complexity"] != (base["complexity"] if base else None)
+            or row["ending_complexity"] != (head["complexity"] if head else None)
+        ):
+            raise StandardResultsError(code)
+        if row["decision"] == "BLOCK":
+            metric = head if head is not None else base
+            if metric is None:
+                raise StandardResultsError(code)
+            blocks.append(f"FUNCTION_COMPLEXITY:{metric['qualified_name']}")
+    return blocks
+
+
+def _s02_edges(value: object, code: str) -> None:
+    for row in _s02_rows(value, _S02_EDGE_KEYS, code):
+        if (
+            any(
+                not isinstance(row[name], str) or not row[name]
+                for name in ("source", "specifier", "target")
+            )
+            or type(row["line"]) is not int
+            or row["line"] < 1
+            or type(row["internal"]) is not bool
+        ):
+            raise StandardResultsError(code)
+
+
+def _s02_architecture(value: object, policy_blocks: list[str], code: str) -> None:
+    keys = {"adapter", "blocks", "covered_paths", "edges", "executed", "nodes"}
+    row = _s02_exact(value, keys, code)
+    blocks = _string_list(row["blocks"], code)
+    if (
+        not isinstance(row["adapter"], str)
+        or not row["adapter"]
+        or type(row["executed"]) is not bool
+        or not set(blocks).issubset(policy_blocks)
+    ):
+        raise StandardResultsError(code)
+    _s02_strings(row["covered_paths"], code)
+    _s02_strings(row["nodes"], code)
+    _s02_edges(row["edges"], code)
+
+
+def _s02_modularity(value: object, policy_blocks: list[str], code: str) -> None:
+    keys = {"blocks", "changed_paths", "coupling_edges", "coverage", "justifications", "new_paths"}
+    row = _s02_exact(value, keys, code)
+    blocks = _string_list(row["blocks"], code)
+    if not set(blocks).issubset(policy_blocks):
+        raise StandardResultsError(code)
+    _s02_strings(row["changed_paths"], code)
+    _s02_strings(row["new_paths"], code)
+    _s02_edges(row["coupling_edges"], code)
+    for coverage in _s02_rows(row["coverage"], {"adapters", "architecture", "path"}, code):
+        if not isinstance(coverage["path"], str) or type(coverage["architecture"]) is not bool:
+            raise StandardResultsError(code)
+        _s02_strings(coverage["adapters"], code)
+    justification_keys = {"basis", "justification", "owner_path", "path"}
+    for item in _s02_rows(row["justifications"], justification_keys, code):
+        if item["basis"] not in {"domain", "responsibility"} or any(
+            not isinstance(item[name], str) or not item[name] for name in justification_keys
+        ):
+            raise StandardResultsError(code)
+
+
+def _s02_complexity_lists(row: dict[str, Any], code: str) -> None:
+    for name in ("high_risk_paths", "production_paths", "touched_qualified_functions"):
+        _s02_strings(row[name], code)
+    if not isinstance(row["tool_versions"], dict) or any(
+        not isinstance(key, str) or not isinstance(value, str)
+        for key, value in row["tool_versions"].items()
+    ):
+        raise StandardResultsError(code)
+    for item in _s02_rows(row["rename_bindings"], {"new_path", "old_path"}, code):
+        if any(not isinstance(item[name], str) or not item[name] for name in item):
+            raise StandardResultsError(code)
+
+
+def _s02_ruff(value: object, code: str) -> None:
+    keys = {"code", "complexity", "line", "message", "path", "qualified_name"}
+    for row in _s02_rows(value, keys, code):
+        if any(
+            not isinstance(row[name], str) or not row[name]
+            for name in ("code", "message", "path", "qualified_name")
+        ) or any(type(row[name]) is not int or row[name] < 1 for name in ("complexity", "line")):
+            raise StandardResultsError(code)
+
+
+def _s02_gate_coverage(value: object, code: str, required: bool) -> None:
+    rows = _s02_rows(value, {"adapter", "paths"}, code, required)
+    for row in rows:
+        if not isinstance(row["adapter"], str) or not row["adapter"]:
+            raise StandardResultsError(code)
+        _s02_strings(row["paths"], code, True)
+
+
+def _s02_complexity(value: object, identity: RunIdentity) -> _S02Complexity:
+    code = "MALFORMED_COMPLEXITY_RESULT"
+    row = _s02_exact(value, _S02_COMPLEXITY_KEYS, code)
+    actual = (row["base_sha"], row["head_sha"], row["repository_remote"])
+    expected = (identity.base_sha, identity.head_sha, f"github.com/{identity.repository}")
+    if actual != expected:
+        raise StandardResultsError("COMPLEXITY_RESULT_BINDING_MISMATCH")
+    if row["schema_version"] != "1.0" or row["standard_sha256"] != clause_inventory.STANDARD_SHA256:
+        raise StandardResultsError(code)
+    blocks = _string_list(row["policy_blocks"], code)
+    function_blocks = _s02_function_blocks(row["functions"], code)
+    technical_rows = _s02_rows(row["technical_errors"], {"code", "message"}, code)
+    technical = [item["code"] for item in technical_rows]
+    if any(
+        not isinstance(item["code"], str)
+        or not item["code"]
+        or not isinstance(item["message"], str)
+        or not item["message"]
+        for item in technical_rows
+    ):
+        raise StandardResultsError(code)
+    changed = _s02_changed(row["changed_files"], code)
+    result = "TECHNICAL_FAILURE" if technical else "BLOCK" if blocks or function_blocks else "PASS"
+    if row["overall_result"] != result:
+        raise StandardResultsError(code)
+    if (
+        not _s02_sha(row["base_contract_blob_sha"], _S02_SHA40)
+        or not _s02_sha(row["base_tree_sha"], _S02_SHA40)
+        or not _s02_sha(row["head_tree_sha"], _S02_SHA40)
+        or not _s02_sha(row["contract_sha256"], _S02_SHA64)
+        or row["review_evidence_path"] != ".supportability-review.toml"
+        or row["language"] not in {"python", "typescript"}
+        or any(
+            not isinstance(row[name], str) or not row[name]
+            for name in ("contract_path", "dependency_direction_explanation")
+        )
+    ):
+        raise StandardResultsError(code)
+    _s02_architecture(row["architecture"], blocks, code)
+    _s02_modularity(row["modularity"], blocks, code)
+    _s02_review(row["review_evidence"], blocks, code)
+    _s02_commands(row["commands"], code, not technical)
+    _s02_gate_coverage(row["gate_coverage"], code, not technical)
+    quality_adapters = _s02_profile(row["quality_profile"], identity, code)
+    _s02_complexity_lists(row, code)
+    _s02_ruff(row["ruff_diagnostics"], code)
+    return _S02Complexity(
+        tuple((*blocks, *function_blocks)),
+        tuple(technical),
+        changed,
+        quality_adapters,
+        hashlib.sha256(_canonical(row)).hexdigest(),
+    )
+
+
+def _s02_apply_block(
+    state: _S02State,
+    block: str,
+    source: str,
+    allowed: frozenset[int],
+    dependents: frozenset[int],
+) -> None:
+    owners = standard_block_ownership.owners(block)
+    shared = standard_block_ownership.shared_dependency(block)
+    if not owners:
+        state.technical(
+            f"UNKNOWN_STANDARD_BLOCK_OWNER:{block}",
+            "standard-block-ownership",
+            standard_block_ownership.ALL_STANDARDS,
+        )
+    elif len(owners) > 1 and shared is None:
+        state.technical(
+            f"AMBIGUOUS_STANDARD_BLOCK_OWNER:{block}",
+            "standard-block-ownership",
+            standard_block_ownership.ALL_STANDARDS,
+        )
+    elif not owners.issubset(allowed):
+        state.technical(
+            f"STANDARD_BLOCK_SOURCE_MISMATCH:{block}",
+            f"{source}:policy-blocks",
+            dependents | owners,
+        )
+    elif shared:
+        state.policy(block, shared[0], shared[1])
+    else:
+        state.policy(block, f"{source}:policy-blocks", owners)
+
+
+def _s02_characterization_artifact(value: object, passing: bool, code: str) -> None:
+    row = _s02_exact(value, {"capture_sha256", "digest", "id"}, code)
+    capture = row["capture_sha256"]
+    if (
+        not isinstance(row["id"], str)
+        or not row["id"].isdecimal()
+        or int(row["id"]) < 1
+        or not _s02_sha(row["digest"], _S02_SHA64)
+        or (capture is not None and not _s02_sha(capture, _S02_SHA64))
+        or (passing and capture is None)
+    ):
+        raise StandardResultsError(code)
+
+
+def _s02_characterization_scenario(value: object, passing: bool, code: str) -> None:
+    keys = {
+        "base_behavior_sha256",
+        "command",
+        "compatibility",
+        "covers",
+        "golden_behavior_sha256",
+        "head_behavior_sha256",
+        "id",
+        "kind",
+    }
+    row = _s02_exact(value, keys, code)
+    hashes = tuple(row[name] for name in keys if name.endswith("_sha256"))
+    command = row["command"]
+    if (
+        not isinstance(row["id"], str)
+        or not row["id"]
+        or row["kind"] not in {"test", "sample_io", "snapshot", "golden", "cli", "regression"}
+        or row["compatibility"] not in {"PASS", "BLOCK"}
+        or any(item is not None and not _s02_sha(item, _S02_SHA64) for item in hashes)
+        or (command is not None and not isinstance(command, list))
+    ):
+        raise StandardResultsError(code)
+    _s02_strings(row["covers"], code, True)
+    if command is not None:
+        _s02_strings(command, code, True)
+    if passing and (
+        row["compatibility"] != "PASS" or command is None or any(item is None for item in hashes)
+    ):
+        raise StandardResultsError(code)
+
+
+def _s02_characterization(value: object, identity: RunIdentity) -> list[str]:
+    code = "MALFORMED_CHARACTERIZATION_RESULT"
+    row = _s02_exact(value, _S02_CHARACTERIZATION_KEYS, code)
+    actual = tuple(row[name] for name in ("repository", "base_sha", "head_sha", "workflow_sha"))
+    expected = (
+        f"github.com/{identity.repository}",
+        identity.base_sha,
+        identity.head_sha,
+        identity.workflow_sha,
+    )
+    if actual != expected:
+        raise StandardResultsError("CHARACTERIZATION_RESULT_BINDING_MISMATCH")
+    blocks = _string_list(row["policy_blocks"], code)
+    if row["schema_version"] != "characterization-result.v1":
+        raise StandardResultsError(code)
+    if row["overall_result"] != ("BLOCK" if blocks else "PASS"):
+        raise StandardResultsError(code)
+    passing = not blocks
+    if (
+        not _s02_sha(row["behavior_fingerprint"], _S02_SHA64)
+        or not _s02_sha(row["manifest_blob_sha"], _S02_SHA40)
+        or not _s02_sha(row["manifest_sha256"], _S02_SHA64)
+    ):
+        raise StandardResultsError(code)
+    artifacts = _s02_exact(row["artifacts"], {"base", "head"}, code)
+    for side in ("base", "head"):
+        _s02_characterization_artifact(artifacts[side], passing, code)
+    coverage = _s02_exact(row["coverage"], {"covered_paths", "required_paths"}, code)
+    _s02_strings(coverage["covered_paths"], code)
+    _s02_strings(coverage["required_paths"], code)
+    for scenario in _s02_dict_list(row["scenarios"], code, True):
+        _s02_characterization_scenario(scenario, passing, code)
+    return blocks
+
+
+def _s02_refactor_authorization(value: object, comment_id: object, code: str) -> None:
+    if value is None:
+        if comment_id is not None:
+            raise StandardResultsError(code)
+        return
+    keys = {"base_sha", "broad", "head_sha", "repository", "scope", "sequence", "targets"}
+    row = _s02_exact(value, keys, code)
+    sequence = _s02_exact(row["sequence"], {"predecessor_sha", "step"}, code)
+    if (
+        not _s02_sha(row["base_sha"], _S02_SHA40)
+        or not _s02_sha(row["head_sha"], _S02_SHA40)
+        or not isinstance(row["repository"], str)
+        or type(row["broad"]) is not bool
+        or type(comment_id) is not int
+        or comment_id < 1
+        or not _s02_sha(sequence["predecessor_sha"], _S02_SHA40)
+        or type(sequence["step"]) is not int
+        or sequence["step"] < 1
+    ):
+        raise StandardResultsError(code)
+    _s02_strings(row["scope"], code, True)
+    _s02_strings(row["targets"], code, True)
+
+
+def _s02_refactor(
+    value: object,
+    characterization: object,
+    identity: RunIdentity,
+) -> list[str]:
+    code = "MALFORMED_REFACTOR_RESULT"
+    row = _s02_exact(value, _S02_REFACTOR_KEYS, code)
+    if tuple(row[name] for name in ("repository", "base_sha", "head_sha")) != (
+        identity.repository,
+        identity.base_sha,
+        identity.head_sha,
+    ):
+        raise StandardResultsError("REFACTOR_RESULT_BINDING_MISMATCH")
+    blocks = _string_list(row["policy_blocks"], code)
+    if (
+        row["schema_version"] != "refactor-policy-result.v1"
+        or type(row["applicable"]) is not bool
+        or row["other_standard_clauses_waived"] is not False
+        or row["overall_result"] != ("BLOCK" if blocks else "PASS")
+        or not _s02_sha(row["characterization_sha256"], _S02_SHA64)
+    ):
+        raise StandardResultsError(code)
+    for name in ("changed_paths", "targets", "unbounded_paths"):
+        _s02_strings(row[name], code)
+    _s02_refactor_authorization(row["authorization"], row["authorization_comment_id"], code)
+    expected = hashlib.sha256(_canonical(characterization)).hexdigest()
+    if row["characterization_sha256"] != expected:
+        raise StandardResultsError("REFACTOR_RESULT_BINDING_MISMATCH")
+    return blocks
+
+
+def _s02_provenance_adapters(value: object, code: str) -> tuple[str, ...]:
+    keys = {"adapter", "raw_proof_sha256", "stderr_sha256", "stdout_sha256"}
+    commands = _s02_rows(value, keys, code, True)
+    adapters: list[str] = []
+    for command in commands:
+        if (
+            not isinstance(command["adapter"], str)
+            or not command["adapter"]
+            or any(
+                not _s02_sha(command[name], _S02_SHA64)
+                for name in ("raw_proof_sha256", "stderr_sha256", "stdout_sha256")
+            )
+        ):
+            raise StandardResultsError(code)
+        adapters.append(command["adapter"])
+    if len(adapters) != len(set(adapters)):
+        raise StandardResultsError(code)
+    return tuple(adapters)
+
+
+def _s02_quality_artifact(
+    provenance: object,
+    expected_artifact: object,
+    profile_adapters: tuple[str, ...],
+    identity: RunIdentity,
+) -> dict[str, object]:
+    code = "MALFORMED_QUALITY_RESULT_BINDING"
+    row = _s02_exact(provenance, _S02_QUALITY_KEYS, code)
+    if (
+        tuple(row[name] for name in ("repository", "repository_id", "run_id", "run_attempt", "job"))
+        != (
+            identity.repository,
+            str(identity.repository_id),
+            str(identity.run_id),
+            str(identity.run_attempt),
+            "quality-profile",
+        )
+        or row["runner_environment"] != "github-hosted"
+    ):
+        raise StandardResultsError("QUALITY_RESULT_BINDING_MISMATCH")
+    if (
+        not isinstance(row["artifact_id"], str)
+        or not row["artifact_id"].isdecimal()
+        or int(row["artifact_id"]) < 1
+        or not _s02_sha(row["artifact_digest"], _S02_SHA64)
+        or not _s02_sha(row["capture_sha256"], _S02_SHA64)
+    ):
+        raise StandardResultsError(code)
+    adapters = _s02_provenance_adapters(row["commands"], code)
+    if adapters != profile_adapters:
+        raise StandardResultsError(code)
+    if expected_artifact is None:
+        raise StandardResultsError("MISSING_EXTERNAL_QUALITY_ARTIFACT")
+    trusted = _s02_exact(
+        expected_artifact,
+        {"capture_sha256", "digest", "id"},
+        "MALFORMED_EXTERNAL_QUALITY_ARTIFACT",
+    )
+    if (
+        not isinstance(trusted["id"], str)
+        or not trusted["id"].isdecimal()
+        or int(trusted["id"]) < 1
+        or not _s02_sha(trusted["digest"], _S02_SHA64)
+        or not _s02_sha(trusted["capture_sha256"], _S02_SHA64)
+    ):
+        raise StandardResultsError("MALFORMED_EXTERNAL_QUALITY_ARTIFACT")
+    if (row["artifact_id"], row["artifact_digest"], row["capture_sha256"]) != (
+        trusted["id"],
+        trusted["digest"],
+        trusted["capture_sha256"],
+    ):
+        raise StandardResultsError("QUALITY_ARTIFACT_IDENTITY_MISMATCH")
+    return {
+        "capture_sha256": trusted["capture_sha256"],
+        "digest": trusted["digest"],
+        "id": int(trusted["id"]),
+    }
+
+
+def _s02_outcomes(value: object) -> dict[str, str]:
+    if value is None:
+        return dict.fromkeys(SOURCE_KEYS, "success")
+    if not isinstance(value, dict):
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_SOURCE_OUTCOMES")
+    if set(value) != set(SOURCE_KEYS) or any(
+        not isinstance(item, str) or item not in SOURCE_OUTCOMES for item in value.values()
+    ):
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_SOURCE_OUTCOMES")
+    return dict(value)
+
+
+def _s02_errors(value: object) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_SOURCE_ERRORS")
+    errors = dict(value)
+    if set(errors) - set(_S02_SOURCE_CODES):
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_SOURCE_ERRORS")
+    if any(code not in _S02_SOURCE_CODES[source] for source, code in errors.items()):
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_SOURCE_ERRORS")
+    if "gate_install" in errors:
+        return {"gate_install": errors["gate_install"]}
+    if "complexity" in errors:
+        return {"complexity": errors["complexity"]}
+    if "characterization" in errors:
+        errors.pop("refactor", None)
+    return errors
+
+
+def _s02_source_failure(state: _S02State, source: str, code: str) -> None:
+    dependency = {
+        "gate_install": "gate-install",
+        "complexity": "complexity-result",
+        "characterization": "characterization-result",
+        "refactor": "refactor-policy-result",
+        "quality_provenance": "quality-profile:artifact-binding",
+    }[source]
+    expected = standard_block_ownership.expected_technical_dependency(code, dependency)
+    if expected is None:
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_SOURCE_ERRORS")
+    state.technical(code, expected[0], expected[1])
+
+
+def _s02_entries(state: _S02State) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for standard, context in enumerate(CHECK_CONTEXTS, start=1):
+        applicable = standard in state.applicable
+        blocks = sorted(state.blocks[standard])
+        errors = sorted(state.errors[standard])
+        result = (
+            "NOT_APPLICABLE_SHORT_TASK"
+            if not applicable
+            else "TECHNICAL_FAILURE"
+            if errors
+            else "BLOCK"
+            if blocks
+            else "PASS"
+        )
+        rows.append(
+            {
+                "applicable": applicable,
+                "check_context": context,
+                "evidence_sources": list(EVIDENCE_SOURCES[standard - 1]),
+                "policy_blocks": blocks,
+                "result": result,
+                "standard": standard,
+                "technical_errors": errors,
+            }
+        )
+    return rows
+
+
+def _s02_load_complexity(
+    value: object, identity: RunIdentity, errors: dict[str, str]
+) -> tuple[_S02Complexity | None, str | None]:
+    if "gate_install" in errors:
+        return None, None
+    source_error = errors.get("complexity")
+    if source_error is not None:
+        return None, source_error
+    try:
+        return _s02_complexity(value, identity), None
+    except StandardResultsError as error:
+        return None, error.code
+
+
+def _s02_authenticated_short(data: _S02Complexity | None) -> bool:
+    return bool(
+        data is not None
+        and not data.blocks
+        and not data.technical
+        and _s02_short(data.changed_files)
+    )
+
+
+def _s02_add_complexity(
+    state: _S02State,
+    data: _S02Complexity | None,
+    source_error: str | None,
+    errors: dict[str, str],
+) -> None:
+    if "gate_install" in errors:
+        _s02_source_failure(state, "gate_install", errors["gate_install"])
+        return
+    if source_error is not None:
+        state.technical(source_error, "complexity-result", standard_block_ownership.ALL_STANDARDS)
+        return
+    if data is None:
+        return
+    for block in data.blocks:
+        _s02_apply_block(
+            state,
+            block,
+            "complexity-result",
+            standard_block_ownership.ALL_STANDARDS,
+            standard_block_ownership.ALL_STANDARDS,
+        )
+    for code in data.technical:
+        rendered = f"COMPLEXITY_RESULT:{code}"
+        owners = standard_block_ownership.technical_owners(rendered)
+        state.technical(
+            rendered,
+            "complexity-result:technical-errors",
+            owners or standard_block_ownership.COMPLEXITY_TECHNICAL_STANDARDS,
+        )
+
+
+def _s02_add_behavior(
+    state: _S02State,
+    characterization: object,
+    refactor: object,
+    identity: RunIdentity,
+    errors: dict[str, str],
+    short: bool,
+) -> None:
+    if "gate_install" in errors or short:
+        return
+    char_error = errors.get("characterization")
+    if char_error is not None:
+        _s02_source_failure(state, "characterization", char_error)
+        return
+    try:
+        blocks = _s02_characterization(characterization, identity)
+    except StandardResultsError as error:
+        state.technical(error.code, "characterization-result", frozenset({5, 6}))
+        return
+    for block in blocks:
+        _s02_apply_block(
+            state,
+            block,
+            "characterization-result",
+            frozenset({5}),
+            frozenset({5, 6}),
+        )
+    if "refactor" in errors:
+        _s02_source_failure(state, "refactor", errors["refactor"])
+        return
+    try:
+        refactor_blocks = _s02_refactor(refactor, characterization, identity)
+    except StandardResultsError as error:
+        state.technical(error.code, "refactor-policy-result", frozenset({6}))
+        return
+    for block in refactor_blocks:
+        _s02_apply_block(
+            state,
+            block,
+            "refactor-policy-result",
+            frozenset({6}),
+            frozenset({6}),
+        )
+
+
+def _s02_add_quality(
+    state: _S02State,
+    provenance: object,
+    expected_artifact: object,
+    data: _S02Complexity | None,
+    identity: RunIdentity,
+    errors: dict[str, str],
+    complexity_error: str | None,
+) -> dict[str, object] | None:
+    if "gate_install" in errors or complexity_error is not None:
+        return None
+    if "quality_provenance" in errors:
+        _s02_source_failure(state, "quality_provenance", errors["quality_provenance"])
+        return None
+    try:
+        return _s02_quality_artifact(
+            provenance,
+            expected_artifact,
+            data.quality_adapters if data is not None else (),
+            identity,
+        )
+    except StandardResultsError as error:
+        state.technical(error.code, "quality-profile:artifact-binding", frozenset({7}))
+        return None
+
+
+def compose_results(
+    complexity: dict[str, Any] | None,
+    characterization: dict[str, Any] | None,
+    refactor: dict[str, Any] | None,
+    quality_provenance: dict[str, Any] | None,
+    identity: RunIdentity,
+    *,
+    expected_quality_artifact: dict[str, object] | None,
+    source_outcomes: dict[str, str] | None = None,
+    source_errors: dict[str, str] | None = None,
+) -> dict[str, object]:
+    """Compose eight deterministic rows without target execution or advisory judgment."""
+    _s02_identity(identity)
+    outcomes = _s02_outcomes(source_outcomes)
+    errors = _s02_errors(source_errors)
+    data, complexity_error = _s02_load_complexity(complexity, identity, errors)
+    short = _s02_authenticated_short(data)
+    state = _S02State(frozenset({7}) if short else standard_block_ownership.ALL_STANDARDS)
+    _s02_add_complexity(state, data, complexity_error, errors)
+    _s02_add_behavior(state, characterization, refactor, identity, errors, short)
+    artifact = _s02_add_quality(
+        state,
+        quality_provenance,
+        expected_quality_artifact,
+        data,
+        identity,
+        errors,
+        complexity_error,
+    )
+    source_validated = bool(data and not data.technical)
+    payload: dict[str, object] = {
+        "applicability_evidence": {
+            "changed_files": list(data.changed_files) if data else [],
+            "classification": "SHORT_TASK" if short else "FULL_PROCESS",
+            "source_sha256": data.source_sha256 if data else None,
+            "source_validated": source_validated,
+        },
+        "base_sha": identity.base_sha,
+        "entries": _s02_entries(state),
+        "head_sha": identity.head_sha,
+        "quality_artifact": artifact,
+        "repository": identity.repository,
+        "repository_id": identity.repository_id,
+        "run_attempt": identity.run_attempt,
+        "run_id": identity.run_id,
+        "schema_version": SCHEMA_VERSION,
+        "shared_failures": [
+            {
+                "affected_standards": list(affected),
+                "code": code,
+                "dependency": dependency,
+                "kind": kind,
+            }
+            for kind, code, dependency, affected in sorted(state.shared)
+        ],
+        "short_task": short,
+        "source_outcomes": outcomes,
+        "standard_sha256": clause_inventory.STANDARD_SHA256,
+        "workflow_sha": identity.workflow_sha,
+    }
+    validate_payload(payload, identity)
+    return payload
+
+
+def _s02_applicability(value: object, short_task: bool) -> bool:
+    row = _s02_exact(
+        value,
+        {"changed_files", "classification", "source_sha256", "source_validated"},
+        "MALFORMED_STANDARD_RESULTS_APPLICABILITY",
+    )
+    changed = _s02_changed(row["changed_files"], "MALFORMED_STANDARD_RESULTS_APPLICABILITY")
+    if type(row["source_validated"]) is not bool:
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_APPLICABILITY")
+    if row["source_sha256"] is not None and not _s02_sha(row["source_sha256"], _S02_SHA64):
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_APPLICABILITY")
+    eligible = bool(row["source_validated"] and _s02_short(changed))
+    classification = "SHORT_TASK" if short_task else "FULL_PROCESS"
+    if (short_task and not eligible) or row["classification"] != classification:
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_APPLICABILITY")
+    if row["source_validated"] and row["source_sha256"] is None:
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_APPLICABILITY")
+    return eligible
+
+
+def _s02_source_uncertain(entries: list[dict[str, Any]]) -> bool:
+    if any(row["policy_blocks"] for row in entries):
+        return True
+    codes = {code for row in entries for code in row["technical_errors"]}
+    return any(
+        standard_block_ownership.expected_technical_dependency(
+            code, "quality-profile:artifact-binding"
+        )
+        != ("quality-profile:artifact-binding", frozenset({7}))
+        for code in codes
+    )
+
+
+def _s02_entry(value: object, standard: int, short_task: bool) -> dict[str, Any]:
+    keys = {
+        "applicable",
+        "check_context",
+        "evidence_sources",
+        "policy_blocks",
+        "result",
+        "standard",
+        "technical_errors",
+    }
+    row = _s02_exact(value, keys, "MALFORMED_STANDARD_RESULT_ENTRY")
+    if (
+        type(row["standard"]) is not int
+        or row["standard"] != standard
+        or type(row["applicable"]) is not bool
+        or row["check_context"] != CHECK_CONTEXTS[standard - 1]
+        or row["evidence_sources"] != list(EVIDENCE_SOURCES[standard - 1])
+    ):
+        raise StandardResultsError("MALFORMED_STANDARD_RESULT_ENTRY")
+    blocks = _string_list(row["policy_blocks"], "MALFORMED_STANDARD_RESULT_ENTRY")
+    errors = _string_list(row["technical_errors"], "MALFORMED_STANDARD_RESULT_ENTRY")
+    expected_applicable = not short_task or standard == 7
+    if row["applicable"] is not expected_applicable or (
+        not expected_applicable and (blocks or errors)
+    ):
+        raise StandardResultsError("MALFORMED_STANDARD_RESULT_ENTRY")
+    result = (
+        "NOT_APPLICABLE_SHORT_TASK"
+        if not expected_applicable
+        else "TECHNICAL_FAILURE"
+        if errors
+        else "BLOCK"
+        if blocks
+        else "PASS"
+    )
+    if row["result"] != result or row["result"] not in RESULTS:
+        raise StandardResultsError("MALFORMED_STANDARD_RESULT_ENTRY")
+    return row
+
+
+def _s02_shared(value: object) -> dict[tuple[str, str], tuple[str, frozenset[int]]]:
+    rows = _s02_dict_list(value, "MALFORMED_SHARED_FAILURE")
+    shared: dict[tuple[str, str], tuple[str, frozenset[int]]] = {}
+    for row in rows:
+        if set(row) != {"affected_standards", "code", "dependency", "kind"}:
+            raise StandardResultsError("MALFORMED_SHARED_FAILURE")
+        affected = row["affected_standards"]
+        if (
+            row["kind"] not in {"POLICY_BLOCK", "TECHNICAL_ERROR"}
+            or not isinstance(row["code"], str)
+            or not isinstance(row["dependency"], str)
+            or not isinstance(affected, list)
+            or affected != sorted(set(affected))
+            or len(affected) < 2
+            or any(type(item) is not int or item not in range(1, 9) for item in affected)
+        ):
+            raise StandardResultsError("MALFORMED_SHARED_FAILURE")
+        owners = frozenset(affected)
+        expected = (
+            standard_block_ownership.shared_dependency(row["code"])
+            if row["kind"] == "POLICY_BLOCK"
+            else standard_block_ownership.expected_technical_dependency(
+                row["code"], row["dependency"]
+            )
+        )
+        if row["kind"] == "TECHNICAL_ERROR" and expected is None:
+            raise StandardResultsError("MALFORMED_STANDARD_TECHNICAL_OWNERSHIP")
+        if expected != (row["dependency"], owners):
+            raise StandardResultsError("MALFORMED_SHARED_FAILURE")
+        key = (row["kind"], row["code"])
+        if key in shared:
+            raise StandardResultsError("MALFORMED_SHARED_FAILURE")
+        shared[key] = (row["dependency"], owners)
+    return shared
+
+
+def _s02_claims(
+    entries: list[dict[str, Any]],
+) -> tuple[dict[str, set[int]], dict[str, set[int]]]:
+    policies: dict[str, set[int]] = {}
+    technical: dict[str, set[int]] = {}
+    for standard, row in enumerate(entries, start=1):
+        for code in row["policy_blocks"]:
+            policies.setdefault(code, set()).add(standard)
+        for code in row["technical_errors"]:
+            technical.setdefault(code, set()).add(standard)
+    return policies, technical
+
+
+def _s02_policy_ownership(
+    policies: dict[str, set[int]],
+    shared: dict[tuple[str, str], tuple[str, frozenset[int]]],
+) -> None:
+    for code, actual in policies.items():
+        intended = standard_block_ownership.shared_dependency(code)
+        if intended:
+            if shared.get(("POLICY_BLOCK", code)) != intended or frozenset(actual) != intended[1]:
+                raise StandardResultsError("MALFORMED_STANDARD_BLOCK_OWNERSHIP")
+        elif standard_block_ownership.owners(code) != frozenset(actual):
+            raise StandardResultsError("MALFORMED_STANDARD_BLOCK_OWNERSHIP")
+
+
+def _s02_technical_ownership(
+    technical: dict[str, set[int]],
+    shared: dict[tuple[str, str], tuple[str, frozenset[int]]],
+) -> None:
+    for code, actual in technical.items():
+        bound = shared.get(("TECHNICAL_ERROR", code))
+        expected = standard_block_ownership.expected_technical_dependency(
+            code, bound[0] if bound else ""
+        )
+        if expected is None or expected[1] != frozenset(actual):
+            raise StandardResultsError("MALFORMED_STANDARD_TECHNICAL_OWNERSHIP")
+        if len(actual) > 1 and bound != expected:
+            raise StandardResultsError("MALFORMED_SHARED_FAILURE")
+        if len(actual) == 1 and bound is not None:
+            raise StandardResultsError("MALFORMED_SHARED_FAILURE")
+
+
+def _s02_ownership(
+    entries: list[dict[str, Any]],
+    shared: dict[tuple[str, str], tuple[str, frozenset[int]]],
+) -> None:
+    policies, technical = _s02_claims(entries)
+    _s02_policy_ownership(policies, shared)
+    _s02_technical_ownership(technical, shared)
+    used = {("POLICY_BLOCK", code) for code in policies} | {
+        ("TECHNICAL_ERROR", code) for code in technical
+    }
+    if set(shared) - used:
+        raise StandardResultsError("MALFORMED_SHARED_FAILURE")
+
+
+def validate_payload(value: object, identity: RunIdentity | None = None) -> None:
+    """Validate exact identity, applicability, ownership, and provenance bindings."""
+    keys = {
+        "applicability_evidence",
+        "base_sha",
+        "entries",
+        "head_sha",
+        "quality_artifact",
+        "repository",
+        "repository_id",
+        "run_attempt",
+        "run_id",
+        "schema_version",
+        "shared_failures",
+        "short_task",
+        "source_outcomes",
+        "standard_sha256",
+        "workflow_sha",
+    }
+    row = _s02_exact(value, keys, "MALFORMED_STANDARD_RESULTS_ARTIFACT")
+    actual = RunIdentity(
+        row["repository"],
+        row["repository_id"],
+        row["base_sha"],
+        row["head_sha"],
+        row["workflow_sha"],
+        row["run_id"],
+        row["run_attempt"],
+    )
+    _s02_identity(actual)
+    if identity is not None and actual != identity:
+        raise StandardResultsError("STANDARD_RESULTS_IDENTITY_MISMATCH")
+    if (
+        row["schema_version"] != SCHEMA_VERSION
+        or row["standard_sha256"] != clause_inventory.STANDARD_SHA256
+        or type(row["short_task"]) is not bool
+    ):
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_ARTIFACT")
+    _s02_outcomes(row["source_outcomes"])
+    eligible_short = _s02_applicability(row["applicability_evidence"], row["short_task"])
+    if not isinstance(row["entries"], list) or len(row["entries"]) != 8:
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_ARTIFACT")
+    entries = [
+        _s02_entry(item, standard, row["short_task"])
+        for standard, item in enumerate(row["entries"], start=1)
+    ]
+    shared = _s02_shared(row["shared_failures"])
+    _s02_ownership(entries, shared)
+    if row["short_task"] is not (eligible_short and not _s02_source_uncertain(entries)):
+        raise StandardResultsError("MALFORMED_STANDARD_RESULTS_APPLICABILITY")
+    artifact = row["quality_artifact"]
+    if artifact is None:
+        if entries[6]["result"] != "TECHNICAL_FAILURE":
+            raise StandardResultsError("MALFORMED_STANDARD_RESULTS_ARTIFACT")
+    else:
+        artifact = _s02_exact(
+            artifact,
+            {"capture_sha256", "digest", "id"},
+            "MALFORMED_STANDARD_RESULTS_ARTIFACT",
+        )
+        if (
+            type(artifact["id"]) is not int
+            or artifact["id"] < 1
+            or not _s02_sha(artifact["digest"], _S02_SHA64)
+            or not _s02_sha(artifact["capture_sha256"], _S02_SHA64)
+        ):
+            raise StandardResultsError("MALFORMED_STANDARD_RESULTS_ARTIFACT")
+
+
+def review_required(payload: object) -> bool:
+    """Require advisory review only after all non-short deterministic rows pass."""
+    validate_payload(payload)
+    assert isinstance(payload, dict)
+    return not payload["short_task"] and all(row["result"] == "PASS" for row in payload["entries"])

--- a/src/supportability_gate/standard_results_enforcer.py
+++ b/src/supportability_gate/standard_results_enforcer.py
@@ -1,0 +1,88 @@
+"""Validate and enforce one row from an exact-identity Standard-results artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from supportability_gate import standard_results
+
+
+class _DuplicateJsonKeyError(ValueError):
+    pass
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value = dict(pairs)
+    if len(value) != len(pairs):
+        raise _DuplicateJsonKeyError
+    return value
+
+
+def _read_json(path: Path) -> object:
+    try:
+        content = path.read_bytes()
+    except OSError as error:
+        raise standard_results.StandardResultsError("MISSING_STANDARD_RESULTS") from error
+    try:
+        value: object = json.loads(content, object_pairs_hook=_unique_object)
+    except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateJsonKeyError) as error:
+        raise standard_results.StandardResultsError("MALFORMED_STANDARD_RESULTS") from error
+    return value
+
+
+def _identity(arguments: argparse.Namespace) -> standard_results.RunIdentity:
+    return standard_results.RunIdentity(
+        arguments.repository,
+        arguments.repository_id,
+        arguments.base_sha,
+        arguments.head_sha,
+        arguments.workflow_sha,
+        arguments.run_id,
+        arguments.run_attempt,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="supportability-standard-result-enforcer")
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--repository-id", required=True, type=int)
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--workflow-sha", required=True)
+    parser.add_argument("--run-id", required=True, type=int)
+    parser.add_argument("--run-attempt", required=True, type=int)
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--standard", required=True, type=int, choices=range(1, 9))
+    return parser
+
+
+def _entry(arguments: argparse.Namespace) -> dict[str, object]:
+    payload = _read_json(Path(arguments.input))
+    standard_results.validate_payload(payload, _identity(arguments))
+    rows = cast(dict[str, object], payload)["entries"]
+    return cast(list[dict[str, object]], rows)[int(arguments.standard) - 1]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print and enforce one independently owned Standard result."""
+    arguments = _parser().parse_args(argv)
+    try:
+        entry = _entry(arguments)
+    except standard_results.StandardResultsError as error:
+        print(error.code)
+        return 2
+    print(json.dumps(entry, ensure_ascii=False, sort_keys=True))
+    result = entry["result"]
+    return {
+        "PASS": 0,
+        "NOT_APPLICABLE_SHORT_TASK": 0,
+        "BLOCK": 1,
+        "TECHNICAL_FAILURE": 2,
+    }[cast(str, result)]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/supportability_gate/standard_results_producer.py
+++ b/src/supportability_gate/standard_results_producer.py
@@ -1,0 +1,165 @@
+"""Produce one canonical Standard-results artifact from four independent sources."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from supportability_gate import standard_results
+
+GITHUB_OUTCOMES = ("success", "failure", "cancelled", "skipped")
+SOURCE_SPECS = (
+    (
+        "complexity",
+        "complexity_result",
+        "MISSING_COMPLEXITY_RESULT",
+        "MALFORMED_COMPLEXITY_RESULT",
+    ),
+    (
+        "characterization",
+        "characterization_result",
+        "MISSING_CHARACTERIZATION_RESULT",
+        "MALFORMED_CHARACTERIZATION_RESULT",
+    ),
+    (
+        "refactor",
+        "refactor_result",
+        "MISSING_REFACTOR_RESULT",
+        "MALFORMED_REFACTOR_RESULT",
+    ),
+    (
+        "quality_provenance",
+        "quality_provenance",
+        "MISSING_QUALITY_PROVENANCE",
+        "MALFORMED_QUALITY_PROVENANCE",
+    ),
+)
+
+
+class _DuplicateJsonKeyError(ValueError):
+    pass
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value = dict(pairs)
+    if len(value) != len(pairs):
+        raise _DuplicateJsonKeyError
+    return value
+
+
+def _read_json(path: Path, missing: str, malformed: str) -> tuple[dict[str, Any], str | None]:
+    try:
+        content = path.read_bytes()
+    except FileNotFoundError:
+        return {}, missing
+    except OSError:
+        return {}, malformed
+    try:
+        value: object = json.loads(content, object_pairs_hook=_unique_object)
+    except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateJsonKeyError):
+        return {}, malformed
+    if not isinstance(value, dict):
+        return {}, malformed
+    return value, None
+
+
+def _load_sources(
+    arguments: argparse.Namespace,
+) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+    sources: dict[str, dict[str, Any]] = {}
+    errors: dict[str, str] = {}
+    for source, path_name, missing, malformed in SOURCE_SPECS:
+        value, error = _read_json(Path(getattr(arguments, path_name)), missing, malformed)
+        sources[source] = value
+        if error is not None:
+            errors[source] = error
+    return sources, errors
+
+
+def _identity(arguments: argparse.Namespace) -> standard_results.RunIdentity:
+    return standard_results.RunIdentity(
+        arguments.repository,
+        arguments.repository_id,
+        arguments.base_sha,
+        arguments.head_sha,
+        arguments.workflow_sha,
+        arguments.run_id,
+        arguments.run_attempt,
+    )
+
+
+def _outcomes(arguments: argparse.Namespace) -> dict[str, str]:
+    return {
+        "complexity": arguments.complexity_outcome,
+        "characterization": arguments.characterization_outcome,
+        "install": arguments.install_outcome,
+        "refactor": arguments.refactor_outcome,
+        "quality": arguments.quality_outcome,
+    }
+
+
+def _compose(arguments: argparse.Namespace) -> dict[str, object]:
+    sources, errors = _load_sources(arguments)
+    if arguments.install_outcome != "success":
+        errors = {"gate_install": "GATE_INSTALL_FAILURE"}
+    return standard_results.compose_results(
+        sources["complexity"],
+        sources["characterization"],
+        sources["refactor"],
+        sources["quality_provenance"],
+        _identity(arguments),
+        expected_quality_artifact={
+            "capture_sha256": arguments.expected_quality_capture_sha256,
+            "digest": arguments.expected_quality_artifact_digest,
+            "id": arguments.expected_quality_artifact_id,
+        },
+        source_outcomes=_outcomes(arguments),
+        source_errors=errors,
+    )
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True).encode() + b"\n"
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="supportability-standard-results-producer")
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--repository-id", required=True, type=int)
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--workflow-sha", required=True)
+    parser.add_argument("--run-id", required=True, type=int)
+    parser.add_argument("--run-attempt", required=True, type=int)
+    parser.add_argument("--complexity-result", required=True)
+    parser.add_argument("--characterization-result", required=True)
+    parser.add_argument("--refactor-result", required=True)
+    parser.add_argument("--quality-provenance", required=True)
+    parser.add_argument("--expected-quality-artifact-id", required=True)
+    parser.add_argument("--expected-quality-artifact-digest", required=True)
+    parser.add_argument("--expected-quality-capture-sha256", required=True)
+    parser.add_argument("--complexity-outcome", required=True, choices=GITHUB_OUTCOMES)
+    parser.add_argument("--characterization-outcome", required=True, choices=GITHUB_OUTCOMES)
+    parser.add_argument("--install-outcome", required=True, choices=GITHUB_OUTCOMES)
+    parser.add_argument("--refactor-outcome", required=True, choices=GITHUB_OUTCOMES)
+    parser.add_argument("--quality-outcome", required=True, choices=GITHUB_OUTCOMES)
+    parser.add_argument("--output", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Write authoritative results even when an individual source is unavailable."""
+    arguments = _parser().parse_args(argv)
+    payload = _compose(arguments)
+    _write_json(Path(arguments.output), payload)
+    print(str(standard_results.review_required(payload)).lower())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/characterization/standard-results-boundary.characterization.py
+++ b/tests/characterization/standard-results-boundary.characterization.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+import contextlib
+import copy
+import hashlib
+import io
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+
+
+def _write(path: Path, value: object) -> None:
+    path.write_bytes(json.dumps(value, sort_keys=True).encode())
+
+
+def _review_evidence() -> dict[str, object]:
+    return {
+        "architecture": {
+            "dependency_direction": "Dependencies point toward domain policy.",
+            "reviewed_paths": ["src/sample.py"],
+        },
+        "behavior": {"intended_behavior": "Covered behavior.", "proof": "tests/test_sample.py"},
+        "characterization": {
+            "captured_behavior": "Pre-change behavior is captured.",
+            "proof": "tests/test_sample.py",
+        },
+        "human_review": {
+            "cohesion": "Cohesive.",
+            "intended_behavior": "Intended.",
+            "naming": "Named.",
+            "reviewability": "Reviewable.",
+        },
+        "incremental_refactor": {"completed_step": "One step.", "target": "One boundary."},
+        "module_boundaries": [],
+        "responsibility_boundary": {
+            "does_not_own": "Presentation.",
+            "owns": "Sample behavior.",
+            "path": "src/sample.py",
+        },
+        "review_handoff": {"remaining_risks": ["None known."], "summary": "Ready."},
+        "schema_version": "1.0",
+        "separation_of_concerns": {"after": "One owner.", "before": "Mixed owners."},
+    }
+
+
+def _changed_file(path: str, *, status: str = "MODIFIED") -> dict[str, object]:
+    production = path.startswith("src/")
+    return {
+        "base_production": production,
+        "changed_head_lines": [7],
+        "complexity_assessed": production,
+        "head_production": production,
+        "new_path": path,
+        "old_path": None if status == "ADDED" else path,
+        "status": status,
+    }
+
+
+def _complexity(identity: Any, standard_sha256: str, path: str, status: str) -> dict[str, Any]:
+    production_paths = [path] if path.startswith("src/") else []
+    return {
+        "architecture": {
+            "adapter": "python.ast-imports.v1",
+            "blocks": [],
+            "covered_paths": production_paths,
+            "edges": [],
+            "executed": True,
+            "nodes": production_paths,
+        },
+        "base_contract_blob_sha": "1" * 40,
+        "base_sha": identity.base_sha,
+        "base_tree_sha": "c" * 40,
+        "changed_files": [_changed_file(path, status=status)],
+        "commands": [
+            {
+                "arguments": ["diff", "--name-status", identity.base_sha, identity.head_sha],
+                "exit_code": 0,
+                "stderr_sha256": "0" * 64,
+                "stdout_sha256": "1" * 64,
+                "tool": "git",
+            }
+        ],
+        "contract_path": ".supportability.toml",
+        "contract_sha256": "2" * 64,
+        "dependency_direction_explanation": "PASS: verified import graph [].",
+        "functions": [],
+        "gate_coverage": [
+            {"adapter": "python.c901-touched.v1", "paths": ["src"]},
+            {"adapter": "python.ast-imports.v1", "paths": ["src"]},
+        ],
+        "head_sha": identity.head_sha,
+        "head_tree_sha": "d" * 40,
+        "high_risk_paths": [],
+        "language": "python",
+        "modularity": {
+            "blocks": [],
+            "changed_paths": production_paths,
+            "coupling_edges": [],
+            "coverage": [],
+            "justifications": [],
+            "new_paths": [],
+        },
+        "overall_result": "PASS",
+        "policy_blocks": [],
+        "production_paths": ["src"],
+        "quality_profile": {
+            "base_sha": identity.base_sha,
+            "changed_paths": [path],
+            "commands": [
+                {
+                    "adapter": "python.pytest.v1",
+                    "arguments": ["python", "-m", "pytest", "-q"],
+                    "executed": True,
+                    "exit_code": 0,
+                    "observed_paths": ["src/sample.py"],
+                    "proof_kind": "runtime-lines",
+                    "zero_statement_paths": [],
+                }
+            ],
+            "exclusions": [],
+            "head_sha": identity.head_sha,
+            "high_risk_paths": [],
+            "language": "python",
+            "maximum_complexity": 10,
+            "production_files": ["src/sample.py"],
+            "production_paths": ["src"],
+            "repository_remote": f"github.com/{identity.repository}",
+            "schema_version": "quality-gates.v3",
+            "workflow_sha": identity.workflow_sha,
+        },
+        "rename_bindings": [],
+        "repository_remote": f"github.com/{identity.repository}",
+        "review_evidence": _review_evidence(),
+        "review_evidence_path": ".supportability-review.toml",
+        "ruff_diagnostics": [],
+        "schema_version": "1.0",
+        "standard_sha256": standard_sha256,
+        "technical_errors": [],
+        "tool_versions": {},
+        "touched_qualified_functions": [],
+    }
+
+
+def _characterization(identity: Any, path: str) -> dict[str, Any]:
+    behavior = hashlib.sha256(_canonical([["sample", "e" * 64]])).hexdigest()
+    production_paths = [path] if path.startswith("src/") else []
+    return {
+        "artifacts": {
+            "base": {"capture_sha256": "3" * 64, "digest": "4" * 64, "id": "701"},
+            "head": {"capture_sha256": "5" * 64, "digest": "6" * 64, "id": "702"},
+        },
+        "base_sha": identity.base_sha,
+        "behavior_fingerprint": behavior,
+        "coverage": {"covered_paths": production_paths, "required_paths": production_paths},
+        "head_sha": identity.head_sha,
+        "manifest_blob_sha": "8" * 40,
+        "manifest_sha256": "9" * 64,
+        "overall_result": "PASS",
+        "policy_blocks": [],
+        "repository": f"github.com/{identity.repository}",
+        "scenarios": [
+            {
+                "base_behavior_sha256": "e" * 64,
+                "command": ["python", "tests/characterization/sample.characterization.py"],
+                "compatibility": "PASS",
+                "covers": [path],
+                "golden_behavior_sha256": "e" * 64,
+                "head_behavior_sha256": "e" * 64,
+                "id": "sample",
+                "kind": "golden",
+            }
+        ],
+        "schema_version": "characterization-result.v1",
+        "workflow_sha": identity.workflow_sha,
+    }
+
+
+def _refactor(identity: Any, characterization: dict[str, Any], path: str) -> dict[str, Any]:
+    return {
+        "applicable": False,
+        "authorization": None,
+        "authorization_comment_id": None,
+        "base_sha": identity.base_sha,
+        "characterization_sha256": hashlib.sha256(_canonical(characterization)).hexdigest(),
+        "changed_paths": [path],
+        "head_sha": identity.head_sha,
+        "other_standard_clauses_waived": False,
+        "overall_result": "PASS",
+        "policy_blocks": [],
+        "repository": identity.repository,
+        "schema_version": "refactor-policy-result.v1",
+        "targets": [],
+        "unbounded_paths": [],
+    }
+
+
+def _quality(identity: Any) -> dict[str, Any]:
+    return {
+        "artifact_digest": "d" * 64,
+        "artifact_id": "789",
+        "capture_sha256": "c" * 64,
+        "commands": [
+            {
+                "adapter": "python.pytest.v1",
+                "raw_proof_sha256": "a" * 64,
+                "stderr_sha256": "b" * 64,
+                "stdout_sha256": "c" * 64,
+            }
+        ],
+        "job": "quality-profile",
+        "repository": identity.repository,
+        "repository_id": str(identity.repository_id),
+        "run_attempt": str(identity.run_attempt),
+        "run_id": str(identity.run_id),
+        "runner_environment": "github-hosted",
+    }
+
+
+def _inputs(
+    identity: Any, standard_sha256: str, path: str = "src/sample.py", status: str = "MODIFIED"
+) -> dict[str, dict[str, Any]]:
+    characterization = _characterization(identity, path)
+    return {
+        "complexity": _complexity(identity, standard_sha256, path, status),
+        "characterization": characterization,
+        "refactor": _refactor(identity, characterization, path),
+        "quality": _quality(identity),
+    }
+
+
+def _common(identity: Any) -> list[str]:
+    return [
+        "--repository",
+        identity.repository,
+        "--repository-id",
+        str(identity.repository_id),
+        "--base-sha",
+        identity.base_sha,
+        "--head-sha",
+        identity.head_sha,
+        "--workflow-sha",
+        identity.workflow_sha,
+        "--run-id",
+        str(identity.run_id),
+        "--run-attempt",
+        str(identity.run_attempt),
+    ]
+
+
+def _run_case(
+    directory: Path,
+    name: str,
+    inputs: dict[str, dict[str, Any]],
+    identity: Any,
+    producer: Any,
+    enforcer: Any,
+    standard_results: Any,
+) -> dict[str, object]:
+    source_paths = {source: directory / f"{name}-{source}.json" for source in inputs}
+    for source, value in inputs.items():
+        _write(source_paths[source], value)
+    output = directory / f"{name}-standard-results.json"
+    common = _common(identity)
+    arguments = [
+        *common,
+        "--complexity-result",
+        str(source_paths["complexity"]),
+        "--characterization-result",
+        str(source_paths["characterization"]),
+        "--refactor-result",
+        str(source_paths["refactor"]),
+        "--quality-provenance",
+        str(source_paths["quality"]),
+        "--expected-quality-artifact-id",
+        "789",
+        "--expected-quality-artifact-digest",
+        "d" * 64,
+        "--expected-quality-capture-sha256",
+        "c" * 64,
+        "--complexity-outcome",
+        "success",
+        "--characterization-outcome",
+        "success",
+        "--install-outcome",
+        "success",
+        "--refactor-outcome",
+        "success",
+        "--quality-outcome",
+        "success",
+        "--output",
+        str(output),
+    ]
+    with contextlib.redirect_stdout(io.StringIO()):
+        producer_exit = producer.main(arguments)
+        enforcer_exits = [
+            enforcer.main([*common, "--input", str(output), "--standard", str(standard)])
+            for standard in range(1, 9)
+        ]
+    payload = json.loads(output.read_bytes())
+    return {
+        "applicability_evidence": payload["applicability_evidence"],
+        "enforcer_exits": enforcer_exits,
+        "lane_failures": [
+            {
+                "policy_blocks": entry["policy_blocks"],
+                "standard": entry["standard"],
+                "technical_errors": entry["technical_errors"],
+            }
+            for entry in payload["entries"]
+            if entry["policy_blocks"] or entry["technical_errors"]
+        ],
+        "producer_exit": producer_exit,
+        "review_required": standard_results.review_required(payload),
+        "rows": [
+            {
+                "applicable": entry["applicable"],
+                "evidence_sources": entry["evidence_sources"],
+                "result": entry["result"],
+            }
+            for entry in payload["entries"]
+        ],
+        "shared_failures": payload["shared_failures"],
+        "short_task": payload["short_task"],
+    }
+
+
+def main() -> None:
+    target = Path(os.environ["SUPPORTABILITY_CHARACTERIZATION_TARGET"])
+    definition = Path(os.environ["SUPPORTABILITY_CHARACTERIZATION_DEFINITION"])
+    modules = (
+        "standard_block_ownership.py",
+        "standard_results.py",
+        "standard_results_enforcer.py",
+        "standard_results_producer.py",
+    )
+    root = (
+        target
+        if all((target / "src/supportability_gate" / name).is_file() for name in modules)
+        else definition
+    )
+    sys.path.insert(0, str(root / "src"))
+
+    from supportability_gate import (  # noqa: PLC0415
+        clause_inventory,
+        standard_results,
+        standard_results_enforcer,
+        standard_results_producer,
+    )
+
+    identity = standard_results.RunIdentity(
+        "example/repository", 123, "b" * 40, "a" * 40, "f" * 40, 456, 1
+    )
+    cases: dict[str, dict[str, dict[str, Any]]] = {}
+    cases["clean"] = _inputs(identity, clause_inventory.STANDARD_SHA256)
+
+    gate_three = copy.deepcopy(cases["clean"])
+    cycle = "IMPORT_CYCLE:src/a.py:1:src.b"
+    gate_three["complexity"]["architecture"]["blocks"] = [cycle]
+    gate_three["complexity"]["policy_blocks"] = [cycle]
+    gate_three["complexity"]["overall_result"] = "BLOCK"
+    cases["gate-3-policy"] = gate_three
+
+    gate_seven = copy.deepcopy(cases["clean"])
+    gate_seven["quality"]["artifact_digest"] = "e" * 64
+    cases["gate-7-technical"] = gate_seven
+
+    simultaneous = copy.deepcopy(gate_three)
+    simultaneous["quality"]["artifact_digest"] = "e" * 64
+    cases["simultaneous"] = simultaneous
+
+    shared_complexity = copy.deepcopy(cases["clean"])
+    shared_complexity["complexity"]["head_sha"] = "e" * 40
+    cases["shared-complexity-identity"] = shared_complexity
+
+    shared_review = copy.deepcopy(cases["clean"])
+    review_block = "MALFORMED_REVIEW_EVIDENCE:document"
+    shared_review["complexity"]["review_evidence"] = None
+    shared_review["complexity"]["policy_blocks"] = [review_block]
+    shared_review["complexity"]["overall_result"] = "BLOCK"
+    cases["shared-review-document"] = shared_review
+
+    cases["short-task"] = _inputs(
+        identity,
+        clause_inventory.STANDARD_SHA256,
+        "docs/release-note.md",
+        "ADDED",
+    )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        directory = Path(temporary)
+        behavior_cases = {
+            name: _run_case(
+                directory,
+                name,
+                inputs,
+                identity,
+                standard_results_producer,
+                standard_results_enforcer,
+                standard_results,
+            )
+            for name, inputs in cases.items()
+        }
+    behavior = {
+        "cases": behavior_cases,
+        "contexts": [
+            entry["check_context"]
+            for entry in standard_results.compose_results(
+                *cases["clean"].values(),
+                identity,
+                expected_quality_artifact={
+                    "capture_sha256": "c" * 64,
+                    "digest": "d" * 64,
+                    "id": "789",
+                },
+                source_outcomes={
+                    name: "success"
+                    for name in ("install", "complexity", "characterization", "refactor", "quality")
+                },
+            )["entries"]
+        ],
+        "schema_version": standard_results.SCHEMA_VERSION,
+    }
+    print(
+        json.dumps(
+            {
+                "behavior": behavior,
+                "scenario": "standard-results-boundary",
+                "schema_version": "1.0",
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/characterization/standard-results-boundary.characterization.py
+++ b/tests/characterization/standard-results-boundary.characterization.py
@@ -261,13 +261,24 @@ def _run_case(
     identity: Any,
     producer: Any,
     enforcer: Any,
-    standard_results: Any,
 ) -> dict[str, object]:
     source_paths = {source: directory / f"{name}-{source}.json" for source in inputs}
     for source, value in inputs.items():
         _write(source_paths[source], value)
     output = directory / f"{name}-standard-results.json"
     common = _common(identity)
+    outcomes = {
+        source: "success" if inputs[source]["overall_result"] == "PASS" else "failure"
+        for source in ("complexity", "characterization", "refactor")
+    }
+    outcomes["quality"] = (
+        "failure"
+        if any(
+            not command["executed"] or command["exit_code"]
+            for command in inputs["complexity"]["quality_profile"]["commands"]
+        )
+        else "success"
+    )
     arguments = [
         *common,
         "--complexity-result",
@@ -285,20 +296,22 @@ def _run_case(
         "--expected-quality-capture-sha256",
         "c" * 64,
         "--complexity-outcome",
-        "success",
+        outcomes["complexity"],
         "--characterization-outcome",
-        "success",
+        outcomes["characterization"],
         "--install-outcome",
         "success",
         "--refactor-outcome",
-        "success",
+        outcomes["refactor"],
         "--quality-outcome",
-        "success",
+        outcomes["quality"],
         "--output",
         str(output),
     ]
-    with contextlib.redirect_stdout(io.StringIO()):
+    producer_stdout = io.StringIO()
+    with contextlib.redirect_stdout(producer_stdout):
         producer_exit = producer.main(arguments)
+    with contextlib.redirect_stdout(io.StringIO()):
         enforcer_exits = [
             enforcer.main([*common, "--input", str(output), "--standard", str(standard)])
             for standard in range(1, 9)
@@ -317,7 +330,7 @@ def _run_case(
             if entry["policy_blocks"] or entry["technical_errors"]
         ],
         "producer_exit": producer_exit,
-        "review_required": standard_results.review_required(payload),
+        "review_required": producer_stdout.getvalue().rstrip("\n"),
         "rows": [
             {
                 "applicable": entry["applicable"],
@@ -403,7 +416,6 @@ def main() -> None:
                 identity,
                 standard_results_producer,
                 standard_results_enforcer,
-                standard_results,
             )
             for name, inputs in cases.items()
         }

--- a/tests/characterization/standard-results-boundary.golden.json
+++ b/tests/characterization/standard-results-boundary.golden.json
@@ -1,0 +1,914 @@
+{
+  "cases": {
+    "clean": {
+      "applicability_evidence": {
+        "changed_files": [
+          {
+            "base_production": true,
+            "changed_head_lines": [
+              7
+            ],
+            "complexity_assessed": true,
+            "head_production": true,
+            "new_path": "src/sample.py",
+            "old_path": "src/sample.py",
+            "status": "MODIFIED"
+          }
+        ],
+        "classification": "FULL_PROCESS",
+        "source_sha256": "5860cb7f7a9194cdbab9abdbec93468e1d8ab12876c38ebfb4068736c9075a85",
+        "source_validated": true
+      },
+      "enforcer_exits": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "lane_failures": [],
+      "producer_exit": 0,
+      "review_required": true,
+      "rows": [
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:functions",
+            "complexity-result.json:ruff_diagnostics",
+            "complexity-result.json:review_evidence.human_review"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:review_evidence.separation_of_concerns"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:architecture",
+            "complexity-result.json:dependency_direction_explanation",
+            "complexity-result.json:review_evidence.architecture"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:modularity",
+            "complexity-result.json:review_evidence.module_boundaries",
+            "complexity-result.json:review_evidence.responsibility_boundary"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "characterization-result.json",
+            "complexity-result.json:review_evidence.behavior",
+            "complexity-result.json:review_evidence.characterization"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "refactor-policy-result.json",
+            "complexity-result.json:review_evidence.incremental_refactor"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:changed_files",
+            "complexity-result.json:gate_coverage",
+            "complexity-result.json:quality_profile",
+            "quality-provenance.json"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:changed_files",
+            "complexity-result.json:review_evidence.review_handoff"
+          ],
+          "result": "PASS"
+        }
+      ],
+      "shared_failures": [],
+      "short_task": false
+    },
+    "gate-3-policy": {
+      "applicability_evidence": {
+        "changed_files": [
+          {
+            "base_production": true,
+            "changed_head_lines": [
+              7
+            ],
+            "complexity_assessed": true,
+            "head_production": true,
+            "new_path": "src/sample.py",
+            "old_path": "src/sample.py",
+            "status": "MODIFIED"
+          }
+        ],
+        "classification": "FULL_PROCESS",
+        "source_sha256": "e8875898c4ffaa7bf294a6b2fe897c50b43b6c9baf90fa6f15034e03fb4b116e",
+        "source_validated": true
+      },
+      "enforcer_exits": [
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "lane_failures": [
+        {
+          "policy_blocks": [
+            "IMPORT_CYCLE:src/a.py:1:src.b"
+          ],
+          "standard": 3,
+          "technical_errors": []
+        }
+      ],
+      "producer_exit": 0,
+      "review_required": false,
+      "rows": [
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:functions",
+            "complexity-result.json:ruff_diagnostics",
+            "complexity-result.json:review_evidence.human_review"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:review_evidence.separation_of_concerns"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:architecture",
+            "complexity-result.json:dependency_direction_explanation",
+            "complexity-result.json:review_evidence.architecture"
+          ],
+          "result": "BLOCK"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:modularity",
+            "complexity-result.json:review_evidence.module_boundaries",
+            "complexity-result.json:review_evidence.responsibility_boundary"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "characterization-result.json",
+            "complexity-result.json:review_evidence.behavior",
+            "complexity-result.json:review_evidence.characterization"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "refactor-policy-result.json",
+            "complexity-result.json:review_evidence.incremental_refactor"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:changed_files",
+            "complexity-result.json:gate_coverage",
+            "complexity-result.json:quality_profile",
+            "quality-provenance.json"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:changed_files",
+            "complexity-result.json:review_evidence.review_handoff"
+          ],
+          "result": "PASS"
+        }
+      ],
+      "shared_failures": [],
+      "short_task": false
+    },
+    "gate-7-technical": {
+      "applicability_evidence": {
+        "changed_files": [
+          {
+            "base_production": true,
+            "changed_head_lines": [
+              7
+            ],
+            "complexity_assessed": true,
+            "head_production": true,
+            "new_path": "src/sample.py",
+            "old_path": "src/sample.py",
+            "status": "MODIFIED"
+          }
+        ],
+        "classification": "FULL_PROCESS",
+        "source_sha256": "5860cb7f7a9194cdbab9abdbec93468e1d8ab12876c38ebfb4068736c9075a85",
+        "source_validated": true
+      },
+      "enforcer_exits": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        2,
+        0
+      ],
+      "lane_failures": [
+        {
+          "policy_blocks": [],
+          "standard": 7,
+          "technical_errors": [
+            "QUALITY_ARTIFACT_IDENTITY_MISMATCH"
+          ]
+        }
+      ],
+      "producer_exit": 0,
+      "review_required": false,
+      "rows": [
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:functions",
+            "complexity-result.json:ruff_diagnostics",
+            "complexity-result.json:review_evidence.human_review"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:review_evidence.separation_of_concerns"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:architecture",
+            "complexity-result.json:dependency_direction_explanation",
+            "complexity-result.json:review_evidence.architecture"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:modularity",
+            "complexity-result.json:review_evidence.module_boundaries",
+            "complexity-result.json:review_evidence.responsibility_boundary"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "characterization-result.json",
+            "complexity-result.json:review_evidence.behavior",
+            "complexity-result.json:review_evidence.characterization"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "refactor-policy-result.json",
+            "complexity-result.json:review_evidence.incremental_refactor"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:changed_files",
+            "complexity-result.json:gate_coverage",
+            "complexity-result.json:quality_profile",
+            "quality-provenance.json"
+          ],
+          "result": "TECHNICAL_FAILURE"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:changed_files",
+            "complexity-result.json:review_evidence.review_handoff"
+          ],
+          "result": "PASS"
+        }
+      ],
+      "shared_failures": [],
+      "short_task": false
+    },
+    "shared-complexity-identity": {
+      "applicability_evidence": {
+        "changed_files": [],
+        "classification": "FULL_PROCESS",
+        "source_sha256": null,
+        "source_validated": false
+      },
+      "enforcer_exits": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "lane_failures": [
+        {
+          "policy_blocks": [],
+          "standard": 1,
+          "technical_errors": [
+            "COMPLEXITY_RESULT_BINDING_MISMATCH"
+          ]
+        },
+        {
+          "policy_blocks": [],
+          "standard": 2,
+          "technical_errors": [
+            "COMPLEXITY_RESULT_BINDING_MISMATCH"
+          ]
+        },
+        {
+          "policy_blocks": [],
+          "standard": 3,
+          "technical_errors": [
+            "COMPLEXITY_RESULT_BINDING_MISMATCH"
+          ]
+        },
+        {
+          "policy_blocks": [],
+          "standard": 4,
+          "technical_errors": [
+            "COMPLEXITY_RESULT_BINDING_MISMATCH"
+          ]
+        },
+        {
+          "policy_blocks": [],
+          "standard": 5,
+          "technical_errors": [
+            "COMPLEXITY_RESULT_BINDING_MISMATCH"
+          ]
+        },
+        {
+          "policy_blocks": [],
+          "standard": 6,
+          "technical_errors": [
+            "COMPLEXITY_RESULT_BINDING_MISMATCH"
+          ]
+        },
+        {
+          "policy_blocks": [],
+          "standard": 7,
+          "technical_errors": [
+            "COMPLEXITY_RESULT_BINDING_MISMATCH"
+          ]
+        },
+        {
+          "policy_blocks": [],
+          "standard": 8,
+          "technical_errors": [
+            "COMPLEXITY_RESULT_BINDING_MISMATCH"
+          ]
+        }
+      ],
+      "producer_exit": 0,
+      "review_required": false,
+      "rows": [
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:functions",
+            "complexity-result.json:ruff_diagnostics",
+            "complexity-result.json:review_evidence.human_review"
+          ],
+          "result": "TECHNICAL_FAILURE"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:review_evidence.separation_of_concerns"
+          ],
+          "result": "TECHNICAL_FAILURE"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:architecture",
+            "complexity-result.json:dependency_direction_explanation",
+            "complexity-result.json:review_evidence.architecture"
+          ],
+          "result": "TECHNICAL_FAILURE"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:modularity",
+            "complexity-result.json:review_evidence.module_boundaries",
+            "complexity-result.json:review_evidence.responsibility_boundary"
+          ],
+          "result": "TECHNICAL_FAILURE"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "characterization-result.json",
+            "complexity-result.json:review_evidence.behavior",
+            "complexity-result.json:review_evidence.characterization"
+          ],
+          "result": "TECHNICAL_FAILURE"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "refactor-policy-result.json",
+            "complexity-result.json:review_evidence.incremental_refactor"
+          ],
+          "result": "TECHNICAL_FAILURE"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:changed_files",
+            "complexity-result.json:gate_coverage",
+            "complexity-result.json:quality_profile",
+            "quality-provenance.json"
+          ],
+          "result": "TECHNICAL_FAILURE"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:changed_files",
+            "complexity-result.json:review_evidence.review_handoff"
+          ],
+          "result": "TECHNICAL_FAILURE"
+        }
+      ],
+      "shared_failures": [
+        {
+          "affected_standards": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+          ],
+          "code": "COMPLEXITY_RESULT_BINDING_MISMATCH",
+          "dependency": "complexity-result",
+          "kind": "TECHNICAL_ERROR"
+        }
+      ],
+      "short_task": false
+    },
+    "shared-review-document": {
+      "applicability_evidence": {
+        "changed_files": [
+          {
+            "base_production": true,
+            "changed_head_lines": [
+              7
+            ],
+            "complexity_assessed": true,
+            "head_production": true,
+            "new_path": "src/sample.py",
+            "old_path": "src/sample.py",
+            "status": "MODIFIED"
+          }
+        ],
+        "classification": "FULL_PROCESS",
+        "source_sha256": "040027684bce19b67dcfcfbf7bbe8ccf86e556a151710de59747f02643468ee0",
+        "source_validated": true
+      },
+      "enforcer_exits": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1
+      ],
+      "lane_failures": [
+        {
+          "policy_blocks": [
+            "MALFORMED_REVIEW_EVIDENCE:document"
+          ],
+          "standard": 1,
+          "technical_errors": []
+        },
+        {
+          "policy_blocks": [
+            "MALFORMED_REVIEW_EVIDENCE:document"
+          ],
+          "standard": 2,
+          "technical_errors": []
+        },
+        {
+          "policy_blocks": [
+            "MALFORMED_REVIEW_EVIDENCE:document"
+          ],
+          "standard": 3,
+          "technical_errors": []
+        },
+        {
+          "policy_blocks": [
+            "MALFORMED_REVIEW_EVIDENCE:document"
+          ],
+          "standard": 4,
+          "technical_errors": []
+        },
+        {
+          "policy_blocks": [
+            "MALFORMED_REVIEW_EVIDENCE:document"
+          ],
+          "standard": 5,
+          "technical_errors": []
+        },
+        {
+          "policy_blocks": [
+            "MALFORMED_REVIEW_EVIDENCE:document"
+          ],
+          "standard": 6,
+          "technical_errors": []
+        },
+        {
+          "policy_blocks": [
+            "MALFORMED_REVIEW_EVIDENCE:document"
+          ],
+          "standard": 8,
+          "technical_errors": []
+        }
+      ],
+      "producer_exit": 0,
+      "review_required": false,
+      "rows": [
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:functions",
+            "complexity-result.json:ruff_diagnostics",
+            "complexity-result.json:review_evidence.human_review"
+          ],
+          "result": "BLOCK"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:review_evidence.separation_of_concerns"
+          ],
+          "result": "BLOCK"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:architecture",
+            "complexity-result.json:dependency_direction_explanation",
+            "complexity-result.json:review_evidence.architecture"
+          ],
+          "result": "BLOCK"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:modularity",
+            "complexity-result.json:review_evidence.module_boundaries",
+            "complexity-result.json:review_evidence.responsibility_boundary"
+          ],
+          "result": "BLOCK"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "characterization-result.json",
+            "complexity-result.json:review_evidence.behavior",
+            "complexity-result.json:review_evidence.characterization"
+          ],
+          "result": "BLOCK"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "refactor-policy-result.json",
+            "complexity-result.json:review_evidence.incremental_refactor"
+          ],
+          "result": "BLOCK"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:changed_files",
+            "complexity-result.json:gate_coverage",
+            "complexity-result.json:quality_profile",
+            "quality-provenance.json"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:changed_files",
+            "complexity-result.json:review_evidence.review_handoff"
+          ],
+          "result": "BLOCK"
+        }
+      ],
+      "shared_failures": [
+        {
+          "affected_standards": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            8
+          ],
+          "code": "MALFORMED_REVIEW_EVIDENCE:document",
+          "dependency": "structured-review-document",
+          "kind": "POLICY_BLOCK"
+        }
+      ],
+      "short_task": false
+    },
+    "short-task": {
+      "applicability_evidence": {
+        "changed_files": [
+          {
+            "base_production": false,
+            "changed_head_lines": [
+              7
+            ],
+            "complexity_assessed": false,
+            "head_production": false,
+            "new_path": "docs/release-note.md",
+            "old_path": null,
+            "status": "ADDED"
+          }
+        ],
+        "classification": "SHORT_TASK",
+        "source_sha256": "a13b193d84d5b6df3109862eaefeb568b2cca9f674d2a8209a23a780bc7476cc",
+        "source_validated": true
+      },
+      "enforcer_exits": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "lane_failures": [],
+      "producer_exit": 0,
+      "review_required": false,
+      "rows": [
+        {
+          "applicable": false,
+          "evidence_sources": [
+            "complexity-result.json:functions",
+            "complexity-result.json:ruff_diagnostics",
+            "complexity-result.json:review_evidence.human_review"
+          ],
+          "result": "NOT_APPLICABLE_SHORT_TASK"
+        },
+        {
+          "applicable": false,
+          "evidence_sources": [
+            "complexity-result.json:review_evidence.separation_of_concerns"
+          ],
+          "result": "NOT_APPLICABLE_SHORT_TASK"
+        },
+        {
+          "applicable": false,
+          "evidence_sources": [
+            "complexity-result.json:architecture",
+            "complexity-result.json:dependency_direction_explanation",
+            "complexity-result.json:review_evidence.architecture"
+          ],
+          "result": "NOT_APPLICABLE_SHORT_TASK"
+        },
+        {
+          "applicable": false,
+          "evidence_sources": [
+            "complexity-result.json:modularity",
+            "complexity-result.json:review_evidence.module_boundaries",
+            "complexity-result.json:review_evidence.responsibility_boundary"
+          ],
+          "result": "NOT_APPLICABLE_SHORT_TASK"
+        },
+        {
+          "applicable": false,
+          "evidence_sources": [
+            "characterization-result.json",
+            "complexity-result.json:review_evidence.behavior",
+            "complexity-result.json:review_evidence.characterization"
+          ],
+          "result": "NOT_APPLICABLE_SHORT_TASK"
+        },
+        {
+          "applicable": false,
+          "evidence_sources": [
+            "refactor-policy-result.json",
+            "complexity-result.json:review_evidence.incremental_refactor"
+          ],
+          "result": "NOT_APPLICABLE_SHORT_TASK"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:changed_files",
+            "complexity-result.json:gate_coverage",
+            "complexity-result.json:quality_profile",
+            "quality-provenance.json"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": false,
+          "evidence_sources": [
+            "complexity-result.json:changed_files",
+            "complexity-result.json:review_evidence.review_handoff"
+          ],
+          "result": "NOT_APPLICABLE_SHORT_TASK"
+        }
+      ],
+      "shared_failures": [],
+      "short_task": true
+    },
+    "simultaneous": {
+      "applicability_evidence": {
+        "changed_files": [
+          {
+            "base_production": true,
+            "changed_head_lines": [
+              7
+            ],
+            "complexity_assessed": true,
+            "head_production": true,
+            "new_path": "src/sample.py",
+            "old_path": "src/sample.py",
+            "status": "MODIFIED"
+          }
+        ],
+        "classification": "FULL_PROCESS",
+        "source_sha256": "e8875898c4ffaa7bf294a6b2fe897c50b43b6c9baf90fa6f15034e03fb4b116e",
+        "source_validated": true
+      },
+      "enforcer_exits": [
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        2,
+        0
+      ],
+      "lane_failures": [
+        {
+          "policy_blocks": [
+            "IMPORT_CYCLE:src/a.py:1:src.b"
+          ],
+          "standard": 3,
+          "technical_errors": []
+        },
+        {
+          "policy_blocks": [],
+          "standard": 7,
+          "technical_errors": [
+            "QUALITY_ARTIFACT_IDENTITY_MISMATCH"
+          ]
+        }
+      ],
+      "producer_exit": 0,
+      "review_required": false,
+      "rows": [
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:functions",
+            "complexity-result.json:ruff_diagnostics",
+            "complexity-result.json:review_evidence.human_review"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:review_evidence.separation_of_concerns"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:architecture",
+            "complexity-result.json:dependency_direction_explanation",
+            "complexity-result.json:review_evidence.architecture"
+          ],
+          "result": "BLOCK"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:modularity",
+            "complexity-result.json:review_evidence.module_boundaries",
+            "complexity-result.json:review_evidence.responsibility_boundary"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "characterization-result.json",
+            "complexity-result.json:review_evidence.behavior",
+            "complexity-result.json:review_evidence.characterization"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "refactor-policy-result.json",
+            "complexity-result.json:review_evidence.incremental_refactor"
+          ],
+          "result": "PASS"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:changed_files",
+            "complexity-result.json:gate_coverage",
+            "complexity-result.json:quality_profile",
+            "quality-provenance.json"
+          ],
+          "result": "TECHNICAL_FAILURE"
+        },
+        {
+          "applicable": true,
+          "evidence_sources": [
+            "complexity-result.json:changed_files",
+            "complexity-result.json:review_evidence.review_handoff"
+          ],
+          "result": "PASS"
+        }
+      ],
+      "shared_failures": [],
+      "short_task": false
+    }
+  },
+  "contexts": [
+    "Supportability 1 - Cyclomatic Complexity",
+    "Supportability 2 - Separation of Concerns",
+    "Supportability 3 - Dependency Direction",
+    "Supportability 4 - Domain Modularity",
+    "Supportability 5 - Characterization",
+    "Supportability 6 - Incremental Refactor",
+    "Supportability 7 - Quality Gates",
+    "Supportability 8 - Review Handoff"
+  ],
+  "schema_version": "standard-results.v2"
+}

--- a/tests/characterization/standard-results-boundary.golden.json
+++ b/tests/characterization/standard-results-boundary.golden.json
@@ -31,7 +31,7 @@
       ],
       "lane_failures": [],
       "producer_exit": 0,
-      "review_required": true,
+      "review_required": "true",
       "rows": [
         {
           "applicable": true,
@@ -145,7 +145,7 @@
         }
       ],
       "producer_exit": 0,
-      "review_required": false,
+      "review_required": "false",
       "rows": [
         {
           "applicable": true,
@@ -259,7 +259,7 @@
         }
       ],
       "producer_exit": 0,
-      "review_required": false,
+      "review_required": "false",
       "rows": [
         {
           "applicable": true,
@@ -410,7 +410,7 @@
         }
       ],
       "producer_exit": 0,
-      "review_required": false,
+      "review_required": "false",
       "rows": [
         {
           "applicable": true,
@@ -582,7 +582,7 @@
         }
       ],
       "producer_exit": 0,
-      "review_required": false,
+      "review_required": "false",
       "rows": [
         {
           "applicable": true,
@@ -703,7 +703,7 @@
       ],
       "lane_failures": [],
       "producer_exit": 0,
-      "review_required": false,
+      "review_required": "false",
       "rows": [
         {
           "applicable": false,
@@ -824,7 +824,7 @@
         }
       ],
       "producer_exit": 0,
-      "review_required": false,
+      "review_required": "false",
       "rows": [
         {
           "applicable": true,

--- a/tests/test_evaluate_complexity.py
+++ b/tests/test_evaluate_complexity.py
@@ -1071,7 +1071,12 @@ def test_syntax_error_is_technical_failure(tmp_path: Path) -> None:
     exit_code, result = _evaluate(repository, base_sha, head_sha, tmp_path / "result")
 
     assert exit_code == 2
-    assert result["technical_errors"][0]["code"] == "SYNTAX_ERROR"
+    assert [item["code"] for item in result["technical_errors"]] == [
+        "COMPLEXITY_SYNTAX_ERROR",
+        "ARCHITECTURE_SYNTAX_ERROR",
+    ]
+    assert result["quality_profile"] is not None
+    assert (tmp_path / "result" / "quality-provenance.json").is_file()
 
 
 def test_ruff_parity_mismatch_is_technical_failure(tmp_path: Path) -> None:

--- a/tests/test_standard_results.py
+++ b/tests/test_standard_results.py
@@ -1,31 +1,1125 @@
-from pathlib import Path
+from __future__ import annotations
 
-WORKFLOW = (Path(__file__).parents[1] / ".github/workflows/organization-required.yml").read_text(
-    encoding="utf-8"
+import copy
+import hashlib
+import json
+import re
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from supportability_gate import (
+    clause_inventory,
+    standard_block_ownership,
+    standard_results,
+    standard_results_enforcer,
+    standard_results_producer,
 )
+
+IDENTITY = standard_results.RunIdentity(
+    "example/repository", 123, "b" * 40, "a" * 40, "f" * 40, 456, 1
+)
+SUCCESS_OUTCOMES = {
+    "install": "success",
+    "complexity": "success",
+    "characterization": "success",
+    "refactor": "success",
+    "quality": "success",
+}
+EXPECTED_QUALITY_ARTIFACT = {
+    "capture_sha256": "c" * 64,
+    "digest": "d" * 64,
+    "id": "789",
+}
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+
+
+def _review_evidence() -> dict[str, object]:
+    return {
+        "architecture": {
+            "dependency_direction": "Dependencies point toward domain policy.",
+            "reviewed_paths": ["src/sample.py"],
+        },
+        "behavior": {"intended_behavior": "Covered behavior.", "proof": "tests/test_sample.py"},
+        "characterization": {
+            "captured_behavior": "Pre-change behavior is captured.",
+            "proof": "tests/test_sample.py",
+        },
+        "human_review": {
+            "cohesion": "Cohesive.",
+            "intended_behavior": "Intended.",
+            "naming": "Named.",
+            "reviewability": "Reviewable.",
+        },
+        "incremental_refactor": {"completed_step": "One step.", "target": "One boundary."},
+        "module_boundaries": [],
+        "responsibility_boundary": {
+            "does_not_own": "Presentation.",
+            "owns": "Sample behavior.",
+            "path": "src/sample.py",
+        },
+        "review_handoff": {"remaining_risks": ["None known."], "summary": "Ready."},
+        "schema_version": "1.0",
+        "separation_of_concerns": {"after": "One owner.", "before": "Mixed owners."},
+    }
+
+
+def _changed_file(path: str, lines: list[int], *, status: str = "MODIFIED") -> dict[str, object]:
+    production = path.startswith("src/")
+    return {
+        "base_production": production,
+        "changed_head_lines": lines,
+        "complexity_assessed": production,
+        "head_production": production,
+        "new_path": path,
+        "old_path": None if status == "ADDED" else path,
+        "status": status,
+    }
+
+
+def _complexity(
+    path: str = "src/sample.py",
+    lines: list[int] | None = None,
+    *,
+    status: str = "MODIFIED",
+) -> dict[str, Any]:
+    lines = lines or [1]
+    return {
+        "architecture": {
+            "adapter": "python.ast-imports.v1",
+            "blocks": [],
+            "covered_paths": [path] if path.startswith("src/") else [],
+            "edges": [],
+            "executed": True,
+            "nodes": [path] if path.startswith("src/") else [],
+        },
+        "base_contract_blob_sha": "1" * 40,
+        "base_sha": IDENTITY.base_sha,
+        "base_tree_sha": "c" * 40,
+        "changed_files": [_changed_file(path, lines, status=status)],
+        "commands": [
+            {
+                "arguments": ["diff", "--name-status", IDENTITY.base_sha, IDENTITY.head_sha],
+                "exit_code": 0,
+                "stderr_sha256": "0" * 64,
+                "stdout_sha256": "1" * 64,
+                "tool": "git",
+            }
+        ],
+        "contract_path": ".supportability.toml",
+        "contract_sha256": "2" * 64,
+        "dependency_direction_explanation": "PASS: verified import graph [].",
+        "functions": [],
+        "gate_coverage": [
+            {"adapter": "python.c901-touched.v1", "paths": ["src"]},
+            {"adapter": "python.ast-imports.v1", "paths": ["src"]},
+        ],
+        "head_sha": IDENTITY.head_sha,
+        "head_tree_sha": "d" * 40,
+        "high_risk_paths": [],
+        "language": "python",
+        "modularity": {
+            "blocks": [],
+            "changed_paths": [path] if path.startswith("src/") else [],
+            "coupling_edges": [],
+            "coverage": [],
+            "justifications": [],
+            "new_paths": [],
+        },
+        "overall_result": "PASS",
+        "policy_blocks": [],
+        "production_paths": ["src"],
+        "quality_profile": {
+            "base_sha": IDENTITY.base_sha,
+            "changed_paths": [path],
+            "commands": [
+                {
+                    "adapter": "python.pytest.v1",
+                    "arguments": ["python", "-m", "pytest", "-q"],
+                    "executed": True,
+                    "exit_code": 0,
+                    "observed_paths": ["src/sample.py"],
+                    "proof_kind": "runtime-lines",
+                    "zero_statement_paths": [],
+                }
+            ],
+            "exclusions": [],
+            "head_sha": IDENTITY.head_sha,
+            "high_risk_paths": [],
+            "language": "python",
+            "maximum_complexity": 10,
+            "production_files": ["src/sample.py"],
+            "production_paths": ["src"],
+            "repository_remote": f"github.com/{IDENTITY.repository}",
+            "schema_version": "quality-gates.v3",
+            "workflow_sha": IDENTITY.workflow_sha,
+        },
+        "rename_bindings": [],
+        "repository_remote": f"github.com/{IDENTITY.repository}",
+        "review_evidence": _review_evidence(),
+        "review_evidence_path": ".supportability-review.toml",
+        "ruff_diagnostics": [],
+        "schema_version": "1.0",
+        "standard_sha256": clause_inventory.STANDARD_SHA256,
+        "technical_errors": [],
+        "tool_versions": {},
+        "touched_qualified_functions": [],
+    }
+
+
+def _characterization(path: str = "src/sample.py") -> dict[str, Any]:
+    return {
+        "artifacts": {
+            "base": {"capture_sha256": "3" * 64, "digest": "4" * 64, "id": "701"},
+            "head": {"capture_sha256": "5" * 64, "digest": "6" * 64, "id": "702"},
+        },
+        "base_sha": IDENTITY.base_sha,
+        "behavior_fingerprint": hashlib.sha256(_canonical([["sample", "e" * 64]])).hexdigest(),
+        "coverage": {
+            "covered_paths": [path] if path.startswith("src/") else [],
+            "required_paths": [path] if path.startswith("src/") else [],
+        },
+        "head_sha": IDENTITY.head_sha,
+        "manifest_blob_sha": "8" * 40,
+        "manifest_sha256": "9" * 64,
+        "overall_result": "PASS",
+        "policy_blocks": [],
+        "repository": f"github.com/{IDENTITY.repository}",
+        "scenarios": [
+            {
+                "base_behavior_sha256": "e" * 64,
+                "command": ["python", "tests/characterization/sample.characterization.py"],
+                "compatibility": "PASS",
+                "covers": ["src/sample.py"],
+                "golden_behavior_sha256": "e" * 64,
+                "head_behavior_sha256": "e" * 64,
+                "id": "sample",
+                "kind": "golden",
+            }
+        ],
+        "schema_version": "characterization-result.v1",
+        "workflow_sha": IDENTITY.workflow_sha,
+    }
+
+
+def _refactor(characterization: dict[str, Any], path: str) -> dict[str, Any]:
+    return {
+        "applicable": False,
+        "authorization": None,
+        "authorization_comment_id": None,
+        "base_sha": IDENTITY.base_sha,
+        "characterization_sha256": hashlib.sha256(_canonical(characterization)).hexdigest(),
+        "changed_paths": [path],
+        "head_sha": IDENTITY.head_sha,
+        "other_standard_clauses_waived": False,
+        "overall_result": "PASS",
+        "policy_blocks": [],
+        "repository": IDENTITY.repository,
+        "schema_version": "refactor-policy-result.v1",
+        "targets": [],
+        "unbounded_paths": [],
+    }
+
+
+def _quality() -> dict[str, Any]:
+    return {
+        "artifact_digest": "d" * 64,
+        "artifact_id": "789",
+        "capture_sha256": "c" * 64,
+        "commands": [
+            {
+                "adapter": "python.pytest.v1",
+                "raw_proof_sha256": "a" * 64,
+                "stderr_sha256": "b" * 64,
+                "stdout_sha256": "c" * 64,
+            }
+        ],
+        "job": "quality-profile",
+        "repository": IDENTITY.repository,
+        "repository_id": str(IDENTITY.repository_id),
+        "run_attempt": str(IDENTITY.run_attempt),
+        "run_id": str(IDENTITY.run_id),
+        "runner_environment": "github-hosted",
+    }
+
+
+def _inputs(
+    path: str = "src/sample.py",
+    lines: list[int] | None = None,
+    *,
+    status: str = "MODIFIED",
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    complexity = _complexity(path, lines, status=status)
+    characterization = _characterization(path)
+    return complexity, characterization, _refactor(characterization, path), _quality()
+
+
+def _compose(
+    inputs: tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]],
+    *,
+    source_errors: dict[str, str] | None = None,
+    source_outcomes: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    return standard_results.compose_results(
+        *inputs,
+        IDENTITY,
+        expected_quality_artifact=EXPECTED_QUALITY_ARTIFACT,
+        source_errors=source_errors,
+        source_outcomes=source_outcomes or SUCCESS_OUTCOMES,
+    )
+
+
+def _results(payload: dict[str, Any]) -> list[str]:
+    return [entry["result"] for entry in payload["entries"]]
+
+
+def _entry(payload: dict[str, Any], standard: int) -> dict[str, Any]:
+    return payload["entries"][standard - 1]
+
+
+def _technical_standards(payload: dict[str, Any]) -> set[int]:
+    return {
+        standard
+        for standard, entry in enumerate(payload["entries"], start=1)
+        if entry["result"] == "TECHNICAL_FAILURE"
+    }
+
+
+def test_clean_current_aggregate_schema_passes_without_prototype_standard_blocks() -> None:
+    inputs = _inputs()
+    payload = _compose(inputs)
+
+    assert "standard_blocks" not in inputs[0]
+    assert _results(payload) == ["PASS"] * 8
+    assert payload["applicability_evidence"] == {
+        "changed_files": inputs[0]["changed_files"],
+        "classification": "FULL_PROCESS",
+        "source_sha256": hashlib.sha256(_canonical(inputs[0])).hexdigest(),
+        "source_validated": True,
+    }
+    assert standard_results.validate_payload(payload, IDENTITY) is None
+    assert standard_results.review_required(payload) is True
+
+
+def test_current_refactor_schema_has_exact_boolean_applicable() -> None:
+    inputs = _inputs()
+
+    payload = _compose(inputs)
+
+    assert inputs[2]["applicable"] is False
+    assert _entry(payload, 6)["result"] == "PASS"
+
+
+def test_quality_artifact_has_exact_authenticated_identity() -> None:
+    payload = _compose(_inputs())
+
+    assert payload["quality_artifact"] == {
+        "capture_sha256": "c" * 64,
+        "digest": "d" * 64,
+        "id": 789,
+    }
+    forged = copy.deepcopy(payload)
+    forged["quality_artifact"]["id"] = True
+    with pytest.raises(standard_results.StandardResultsError):
+        standard_results.validate_payload(forged, IDENTITY)
+
+
+@pytest.mark.parametrize("field", ["repository_id", "run_id", "run_attempt"])
+def test_boolean_identity_numbers_are_rejected(field: str) -> None:
+    identity = replace(IDENTITY, **{field: True})
+
+    with pytest.raises(
+        standard_results.StandardResultsError,
+        match="MALFORMED_STANDARD_RESULTS_IDENTITY",
+    ):
+        standard_results.compose_results(
+            *_inputs(),
+            identity,
+            expected_quality_artifact=EXPECTED_QUALITY_ARTIFACT,
+            source_outcomes=SUCCESS_OUTCOMES,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("standard", True), ("applicable", 1)],
+)
+def test_boolean_or_integer_row_spoofs_are_rejected(field: str, value: object) -> None:
+    payload = _compose(_inputs())
+    payload["entries"][0][field] = value
+
+    with pytest.raises(standard_results.StandardResultsError):
+        standard_results.validate_payload(payload, IDENTITY)
+
+
+def test_gate_three_cycle_blocks_only_gate_three() -> None:
+    inputs = _inputs()
+    block = "IMPORT_CYCLE:src/a.py:1:src.b"
+    inputs[0]["architecture"]["blocks"] = [block]
+    inputs[0]["policy_blocks"] = [block]
+    inputs[0]["overall_result"] = "BLOCK"
+
+    payload = _compose(inputs)
+
+    assert _results(payload) == ["PASS", "PASS", "BLOCK", *("PASS",) * 5]
+    assert _entry(payload, 3)["policy_blocks"] == [block]
+
+
+def test_quality_provenance_binding_mismatch_is_gate_seven_technical_only() -> None:
+    inputs = _inputs()
+    inputs[3]["run_id"] = "999"
+
+    payload = _compose(inputs)
+
+    assert _results(payload) == [*("PASS",) * 6, "TECHNICAL_FAILURE", "PASS"]
+    assert "QUALITY_RESULT_BINDING_MISMATCH" in _entry(payload, 7)["technical_errors"]
+
+
+@pytest.mark.parametrize(
+    ("field", "poison"),
+    [
+        ("artifact_id", "790"),
+        ("artifact_digest", "e" * 64),
+        ("capture_sha256", "f" * 64),
+    ],
+)
+def test_valid_looking_quality_artifact_poison_is_gate_seven_technical_only(
+    field: str, poison: str
+) -> None:
+    inputs = _inputs()
+    inputs[3][field] = poison
+
+    payload = _compose(inputs)
+
+    assert _results(payload) == [*("PASS",) * 6, "TECHNICAL_FAILURE", "PASS"]
+    assert _entry(payload, 7)["technical_errors"] == ["QUALITY_ARTIFACT_IDENTITY_MISMATCH"]
+    assert payload["quality_artifact"] is None
+
+
+def test_simultaneous_gate_three_and_gate_seven_poisons_remain_independent() -> None:
+    inputs = _inputs()
+    block = "IMPORT_CYCLE:src/a.py:1:src.b"
+    inputs[0]["architecture"]["blocks"] = [block]
+    inputs[0]["policy_blocks"] = [block]
+    inputs[0]["overall_result"] = "BLOCK"
+    inputs[3]["run_id"] = "999"
+
+    payload = _compose(inputs)
+
+    assert _results(payload) == [
+        "PASS",
+        "PASS",
+        "BLOCK",
+        "PASS",
+        "PASS",
+        "PASS",
+        "TECHNICAL_FAILURE",
+        "PASS",
+    ]
+
+
+def test_unmapped_aggregate_analyzer_error_stays_with_aggregate_owners() -> None:
+    inputs = _inputs()
+    inputs[0]["technical_errors"] = [{"code": "SYNTAX_ERROR", "message": "invalid syntax"}]
+    inputs[0]["overall_result"] = "TECHNICAL_FAILURE"
+
+    payload = _compose(inputs)
+
+    expected = {1, 2, 3, 4, 7, 8}
+    code = "COMPLEXITY_RESULT:SYNTAX_ERROR"
+    assert _technical_standards(payload) == expected
+    assert _entry(payload, 5)["result"] == "PASS"
+    assert _entry(payload, 6)["result"] == "PASS"
+    assert payload["shared_failures"] == [
+        {
+            "affected_standards": sorted(expected),
+            "code": code,
+            "dependency": "complexity-result:technical-errors",
+            "kind": "TECHNICAL_ERROR",
+        }
+    ]
+
+
+def test_wrong_source_block_affects_source_dependents_and_claimed_owner_only() -> None:
+    inputs = _inputs()
+    block = "IMPORT_CYCLE:src/a.py:1:src.b"
+    inputs[1]["policy_blocks"] = [block]
+    inputs[1]["overall_result"] = "BLOCK"
+    inputs[2]["characterization_sha256"] = hashlib.sha256(_canonical(inputs[1])).hexdigest()
+
+    payload = _compose(inputs)
+
+    expected = {3, 5, 6}
+    code = f"STANDARD_BLOCK_SOURCE_MISMATCH:{block}"
+    assert _technical_standards(payload) == expected
+    assert payload["shared_failures"] == [
+        {
+            "affected_standards": sorted(expected),
+            "code": code,
+            "dependency": "characterization-result:policy-blocks",
+            "kind": "TECHNICAL_ERROR",
+        }
+    ]
+
+
+def test_malformed_shared_review_document_names_only_affected_lanes() -> None:
+    inputs = _inputs()
+    inputs[0]["review_evidence"] = None
+    inputs[0]["policy_blocks"] = ["MALFORMED_REVIEW_EVIDENCE:document"]
+    inputs[0]["overall_result"] = "BLOCK"
+
+    payload = _compose(inputs)
+
+    assert _results(payload) == [*("BLOCK",) * 6, "PASS", "BLOCK"]
+    assert payload["shared_failures"] == [
+        {
+            "affected_standards": [1, 2, 3, 4, 5, 6, 8],
+            "code": "MALFORMED_REVIEW_EVIDENCE:document",
+            "dependency": "structured-review-document",
+            "kind": "POLICY_BLOCK",
+        }
+    ]
+
+
+def test_unknown_root_review_key_is_shared_document_defect() -> None:
+    block = "MALFORMED_REVIEW_EVIDENCE:review_evidence.unexpected"
+    expected = frozenset({1, 2, 3, 4, 5, 6, 8})
+
+    assert standard_block_ownership.review_owners(block) == expected
+    assert standard_block_ownership.shared_dependency(block) == (
+        "structured-review-document",
+        expected,
+    )
+
+
+@pytest.mark.parametrize(
+    "code",
+    ["PROFILE_NODE_MISMATCH", "MCCABE_GRAPH_MISMATCH", "MISSING_FUNCTION_BODY"],
+)
+def test_metric_technical_failures_belong_only_to_gate_one(code: str) -> None:
+    rendered = f"COMPLEXITY_RESULT:{code}"
+
+    assert standard_block_ownership.technical_owners(rendered) == frozenset({1})
+    assert standard_block_ownership.expected_technical_dependency(rendered, "") == (
+        "complexity-result:technical-errors",
+        frozenset({1}),
+    )
+
+
+def test_review_location_kind_must_be_emittable() -> None:
+    impossible = "MISSING_REVIEW_EVIDENCE:architecture.not_a_field"
+    emitted = "MALFORMED_REVIEW_EVIDENCE:architecture.not_a_field"
+
+    assert standard_block_ownership.review_owners(impossible) == frozenset()
+    assert standard_block_ownership.shared_dependency(impossible) is None
+    assert standard_block_ownership.review_owners(emitted) == frozenset({3})
+
+
+def test_one_added_document_line_is_authenticated_short_task() -> None:
+    inputs = _inputs("docs/release-note.md", [7], status="ADDED")
+    payload = _compose(inputs)
+
+    assert payload["short_task"] is True
+    assert payload["applicability_evidence"] == {
+        "changed_files": inputs[0]["changed_files"],
+        "classification": "SHORT_TASK",
+        "source_sha256": hashlib.sha256(_canonical(inputs[0])).hexdigest(),
+        "source_validated": True,
+    }
+    assert _results(payload) == [
+        *("NOT_APPLICABLE_SHORT_TASK",) * 6,
+        "PASS",
+        "NOT_APPLICABLE_SHORT_TASK",
+    ]
+    assert "quality-provenance.json" in _entry(payload, 7)["evidence_sources"]
+    assert payload["source_outcomes"]["quality"] == "success"
+    assert standard_results.review_required(payload) is False
+
+
+def test_corrupt_complexity_binding_cannot_authenticate_short_task() -> None:
+    inputs = _inputs("docs/release-note.md", [7], status="ADDED")
+    inputs[0]["head_sha"] = "e" * 40
+
+    payload = _compose(inputs)
+
+    assert payload["short_task"] is False
+    assert payload["applicability_evidence"]["classification"] == "FULL_PROCESS"
+    assert payload["applicability_evidence"]["source_validated"] is False
+    assert _technical_standards(payload) == set(range(1, 9))
+    assert payload["shared_failures"] == [
+        {
+            "affected_standards": list(range(1, 9)),
+            "code": "COMPLEXITY_RESULT_BINDING_MISMATCH",
+            "dependency": "complexity-result",
+            "kind": "TECHNICAL_ERROR",
+        }
+    ]
+
+
+def test_forged_short_results_are_rejected_by_applicability_evidence() -> None:
+    payload = _compose(_inputs())
+    payload["short_task"] = True
+    for standard, entry in enumerate(payload["entries"], start=1):
+        if standard == 7:
+            continue
+        entry["applicable"] = False
+        entry["result"] = "NOT_APPLICABLE_SHORT_TASK"
+
+    with pytest.raises(
+        standard_results.StandardResultsError,
+        match="MALFORMED_STANDARD_RESULTS_APPLICABILITY",
+    ):
+        standard_results.validate_payload(payload, IDENTITY)
+
+
+@pytest.mark.parametrize(
+    ("path", "lines"),
+    [
+        ("README.md", [1]),
+        ("README.md", [1, 2]),
+        ("docs/architecture.md", [1]),
+        ("docs/architecture.md", [1, 2, 3]),
+        ("docs/supportability_standard.md", [1]),
+        ("docs/fixed_roadmap.md", [1]),
+        ("docs/product_completion_contract.md", [1]),
+    ],
+)
+def test_uncertain_or_broad_docs_default_to_full_process(path: str, lines: list[int]) -> None:
+    payload = _compose(_inputs(path, lines))
+
+    assert payload["short_task"] is False
+    assert _results(payload) == ["PASS"] * 8
+    assert standard_results.review_required(payload) is True
+
+
+@pytest.mark.parametrize(
+    ("case", "expected", "code", "dependency"),
+    [
+        ("architecture", set(range(1, 9)), "MALFORMED_COMPLEXITY_RESULT", "complexity-result"),
+        ("modularity", set(range(1, 9)), "MALFORMED_COMPLEXITY_RESULT", "complexity-result"),
+        ("review", set(range(1, 9)), "MALFORMED_COMPLEXITY_RESULT", "complexity-result"),
+        (
+            "aggregate_commands",
+            set(range(1, 9)),
+            "MALFORMED_COMPLEXITY_RESULT",
+            "complexity-result",
+        ),
+        ("quality_profile", set(range(1, 9)), "MALFORMED_COMPLEXITY_RESULT", "complexity-result"),
+        (
+            "characterization",
+            {5, 6},
+            "MALFORMED_CHARACTERIZATION_RESULT",
+            "characterization-result",
+        ),
+        ("refactor", {6}, "MALFORMED_REFACTOR_RESULT", None),
+        ("quality_provenance", {7}, "MALFORMED_QUALITY_RESULT_BINDING", None),
+    ],
+)
+def test_missing_critical_source_fields_fail_closed(
+    case: str,
+    expected: set[int],
+    code: str,
+    dependency: str | None,
+) -> None:
+    inputs = _inputs()
+    if case in {"architecture", "modularity"}:
+        inputs[0].pop(case)
+    elif case == "review":
+        inputs[0].pop("review_evidence")
+    elif case == "aggregate_commands":
+        inputs[0].pop("commands")
+    elif case == "quality_profile":
+        inputs[0]["quality_profile"].pop("commands")
+    elif case == "characterization":
+        inputs[1].pop("scenarios")
+    elif case == "refactor":
+        inputs[2].pop("applicable")
+    else:
+        inputs[3].pop("commands")
+
+    payload = _compose(inputs)
+
+    assert _technical_standards(payload) == expected
+    assert all(_entry(payload, standard)["technical_errors"] == [code] for standard in expected)
+    if dependency:
+        assert payload["shared_failures"] == [
+            {
+                "affected_standards": sorted(expected),
+                "code": code,
+                "dependency": dependency,
+                "kind": "TECHNICAL_ERROR",
+            }
+        ]
+
+
+@pytest.mark.parametrize("case", ["unknown", "duplicate", "stale", "spoofed", "misbound"])
+def test_malformed_result_artifacts_fail_closed(case: str) -> None:
+    payload = copy.deepcopy(_compose(_inputs()))
+    if case == "unknown":
+        payload["unknown"] = True
+    elif case == "duplicate":
+        payload["entries"][1] = copy.deepcopy(payload["entries"][0])
+    elif case == "stale":
+        payload["head_sha"] = "e" * 40
+    elif case == "spoofed":
+        payload["entries"][0]["policy_blocks"] = ["IMPORT_CYCLE:src/a.py:1:src.b"]
+        payload["entries"][0]["result"] = "BLOCK"
+    else:
+        payload["repository_id"] = 999
+
+    with pytest.raises(standard_results.StandardResultsError):
+        standard_results.validate_payload(payload, IDENTITY)
+
+
+def test_malformed_shared_failure_set_fails_closed() -> None:
+    inputs = _inputs()
+    inputs[0]["review_evidence"] = None
+    inputs[0]["policy_blocks"] = ["MALFORMED_REVIEW_EVIDENCE:document"]
+    inputs[0]["overall_result"] = "BLOCK"
+    payload = _compose(inputs)
+    payload["shared_failures"][0]["affected_standards"] = [1, 2, 3]
+
+    with pytest.raises(standard_results.StandardResultsError):
+        standard_results.validate_payload(payload, IDENTITY)
+
+
+def test_gate_seven_technical_error_cannot_be_moved_to_another_lane() -> None:
+    payload = _quality_failure_payload()
+    quality_error = _entry(payload, 7)["technical_errors"].pop()
+    _entry(payload, 7)["result"] = "PASS"
+    _entry(payload, 1)["technical_errors"] = [quality_error]
+    _entry(payload, 1)["result"] = "TECHNICAL_FAILURE"
+    payload["quality_artifact"] = _compose(_inputs())["quality_artifact"]
+
+    with pytest.raises(
+        standard_results.StandardResultsError,
+        match="MALFORMED_STANDARD_TECHNICAL_OWNERSHIP",
+    ):
+        standard_results.validate_payload(payload, IDENTITY)
+
+
+def test_copied_generic_technical_error_across_rows_is_rejected() -> None:
+    payload = _compose(_inputs())
+    code = "GENERIC_TECHNICAL_FAILURE"
+    for entry in payload["entries"]:
+        entry["technical_errors"] = [code]
+        entry["result"] = "TECHNICAL_FAILURE"
+    payload["shared_failures"] = [
+        {
+            "affected_standards": list(range(1, 9)),
+            "code": code,
+            "dependency": "complexity-result",
+            "kind": "TECHNICAL_ERROR",
+        }
+    ]
+
+    with pytest.raises(
+        standard_results.StandardResultsError,
+        match="MALFORMED_STANDARD_TECHNICAL_OWNERSHIP",
+    ):
+        standard_results.validate_payload(payload, IDENTITY)
+
+
+def test_forged_shared_dependency_is_rejected_even_when_rows_match() -> None:
+    inputs = _inputs()
+    block = "MALFORMED_REVIEW_EVIDENCE:document"
+    inputs[0]["review_evidence"] = None
+    inputs[0]["policy_blocks"] = [block]
+    inputs[0]["overall_result"] = "BLOCK"
+    payload = _compose(inputs)
+    payload["shared_failures"][0]["dependency"] = "forged-dependency"
+
+    with pytest.raises(
+        standard_results.StandardResultsError,
+        match="MALFORMED_SHARED_FAILURE",
+    ):
+        standard_results.validate_payload(payload, IDENTITY)
+
+
+def test_synchronized_shared_ownership_spoof_is_rejected() -> None:
+    payload = _compose(_inputs())
+    block = "IMPORT_CYCLE:src/a.py:1:src.b"
+    for standard in (3, 4):
+        _entry(payload, standard)["policy_blocks"] = [block]
+        _entry(payload, standard)["result"] = "BLOCK"
+    payload["shared_failures"] = [
+        {
+            "affected_standards": [3, 4],
+            "code": block,
+            "dependency": "forged-dependency",
+            "kind": "POLICY_BLOCK",
+        }
+    ]
+
+    with pytest.raises(
+        standard_results.StandardResultsError,
+        match="MALFORMED_SHARED_FAILURE",
+    ):
+        standard_results.validate_payload(payload, IDENTITY)
+
+
+def _enforcer_arguments(path: Path, standard: int) -> list[str]:
+    return [
+        "--repository",
+        IDENTITY.repository,
+        "--repository-id",
+        str(IDENTITY.repository_id),
+        "--base-sha",
+        IDENTITY.base_sha,
+        "--head-sha",
+        IDENTITY.head_sha,
+        "--workflow-sha",
+        IDENTITY.workflow_sha,
+        "--run-id",
+        str(IDENTITY.run_id),
+        "--run-attempt",
+        str(IDENTITY.run_attempt),
+        "--input",
+        str(path),
+        "--standard",
+        str(standard),
+    ]
+
+
+def test_exact_result_artifact_identity_mismatch_is_shared_via_enforcer(tmp_path: Path) -> None:
+    payload = _compose(_inputs())
+    payload["head_sha"] = "e" * 40
+    path = tmp_path / "standard-results.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert {
+        standard_results_enforcer.main(_enforcer_arguments(path, standard))
+        for standard in range(1, 9)
+    } == {2}
+
+
+def _producer_arguments(tmp_path: Path) -> tuple[list[str], dict[str, Path], Path]:
+    inputs = _inputs()
+    sources = {
+        "complexity": inputs[0],
+        "characterization": inputs[1],
+        "refactor": inputs[2],
+        "quality": inputs[3],
+    }
+    paths: dict[str, Path] = {}
+    for source, value in sources.items():
+        path = tmp_path / f"{source}.json"
+        path.write_text(json.dumps(value), encoding="utf-8")
+        paths[source] = path
+    output = tmp_path / "standard-results.json"
+    return (
+        [
+            "--repository",
+            IDENTITY.repository,
+            "--repository-id",
+            str(IDENTITY.repository_id),
+            "--base-sha",
+            IDENTITY.base_sha,
+            "--head-sha",
+            IDENTITY.head_sha,
+            "--workflow-sha",
+            IDENTITY.workflow_sha,
+            "--run-id",
+            str(IDENTITY.run_id),
+            "--run-attempt",
+            str(IDENTITY.run_attempt),
+            "--install-outcome",
+            "success",
+            "--expected-quality-artifact-id",
+            EXPECTED_QUALITY_ARTIFACT["id"],
+            "--expected-quality-artifact-digest",
+            EXPECTED_QUALITY_ARTIFACT["digest"],
+            "--expected-quality-capture-sha256",
+            EXPECTED_QUALITY_ARTIFACT["capture_sha256"],
+            "--complexity-result",
+            str(paths["complexity"]),
+            "--characterization-result",
+            str(paths["characterization"]),
+            "--refactor-result",
+            str(paths["refactor"]),
+            "--quality-provenance",
+            str(paths["quality"]),
+            "--complexity-outcome",
+            "success",
+            "--characterization-outcome",
+            "success",
+            "--refactor-outcome",
+            "success",
+            "--quality-outcome",
+            "success",
+            "--output",
+            str(output),
+        ],
+        paths,
+        output,
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_technical", "code", "dependency"),
+    [
+        (
+            "complexity",
+            set(range(1, 9)),
+            "MISSING_COMPLEXITY_RESULT",
+            "complexity-result",
+        ),
+        (
+            "characterization",
+            {5, 6},
+            "MISSING_CHARACTERIZATION_RESULT",
+            "characterization-result",
+        ),
+        ("refactor", {6}, "MISSING_REFACTOR_RESULT", None),
+        ("quality", {7}, "MISSING_QUALITY_PROVENANCE", None),
+    ],
+)
+def test_producer_missing_inputs_have_independent_outcomes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    source: str,
+    expected_technical: set[int],
+    code: str,
+    dependency: str | None,
+) -> None:
+    arguments, paths, output = _producer_arguments(tmp_path)
+    paths[source].unlink()
+    arguments[arguments.index(f"--{source}-outcome") + 1] = "failure"
+
+    assert standard_results_producer.main(arguments) == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert capsys.readouterr().out.strip() == "false"
+    assert _technical_standards(payload) == expected_technical
+    assert payload["source_outcomes"][source] == "failure"
+    assert all(
+        entry["result"] == "PASS"
+        for standard, entry in enumerate(payload["entries"], start=1)
+        if standard not in expected_technical
+    )
+    assert all(
+        _entry(payload, standard)["technical_errors"] == [code] for standard in expected_technical
+    )
+    if dependency:
+        assert payload["shared_failures"] == [
+            {
+                "affected_standards": sorted(expected_technical),
+                "code": code,
+                "dependency": dependency,
+                "kind": "TECHNICAL_ERROR",
+            }
+        ]
+
+
+def test_missing_characterization_suppresses_derived_refactor_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    arguments, paths, output = _producer_arguments(tmp_path)
+    paths["characterization"].unlink()
+    paths["refactor"].unlink()
+    for source in ("characterization", "refactor"):
+        arguments[arguments.index(f"--{source}-outcome") + 1] = "failure"
+
+    assert standard_results_producer.main(arguments) == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert capsys.readouterr().out.strip() == "false"
+    assert _technical_standards(payload) == {5, 6}
+    assert payload["shared_failures"] == [
+        {
+            "affected_standards": [5, 6],
+            "code": "MISSING_CHARACTERIZATION_RESULT",
+            "dependency": "characterization-result",
+            "kind": "TECHNICAL_ERROR",
+        }
+    ]
+    assert all(
+        "MISSING_REFACTOR_RESULT" not in entry["technical_errors"] for entry in payload["entries"]
+    )
+
+
+def test_install_failure_suppresses_all_derived_source_errors(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    arguments, paths, output = _producer_arguments(tmp_path)
+    for path in paths.values():
+        path.unlink()
+    arguments[arguments.index("--install-outcome") + 1] = "failure"
+    for source in ("complexity", "characterization", "refactor", "quality"):
+        arguments[arguments.index(f"--{source}-outcome") + 1] = "skipped"
+
+    assert standard_results_producer.main(arguments) == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert capsys.readouterr().out.strip() == "false"
+    assert _technical_standards(payload) == set(range(1, 9))
+    assert payload["shared_failures"] == [
+        {
+            "affected_standards": list(range(1, 9)),
+            "code": "GATE_INSTALL_FAILURE",
+            "dependency": "gate-install",
+            "kind": "TECHNICAL_ERROR",
+        }
+    ]
+    assert payload["quality_artifact"] is None
+    assert {code for entry in payload["entries"] for code in entry["technical_errors"]} == {
+        "GATE_INSTALL_FAILURE"
+    }
+
+
+def _duplicate_root_key(value: dict[str, Any]) -> str:
+    key = next(iter(value))
+    return f"{json.dumps(value)[:-1]}, {json.dumps(key)}: null}}"
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_technical", "code"),
+    [
+        ("complexity", set(range(1, 9)), "MALFORMED_COMPLEXITY_RESULT"),
+        ("characterization", {5, 6}, "MALFORMED_CHARACTERIZATION_RESULT"),
+        ("refactor", {6}, "MALFORMED_REFACTOR_RESULT"),
+        ("quality", {7}, "MALFORMED_QUALITY_PROVENANCE"),
+    ],
+)
+def test_producer_rejects_duplicate_json_keys(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    source: str,
+    expected_technical: set[int],
+    code: str,
+) -> None:
+    arguments, paths, output = _producer_arguments(tmp_path)
+    value = json.loads(paths[source].read_text(encoding="utf-8"))
+    paths[source].write_text(_duplicate_root_key(value), encoding="utf-8")
+
+    assert standard_results_producer.main(arguments) == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert capsys.readouterr().out.strip() == "false"
+    assert _technical_standards(payload) == expected_technical
+    assert all(
+        _entry(payload, standard)["technical_errors"] == [code] for standard in expected_technical
+    )
+
+
+def test_non_success_outcome_does_not_override_valid_lane_evidence() -> None:
+    outcomes = dict(SUCCESS_OUTCOMES)
+    outcomes["quality"] = "failure"
+
+    payload = _compose(_inputs(), source_outcomes=outcomes)
+
+    assert _results(payload) == ["PASS"] * 8
+    assert payload["source_outcomes"] == outcomes
+
+
+def _cycle_payload() -> dict[str, Any]:
+    inputs = _inputs()
+    block = "IMPORT_CYCLE:src/a.py:1:src.b"
+    inputs[0]["architecture"]["blocks"] = [block]
+    inputs[0]["policy_blocks"] = [block]
+    inputs[0]["overall_result"] = "BLOCK"
+    return _compose(inputs)
+
+
+def _quality_failure_payload() -> dict[str, Any]:
+    inputs = _inputs()
+    inputs[3]["run_id"] = "999"
+    return _compose(inputs)
+
+
+@pytest.mark.parametrize(
+    ("payload_factory", "standard", "expected"),
+    [
+        (lambda: _compose(_inputs()), 1, 0),
+        (_cycle_payload, 3, 1),
+        (_cycle_payload, 1, 0),
+        (_quality_failure_payload, 7, 2),
+        (_quality_failure_payload, 1, 0),
+        (lambda: _compose(_inputs("docs/release-note.md", [1], status="ADDED")), 1, 0),
+    ],
+)
+def test_enforcer_exit_codes(
+    tmp_path: Path, payload_factory: Any, standard: int, expected: int
+) -> None:
+    path = tmp_path / "standard-results.json"
+    path.write_text(json.dumps(payload_factory()), encoding="utf-8")
+
+    assert standard_results_enforcer.main(_enforcer_arguments(path, standard)) == expected
+
+
+def test_enforcer_malformed_artifact_exits_technical(tmp_path: Path) -> None:
+    path = tmp_path / "standard-results.json"
+    path.write_text("{}", encoding="utf-8")
+
+    assert standard_results_enforcer.main(_enforcer_arguments(path, 1)) == 2
+
+
+def test_enforcer_duplicate_json_key_exits_technical(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = tmp_path / "standard-results.json"
+    path.write_text(_duplicate_root_key(_compose(_inputs())), encoding="utf-8")
+
+    assert standard_results_enforcer.main(_enforcer_arguments(path, 1)) == 2
+    assert capsys.readouterr().out.strip() == "MALFORMED_STANDARD_RESULTS"
 
 
 def _job(name: str, next_name: str | None) -> str:
-    body = WORKFLOW.split(f"\n  {name}:\n", 1)[1]
+    workflow = (
+        Path(__file__).parents[1] / ".github/workflows/organization-required.yml"
+    ).read_text(encoding="utf-8")
+    body = workflow.split(f"\n  {name}:\n", 1)[1]
     return body.split(f"\n  {next_name}:\n", 1)[0] if next_name else body
 
 
-def test_connector_collection_is_separate_from_deterministic_evidence() -> None:
-    connector = _job("collect-codex-review", "characterize-base")
-    deterministic = _job("deterministic-evidence", "supportability-gate")
-
-    assert "needs: observe-codex-review" in connector
-    assert "require_focused_completion" in connector
-    assert "observe-codex-review" not in deterministic
-    assert "require_focused_completion" not in deterministic
-
-
-def test_required_gate_binds_connector_and_deterministic_results() -> None:
+def test_workflow_wires_conditional_reviews_independent_matrix_and_final_gate() -> None:
+    quality = _job("quality-profile", "deterministic-evidence")
+    evidence = _job("deterministic-evidence", "observe-codex-review")
+    observer = _job("observe-codex-review", "collect-codex-review")
+    connector = _job("collect-codex-review", "standard-results")
+    matrix = _job("standard-results", "supportability-gate")
     gate = _job("supportability-gate", None)
 
+    assert "capture-outcome: ${{ steps.capture.outcome }}" in quality
+    assert "id: capture\n        continue-on-error: true" in quality
+    assert "id: upload\n        if: always()" in quality
+    assert 'exit "$status"' in quality
+    assert "review-required: ${{ steps.standard_results.outputs.review-required }}" in evidence
+    assert "python -P -m supportability_gate.standard_results_producer" in evidence
+    assert '--install-outcome "${{ steps.install.outcome }}"' in evidence
+    assert '--quality-outcome "${{ needs.quality-profile.outputs.capture-outcome }}"' in evidence
+    assert (
+        '--expected-quality-artifact-id "${{ needs.quality-profile.outputs.artifact-id }}"'
+        in evidence
+    )
+    assert (
+        '--expected-quality-artifact-digest "${{ needs.quality-profile.outputs.artifact-digest }}"'
+        in evidence
+    )
+    assert (
+        '--expected-quality-capture-sha256 "${{ needs.quality-profile.outputs.capture-sha256 }}"'
+        in evidence
+    )
+    condition = "needs.deterministic-evidence.outputs.review-required == 'true'"
+    assert condition in observer
+    assert condition in connector
+    rows = re.findall(r"(?m)^          - standard: ([1-8])\n            context: (.+)$", matrix)
+    assert rows == [
+        (str(standard), context)
+        for standard, context in enumerate(standard_results.CHECK_CONTEXTS, start=1)
+    ]
+    assert "fail-fast: false" in matrix
+    assert "python -P -m supportability_gate.standard_results_enforcer" in matrix
+    assert "if: always()" in matrix
     assert "name: Supportability Gate" in gate
-    assert "needs: [collect-codex-review, deterministic-evidence]" in gate
-    assert "CONNECTOR_RESULT: ${{ needs.collect-codex-review.result }}" in gate
-    assert "DETERMINISTIC_RESULT: ${{ needs.deterministic-evidence.result }}" in gate
-    assert 'for result in "$CONNECTOR_RESULT" "$DETERMINISTIC_RESULT"; do' in gate
-    assert 'if [ "$result" != "success" ]; then status=1; fi' in gate
+    assert "standard-results" in gate
+    assert "REVIEW_REQUIRED: ${{ needs.deterministic-evidence.outputs.review-required }}" in gate
+    assert "STANDARD_RESULTS_RESULT: ${{ needs.standard-results.result }}" in gate
+    assert "COLLECTOR_RESULT: ${{ needs.collect-codex-review.result }}" in gate
+    assert 'if [ "$OBSERVER_RESULT" != "skipped" ]' in gate
+    assert '[ "$COLLECTOR_RESULT" != "skipped" ]' in gate

--- a/tests/test_standard_results.py
+++ b/tests/test_standard_results.py
@@ -4,6 +4,7 @@ import copy
 import hashlib
 import json
 import re
+import subprocess
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,9 @@ import pytest
 
 from supportability_gate import (
     clause_inventory,
+    cli,
+    contract,
+    git_changes,
     standard_block_ownership,
     standard_results,
     standard_results_enforcer,
@@ -265,12 +269,24 @@ def _compose(
     source_errors: dict[str, str] | None = None,
     source_outcomes: dict[str, str] | None = None,
 ) -> dict[str, Any]:
+    if source_outcomes is None:
+        source_outcomes = dict(SUCCESS_OUTCOMES)
+        for source, value in zip(("complexity", "characterization", "refactor"), inputs[:3]):
+            source_outcomes[source] = (
+                "success" if value.get("overall_result") == "PASS" else "failure"
+            )
+        profile = inputs[0].get("quality_profile")
+        if isinstance(profile, dict) and any(
+            not command["executed"] or command["exit_code"]
+            for command in profile.get("commands", [])
+        ):
+            source_outcomes["quality"] = "failure"
     return standard_results.compose_results(
         *inputs,
         IDENTITY,
         expected_quality_artifact=EXPECTED_QUALITY_ARTIFACT,
         source_errors=source_errors,
-        source_outcomes=source_outcomes or SUCCESS_OUTCOMES,
+        source_outcomes=source_outcomes,
     )
 
 
@@ -427,14 +443,22 @@ def test_unmapped_aggregate_analyzer_error_stays_with_aggregate_owners() -> None
     inputs = _inputs()
     inputs[0]["technical_errors"] = [{"code": "SYNTAX_ERROR", "message": "invalid syntax"}]
     inputs[0]["overall_result"] = "TECHNICAL_FAILURE"
+    for field in ("architecture", "modularity"):
+        inputs[0][field] = None
 
     payload = _compose(inputs)
 
     expected = {1, 2, 3, 4, 7, 8}
     code = "COMPLEXITY_RESULT:SYNTAX_ERROR"
     assert _technical_standards(payload) == expected
+    assert all(_entry(payload, standard)["technical_errors"] == [code] for standard in expected)
     assert _entry(payload, 5)["result"] == "PASS"
     assert _entry(payload, 6)["result"] == "PASS"
+    assert payload["quality_artifact"] == {
+        "capture_sha256": "c" * 64,
+        "digest": "d" * 64,
+        "id": 789,
+    }
     assert payload["shared_failures"] == [
         {
             "affected_standards": sorted(expected),
@@ -443,6 +467,74 @@ def test_unmapped_aggregate_analyzer_error_stays_with_aggregate_owners() -> None
             "kind": "TECHNICAL_ERROR",
         }
     ]
+
+    mixed = copy.deepcopy(inputs)
+    mixed[0]["architecture"] = {"invalid": True}
+    mixed_payload = _compose(mixed)
+    assert _technical_standards(mixed_payload) == set(range(1, 9))
+    assert all(
+        entry["technical_errors"] == ["MALFORMED_COMPLEXITY_RESULT"]
+        for entry in mixed_payload["entries"]
+    )
+
+    isolated = copy.deepcopy(inputs)
+    isolated[0]["technical_errors"] = [
+        {"code": "MCCABE_GRAPH_MISMATCH", "message": "graph mismatch"}
+    ]
+    isolated[0]["architecture"] = _complexity()["architecture"]
+    isolated[0]["modularity"] = _complexity()["modularity"]
+    isolated_payload = _compose(isolated)
+    assert _technical_standards(isolated_payload) == {1}
+    assert _entry(isolated_payload, 1)["technical_errors"] == [
+        "COMPLEXITY_RESULT:MCCABE_GRAPH_MISMATCH"
+    ]
+    assert _entry(isolated_payload, 7)["result"] == "PASS"
+    assert isolated_payload["quality_artifact"] == {
+        "capture_sha256": "c" * 64,
+        "digest": "d" * 64,
+        "id": 789,
+    }
+    assert standard_results.validate_payload(isolated_payload, IDENTITY) is None
+
+    for field in ("changed_files", "commands", "gate_coverage", "quality_profile"):
+        forged = copy.deepcopy(isolated)
+        forged[0][field] = None if field == "quality_profile" else []
+        forged_payload = _compose(forged)
+        assert _technical_standards(forged_payload) == set(range(1, 9))
+        assert all(
+            entry["technical_errors"] == ["MALFORMED_COMPLEXITY_RESULT"]
+            for entry in forged_payload["entries"]
+        )
+
+    quality = _inputs()
+    quality[0]["technical_errors"] = [
+        {"code": "MISSING_QUALITY_EVIDENCE", "message": "quality evidence missing"}
+    ]
+    quality[0]["overall_result"] = "TECHNICAL_FAILURE"
+    quality[0]["modularity"] = None
+    quality[0]["quality_profile"] = None
+    quality_payload = _compose(quality)
+    assert _technical_standards(quality_payload) == {4, 7}
+
+    simultaneous = copy.deepcopy(quality)
+    simultaneous[0]["technical_errors"].insert(
+        0, {"code": "MCCABE_GRAPH_MISMATCH", "message": "graph mismatch"}
+    )
+    simultaneous_payload = _compose(simultaneous)
+    assert _technical_standards(simultaneous_payload) == {1, 4, 7}
+
+    syntax = _inputs()
+    syntax[0]["technical_errors"] = [
+        {"code": "COMPLEXITY_SYNTAX_ERROR", "message": "invalid syntax"},
+        {"code": "ARCHITECTURE_SYNTAX_ERROR", "message": "invalid syntax"},
+    ]
+    syntax[0]["overall_result"] = "TECHNICAL_FAILURE"
+    syntax[0]["architecture"] = None
+    syntax[0]["modularity"] = None
+    syntax_payload = _compose(syntax)
+    assert _technical_standards(syntax_payload) == {1, 3, 4}
+    assert _entry(syntax_payload, 7)["result"] == "PASS"
+    assert _entry(syntax_payload, 8)["result"] == "PASS"
 
 
 def test_wrong_source_block_affects_source_dependents_and_claimed_owner_only() -> None:
@@ -484,6 +576,17 @@ def test_malformed_shared_review_document_names_only_affected_lanes() -> None:
             "kind": "POLICY_BLOCK",
         }
     ]
+
+    subset = _inputs()
+    subset[0]["review_evidence"] = None
+    subset[0]["policy_blocks"] = ["INSUFFICIENT_REVIEW_EVIDENCE:separation_of_concerns.before"]
+    subset[0]["overall_result"] = "BLOCK"
+    subset_payload = _compose(subset)
+    assert _technical_standards(subset_payload) == set(range(1, 9))
+    assert all(
+        entry["technical_errors"] == ["MALFORMED_COMPLEXITY_RESULT"]
+        for entry in subset_payload["entries"]
+    )
 
 
 def test_unknown_root_review_key_is_shared_document_defect() -> None:
@@ -539,6 +642,188 @@ def test_one_added_document_line_is_authenticated_short_task() -> None:
     assert "quality-provenance.json" in _entry(payload, 7)["evidence_sources"]
     assert payload["source_outcomes"]["quality"] == "success"
     assert standard_results.review_required(payload) is False
+
+
+def test_cli_captures_one_added_document_line_without_broadening_other_files(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "target"
+    repository.mkdir()
+
+    def git(*arguments: str) -> str:
+        completed = subprocess.run(
+            ["git", *arguments],
+            cwd=repository,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return completed.stdout.strip()
+
+    git("init", "--initial-branch=main")
+    git("config", "user.name", "Fixture")
+    git("config", "user.email", "fixture@example.invalid")
+    git("config", "core.autocrlf", "false")
+    git("remote", "add", "origin", "https://github.com/example/repository.git")
+    (repository / "notes.txt").write_text("base\n", encoding="utf-8")
+    git("add", "--all")
+    git("commit", "-m", "base")
+    base_sha = git("rev-parse", "HEAD")
+
+    document = repository / "docs" / "release-note.md"
+    document.parent.mkdir()
+    document.write_text("release\n", encoding="utf-8")
+    git("add", "--all")
+    git("commit", "-m", "document")
+    document_sha = git("rev-parse", "HEAD")
+
+    policy = contract.parse_contract(
+        (Path(__file__).parents[1] / ".supportability.toml").read_bytes()
+    )
+    records: list[git_changes.CommandRecord] = []
+    identity = git_changes.inspect_repository(repository, base_sha, document_sha, records)
+    assessments = cli._classify_changes(
+        repository,
+        identity,
+        policy,
+        git_changes.changed_paths(repository, base_sha, document_sha, records),
+        records,
+    )
+
+    assert assessments[0].changed_head_lines == (1,)
+    inputs = _inputs("docs/release-note.md", [1], status="ADDED")
+    inputs[0]["changed_files"] = [
+        {
+            "base_production": assessments[0].base_production,
+            "changed_head_lines": list(assessments[0].changed_head_lines),
+            "complexity_assessed": assessments[0].complexity_assessed,
+            "head_production": assessments[0].head_production,
+            "new_path": assessments[0].change.new_path,
+            "old_path": assessments[0].change.old_path,
+            "status": assessments[0].change.status,
+        }
+    ]
+    assert _compose(inputs)["short_task"] is True
+
+    (repository / "notes.txt").write_text("head\n", encoding="utf-8")
+    git("add", "--all")
+    git("commit", "-m", "broad file")
+    broad_sha = git("rev-parse", "HEAD")
+    records = []
+    identity = git_changes.inspect_repository(repository, document_sha, broad_sha, records)
+    broad = cli._classify_changes(
+        repository,
+        identity,
+        policy,
+        git_changes.changed_paths(repository, document_sha, broad_sha, records),
+        records,
+    )
+
+    assert broad[0].change.new_path == "notes.txt"
+    assert broad[0].changed_head_lines == ()
+
+
+@pytest.mark.parametrize(
+    ("source", "outcome", "code", "expected"),
+    [
+        ("complexity", "failure", "MALFORMED_COMPLEXITY_RESULT", set(range(1, 9))),
+        ("complexity", "cancelled", "MALFORMED_COMPLEXITY_RESULT", set(range(1, 9))),
+        ("complexity", "skipped", "MALFORMED_COMPLEXITY_RESULT", set(range(1, 9))),
+        (
+            "characterization",
+            "failure",
+            "MALFORMED_CHARACTERIZATION_RESULT",
+            {5, 6},
+        ),
+        ("refactor", "failure", "MALFORMED_REFACTOR_RESULT", {6}),
+        ("quality", "failure", "MALFORMED_QUALITY_PROVENANCE", {7}),
+    ],
+)
+def test_completed_passing_source_requires_success_outcome(
+    source: str,
+    outcome: str,
+    code: str,
+    expected: set[int],
+    tmp_path: Path,
+) -> None:
+    outcomes = dict(SUCCESS_OUTCOMES)
+    outcomes[source] = outcome
+
+    payload = _compose(_inputs(), source_outcomes=outcomes)
+
+    assert _technical_standards(payload) == expected
+    assert all(_entry(payload, standard)["technical_errors"] == [code] for standard in expected)
+
+    forged = _compose(_inputs())
+    forged["source_outcomes"][source] = outcome
+    path = tmp_path / f"forged-{source}-{outcome}.json"
+    path.write_text(json.dumps(forged), encoding="utf-8")
+    assert standard_results_enforcer.main(_enforcer_arguments(path, 1)) == 2
+
+
+def test_blocked_refactor_source_requires_failure_and_remains_a_policy_block() -> None:
+    inputs = _inputs()
+    block = "MISSING_OWNER_AUTHORIZATION"
+    inputs[2]["policy_blocks"] = [block]
+    inputs[2]["overall_result"] = "BLOCK"
+    outcomes = dict(SUCCESS_OUTCOMES)
+    outcomes["refactor"] = "failure"
+
+    payload = _compose(inputs, source_outcomes=outcomes)
+
+    assert _entry(payload, 6)["result"] == "BLOCK"
+    assert _entry(payload, 6)["policy_blocks"] == [block]
+    assert _technical_standards(payload) == set()
+
+    mismatched = _compose(inputs, source_outcomes=SUCCESS_OUTCOMES)
+    assert _entry(mismatched, 6)["technical_errors"] == ["MALFORMED_REFACTOR_RESULT"]
+
+
+def test_failed_quality_capture_authenticates_its_gate_seven_block() -> None:
+    inputs = _inputs()
+    block = "QUALITY_GATE_FAILED:python.pytest.v1"
+    inputs[0]["quality_profile"]["commands"][0]["exit_code"] = 1
+    inputs[0]["policy_blocks"] = [block]
+    inputs[0]["overall_result"] = "BLOCK"
+
+    payload = _compose(inputs)
+
+    assert _entry(payload, 7)["result"] == "BLOCK"
+    assert _entry(payload, 7)["policy_blocks"] == [block]
+    assert _technical_standards(payload) == set()
+
+
+def test_failed_quality_capture_without_gate_seven_block_is_malformed() -> None:
+    inputs = _inputs()
+    inputs[0]["quality_profile"]["commands"][0]["exit_code"] = 1
+    outcomes = dict(SUCCESS_OUTCOMES)
+    outcomes["quality"] = "failure"
+
+    payload = _compose(inputs, source_outcomes=outcomes)
+
+    assert _technical_standards(payload) == set(range(1, 9))
+    assert all(
+        entry["technical_errors"] == ["MALFORMED_COMPLEXITY_RESULT"] for entry in payload["entries"]
+    )
+
+
+def test_short_task_ignores_irrelevant_characterization_and_refactor_outcomes() -> None:
+    outcomes = dict(SUCCESS_OUTCOMES)
+    outcomes["characterization"] = "cancelled"
+    outcomes["refactor"] = "skipped"
+
+    payload = _compose(
+        _inputs("docs/release-note.md", [1], status="ADDED"),
+        source_outcomes=outcomes,
+    )
+
+    assert payload["short_task"] is True
+    assert _results(payload) == [
+        *("NOT_APPLICABLE_SHORT_TASK",) * 6,
+        "PASS",
+        "NOT_APPLICABLE_SHORT_TASK",
+    ]
 
 
 def test_corrupt_complexity_binding_cannot_authenticate_short_task() -> None:
@@ -1007,16 +1292,6 @@ def test_producer_rejects_duplicate_json_keys(
     )
 
 
-def test_non_success_outcome_does_not_override_valid_lane_evidence() -> None:
-    outcomes = dict(SUCCESS_OUTCOMES)
-    outcomes["quality"] = "failure"
-
-    payload = _compose(_inputs(), source_outcomes=outcomes)
-
-    assert _results(payload) == ["PASS"] * 8
-    assert payload["source_outcomes"] == outcomes
-
-
 def _cycle_payload() -> dict[str, Any]:
     inputs = _inputs()
     block = "IMPORT_CYCLE:src/a.py:1:src.b"
@@ -1092,7 +1367,26 @@ def test_workflow_wires_conditional_reviews_independent_matrix_and_final_gate() 
     assert "review-required: ${{ steps.standard_results.outputs.review-required }}" in evidence
     assert "python -P -m supportability_gate.standard_results_producer" in evidence
     assert '--install-outcome "${{ steps.install.outcome }}"' in evidence
-    assert '--quality-outcome "${{ needs.quality-profile.outputs.capture-outcome }}"' in evidence
+    download_quality = evidence.split("- name: Download authenticated quality evidence", 1)[
+        1
+    ].split("- name: Read back GitHub artifact metadata", 1)[0]
+    artifact_metadata = evidence.split("- name: Read back GitHub artifact metadata", 1)[1].split(
+        "- name: Verify exact behavior characterization", 1
+    )[0]
+    assert "continue-on-error: true" in download_quality
+    assert "continue-on-error: true" in artifact_metadata
+    evaluate = evidence.split("- name: Evaluate immutable pull-request commits", 1)[1].split(
+        "- name: Compose eight independently enforceable results", 1
+    )[0]
+    assert "if: ${{ always() && steps.install.outcome == 'success' }}" in evaluate
+    assert "steps.download_quality.outcome == 'success'" not in evaluate
+    assert "steps.artifact_metadata.outcome == 'success'" not in evaluate
+    assert (
+        "--quality-outcome \"${{ needs.quality-profile.outputs.capture-outcome != 'success' "
+        "&& needs.quality-profile.outputs.capture-outcome || "
+        "steps.download_quality.outcome != 'success' && steps.download_quality.outcome || "
+        'steps.artifact_metadata.outcome }}"' in evidence
+    )
     assert (
         '--expected-quality-artifact-id "${{ needs.quality-profile.outputs.artifact-id }}"'
         in evidence


### PR DESCRIPTION
Closes #145

Implements Project #10 S02 only:
- composes and validates eight independently owned deterministic lane results;
- isolates policy and technical poison while naming exact shared dependencies;
- authenticates the narrow one-line added-document short path;
- binds Gate 7 quality provenance to trusted workflow artifact identity;
- conditionally runs advisory Codex review and retains the aggregate Supportability Gate.

Local exact-head proof on `51e5a824d64eb91c03a413fefef643ad00b71974`:
- Python 3.12.13 exact-lock Ruff lint/format/C901, strict mypy, and Import Linter passed;
- 299 tests passed with 2 skips; focused S02 packet 71 passed;
- compileall, wheel build, fresh exact-lock install, installed CLI help, immutable-Standard tamper test, and exact diff check passed;
- immutable Standard SHA-256 remains `81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2`.

Excluded: S03+, package additions, target-product changes, target import/execution, threshold or ruleset weakening.