### PR TITLE
Keep production assets out of Gate 6 refactor targets

### DIFF
--- a/.supportability-characterization.json
+++ b/.supportability-characterization.json
@@ -31,6 +31,13 @@
     },
     {
       "covers": [
+        "src/supportability_gate/refactor_targets.py"
+      ],
+      "id": "refactor-assets",
+      "kind": "regression"
+    },
+    {
+      "covers": [
         "src/supportability_gate/quality_profile.py",
         "src/supportability_gate/reporting.py"
       ],

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -2,232 +2,50 @@ schema_version = "1.0"
 module_boundaries = []
 
 [behavior]
-intended_behavior = "Gate 7 inventories every in-scope production file, validates supported JSON, Markdown, and PNG assets, and keeps asset paths out of source-command observations; Gate 8 independently verifies the same v6 evidence contract."
-proof = "tests/test_quality_profile.py; tests/test_standard_results.py"
+intended_behavior = "Gate 6 derives refactor targets only for contract-language source responsibilities; production assets remain in the exact changed scope and are owned by Gate 7 receipts."
+proof = "tests/test_refactor_policy.py::test_refactor_targets_leave_mixed_assets_to_quality_gate; tests/test_refactor_policy.py::test_deleted_production_asset_is_not_a_refactor"
 
 [characterization]
-captured_behavior = "The v3 boundary scenario validates the fixed base v5 and head v6 contracts, then normalizes only the intentional asset-schema and derived-digest differences before comparing deterministic behavior."
-proof = "tests/characterization/gate8-standard-results-boundary-v3.characterization.py; tests/characterization/gate8-standard-results-boundary-v3.golden.json"
+captured_behavior = "The refactor-assets scenario normalizes the prior unbounded-asset result to the fixed quality-gate ownership boundary while preserving the exact TypeScript source target."
+proof = "tests/characterization/refactor-assets.characterization.py; tests/characterization/refactor-assets.golden.json"
 
 [separation_of_concerns]
-before = "The v5 evidence boundary treated production inventory as source files and had no production-asset receipt contract."
-after = "The v6 boundary separates production inventory, command-observed source files, and validated asset receipts while preserving independent Gate 8 verification."
+before = "Gate 6 treated every non-source production asset as an unbounded source responsibility, making mixed source-and-asset changes impossible to authorize."
+after = "Gate 6 remains fail-closed for malformed contract-language source but leaves non-source production assets to Gate 7's exact structural receipts."
 
 [[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/cli.py"
+path = "src/supportability_gate/refactor_targets.py"
 kind = "function"
-symbol = "_quality_evidence"
-before = "Gate 7 wiring read the v5 source-only evidence shape."
-after = "Gate 7 wiring reads the v6 mixed-asset evidence without treating assets as command observations."
+symbol = "_renamed_spans"
+before = "A production rename marked every non-profiled asset side as an unbounded source responsibility."
+after = "Only a profiled source side that cannot be parsed remains unbounded; an asset side stays outside Gate 6 source targeting."
 
 [[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
+path = "src/supportability_gate/refactor_targets.py"
 kind = "function"
-symbol = "_asset_receipt"
-before = "No canonical production-asset receipt was derived."
-after = "A canonical receipt records each asset path, kind, fixed validator identity, SHA-256 digest, and validation result."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "_asset_result"
-before = "Gate 7 had no asset format result mapping."
-after = "Supported, unsupported, and malformed production assets map to fixed receipt results."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "_command_blocks"
-before = "Command evidence was checked against the source-only production inventory."
-after = "Command evidence is checked against source files so asset paths cannot appear in argv, observations, or zero-statement paths."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "_parse_evidence"
-before = "The v5 parser accepted no asset receipts or explicit source-file inventory."
-after = "The v6 parser validates exact production, source, and asset evidence fields and their source-only command boundaries."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "_policy_blocks"
-before = "Gate 7 policy blocks covered source-command and manifest defects only."
-after = "Gate 7 policy blocks also require exact asset receipts and fixed malformed or unsupported asset failures."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "_valid_ihdr"
-before = "PNG IHDR field legality was not independently checked."
-after = "PNG width, height, color-depth pairing, compression, filter, and interlace fields are validated."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "_valid_json"
-before = "Production JSON had no Gate 7 asset validator."
-after = "Production JSON requires strict UTF-8, finite constants, unique object keys, and valid JSON syntax."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "_valid_json.reject_constant"
-before = "Non-finite JSON constants were not rejected as production-asset defects."
-after = "Non-finite JSON constants fail the fixed JSON asset validator."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "_valid_json.reject_duplicate_keys"
-before = "Duplicate JSON object keys were not rejected as production-asset defects."
-after = "Duplicate keys in every JSON object fail the fixed JSON asset validator."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "_valid_markdown"
-before = "Production Markdown had no Gate 7 asset validator."
-after = "Production Markdown requires strict UTF-8 and rejects NUL content."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "_valid_png"
-before = "Production PNG files had no structural Gate 7 validator."
-after = "Production PNG files require valid signature, chunk framing, CRCs, legal IHDR fields, terminal empty IEND, and no trailing data."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "asset_receipts"
-before = "The profile exposed no deterministic production-asset receipt collection."
-after = "The profile emits sorted receipts for every non-source production blob and explicitly classifies unsupported suffixes without executing asset content."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "decision_payload"
-before = "The v5 public decision omitted asset receipts and explicit source files."
-after = "The v6 public decision includes exact asset receipts and source files alongside the complete production inventory."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "evidence_blocks"
-before = "Evidence validation did not compare production assets to canonical receipts."
-after = "Evidence validation fails closed on missing, extra, malformed, unsupported, or altered asset receipts and source-only command violations."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "production_files"
-before = "Production discovery returned only language source files."
-after = "Production discovery returns every contract-in-scope file, including supported and unsupported assets."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "function"
-symbol = "source_files"
-before = "There was no explicit source-only projection of the production inventory."
-after = "A source-only projection defines the exclusive command-observation boundary."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_profile.py"
-kind = "module"
-symbol = "src/supportability_gate/quality_profile.py"
-before = "The module owned source-only Gate 7 evidence."
-after = "The module owns mixed production inventory and asset validation while keeping command evidence source-only."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/quality_runner.py"
-kind = "function"
-symbol = "profile_files"
-before = "The runner profiled source and test files without a complete production inventory."
-after = "The runner supplies complete production files while commands still receive only source and test files."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/standard_block_ownership.py"
-kind = "module"
-symbol = "src/supportability_gate/standard_block_ownership.py"
-before = "Gate 7 owned no fixed production-asset failure families."
-after = "Gate 7 owns the fixed malformed and unsupported production-asset block families."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/standard_results.py"
-kind = "function"
-symbol = "_s02_asset_blocks"
-before = "Gate 8 derived no expected asset-failure block set."
-after = "Gate 8 derives the exact malformed and unsupported asset block set from authenticated receipts."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/standard_results.py"
-kind = "function"
-symbol = "_s02_asset_receipts"
-before = "Gate 8 accepted no v6 asset receipt collection."
-after = "Gate 8 validates canonical asset receipt fields, order, suffix-derived identities, SHA-256 digests, and results."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/standard_results.py"
-kind = "function"
-symbol = "_s02_complexity_components"
-before = "Gate 8 complexity binding did not include v6 asset and source evidence."
-after = "Gate 8 independently binds the v6 production inventory, source files, asset receipts, and source-only command observations."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/standard_results.py"
-kind = "function"
-symbol = "_s02_handoff_coverage"
-before = "The review handoff exposed production and test coverage only."
-after = "The review handoff exposes production, source, test, and asset-receipt coverage as separate authenticated facts."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/standard_results.py"
-kind = "function"
-symbol = "_s02_profile"
-before = "Gate 8 validated the v5 quality profile schema."
-after = "Gate 8 validates v6 source and asset fields, exact asset failures, and source-only command observations."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/standard_results.py"
-kind = "function"
-symbol = "_s02_quality_argv"
-before = "Gate 8 argv reconstruction used the full production list as its source boundary."
-after = "Gate 8 argv reconstruction uses only authenticated source files and rejects asset paths."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/standard_results.py"
-kind = "function"
-symbol = "_s02_quality_paths"
-before = "Gate 8 command path validation compared observations to the v5 production inventory."
-after = "Gate 8 requires every observed or zero-statement command path to belong to source files."
-
-[[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/standard_results.py"
-kind = "module"
-symbol = "src/supportability_gate/standard_results.py"
-before = "The module independently verified the v5 standard-results boundary."
-after = "The module independently verifies v6 mixed-asset evidence and exact Gate 7 asset-failure ownership."
+symbol = "derive"
+before = "Non-source production changes entered the refactor target pipeline and became unbounded paths."
+after = "Only production changes with a contract-language source side enter refactor targeting, while source-to-asset renames retain the deleted source target."
 
 [architecture]
-dependency_direction = "The runner and CLI produce Gate 7 evidence; quality_profile owns asset classification and source-only command rules; standard_results independently validates the serialized evidence and handoff without importing target code."
-reviewed_paths = ["src/supportability_gate/cli.py", "src/supportability_gate/quality_profile.py", "src/supportability_gate/quality_runner.py", "src/supportability_gate/standard_block_ownership.py", "src/supportability_gate/standard_results.py"]
+dependency_direction = "refactor_targets derives contract-language source responsibilities through function_changes and Git blobs; quality_profile independently owns exact production-asset receipts."
+reviewed_paths = ["src/supportability_gate/refactor_targets.py"]
 
 [responsibility_boundary]
-path = "src/supportability_gate/quality_profile.py"
-owns = "Gate 7 production inventory partitioning, fixed asset validation and receipts, and source-only command evidence."
-does_not_own = "Gate 8 independent verification, target-code execution, contract overrides, or external delivery state."
+path = "src/supportability_gate/refactor_targets.py"
+owns = "Exact bounded source responsibility identities and fail-closed malformed-source paths for Gate 6."
+does_not_own = "Production-asset parsing, structural validity, receipts, or Gate 7 block ownership."
 
 [incremental_refactor]
-target = "Add one exact mixed-asset evidence schema without changing the fixed command contract or allowing assets into source-command observations."
-completed_step = "Implemented the v6 source and asset evidence boundary, independently bound it in standard results, and versioned its characterization as v3 while retaining v2 bytes."
+target = "Remove the residual Gate 6 mixed-asset false block without changing source responsibility enforcement."
+completed_step = "Restricted refactor applicability to contract-language source sides and retained fail-closed malformed-source behavior."
 
 [review_handoff]
 summary = "DERIVED_FROM_AUTHENTICATED_EVIDENCE"
 remaining_risks = ["DERIVED_FROM_AUTHENTICATED_EVIDENCE"]
 
 [human_review]
-naming = "Production files, source files, asset receipts, and asset failure blocks use distinct names matching their fixed responsibilities."
-cohesion = "Asset parsing and receipt construction remain in quality_profile; independent serialized-evidence checks remain in standard_results."
-intended_behavior = "The local change records all production assets, blocks malformed or unsupported assets, and never treats an asset as a command-observed source path."
-reviewability = "The exact 28 changed production responsibility identities are enumerated above; hosted authorization, protection, and merge completion remain unclaimed."
+naming = "Profiled source, asset, target, and unbounded path retain distinct fixed meanings."
+cohesion = "Refactor target applicability remains in refactor_targets; asset validation remains in quality_profile."
+intended_behavior = "Mixed changes keep exact source targets, assets never become unbounded source paths, and malformed source still fails closed."
+reviewability = "The two changed production responsibility identities are enumerated above; protected authorization and merge remain unclaimed."

--- a/src/supportability_gate/refactor_targets.py
+++ b/src/supportability_gate/refactor_targets.py
@@ -122,7 +122,7 @@ def _renamed_spans(
             (old_path, policy.is_production_path(old_path), base_profiled, base),
             (new_path, policy.is_production_path(new_path), head_profiled, head),
         )
-        if production and (not profiled or side is None)
+        if production and profiled and side is None
     )
     if base is not None and head is not None:
         try:
@@ -192,6 +192,13 @@ def derive(
     targets: list[str] = []
     unbounded: list[str] = []
     for change in changes:
+        profiled_paths = tuple(
+            path
+            for path in (change.old_path, change.new_path)
+            if path and policy.is_production_path(path) and _profile_source(path, policy.language)
+        )
+        if not profiled_paths:
+            continue
         path = _production_change_path(change, policy)
         if path is None:
             continue
@@ -200,13 +207,14 @@ def derive(
         )
         unbounded.extend(newly_unbounded)
         if not spans:
-            unbounded.append(path)
+            unbounded.extend(profiled_paths)
             continue
         if (
             change.old_path is not None
             and change.new_path is not None
             and change.old_path != change.new_path
             and policy.is_production_path(change.new_path)
+            and _profile_source(change.new_path, policy.language)
             and all(target_path != change.new_path for target_path, _ in spans)
         ):
             unbounded.append(change.new_path)

--- a/tests/characterization/refactor-assets.characterization.py
+++ b/tests/characterization/refactor-assets.characterization.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from supportability_gate import refactor_targets
+
+
+def main() -> None:
+    original_blob = refactor_targets.git_changes.read_regular_blob
+    original_base_lines = refactor_targets.git_changes.changed_base_lines
+    original_head_lines = refactor_targets.git_changes.changed_head_lines
+    base_sha, head_sha = "a" * 40, "b" * 40
+    source = "src/sample.ts"
+    assets = ("src/plugin.json", "src/readme.md")
+    broken_source, broken_asset = "src/broken.ts", "src/broken.json"
+
+    def read_blob(_repository: Path, sha: str, path: str, _records: object) -> object:
+        if path == source:
+            value = 1 if sha == base_sha else 2
+            content = (
+                "export function calculate(value: number): number {\n"
+                f"  return value + {value};\n"
+                "}\n"
+            ).encode()
+        elif path == broken_source:
+            content = b"export function broken("
+        else:
+            content = b"{}\n"
+        return SimpleNamespace(content=content)
+
+    refactor_targets.git_changes.read_regular_blob = read_blob
+    refactor_targets.git_changes.changed_base_lines = lambda *args, **kwargs: [2]
+    refactor_targets.git_changes.changed_head_lines = lambda *args, **kwargs: [2]
+    try:
+        targets, unbounded = refactor_targets.derive(
+            Path("."),
+            SimpleNamespace(base_sha=base_sha, head_sha=head_sha),
+            SimpleNamespace(
+                language="typescript",
+                is_production_path=lambda path: path.startswith("src/"),
+            ),
+            (
+                SimpleNamespace(status="M", old_path=source, new_path=source),
+                *(SimpleNamespace(status="A", old_path=None, new_path=path) for path in assets),
+            ),
+            [],
+        )
+        rename_targets, rename_unbounded = refactor_targets.derive(
+            Path("."),
+            SimpleNamespace(base_sha=base_sha, head_sha=head_sha),
+            SimpleNamespace(
+                language="typescript",
+                is_production_path=lambda path: path.startswith("src/"),
+            ),
+            (SimpleNamespace(status="R100", old_path=broken_source, new_path=broken_asset),),
+            [],
+        )
+    finally:
+        refactor_targets.git_changes.read_regular_blob = original_blob
+        refactor_targets.git_changes.changed_base_lines = original_base_lines
+        refactor_targets.git_changes.changed_head_lines = original_head_lines
+
+    expected = ("src/sample.ts::function:calculate:1-3",)
+    if targets != expected or unbounded not in (assets, ()):
+        raise RuntimeError("mixed assets escaped their fixed quality-gate boundary")
+    if rename_targets or rename_unbounded not in (
+        (broken_source,),
+        (broken_asset, broken_source),
+    ):
+        raise RuntimeError("source-to-asset rename lost its source failure boundary")
+    payload = {
+        "behavior": {
+            "asset_owner": "quality-gate",
+            "refactor_targets": list(expected),
+            "unbounded_source_paths": [broken_source],
+        },
+        "scenario": "refactor-assets",
+        "schema_version": "1.0",
+    }
+    print(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/characterization/refactor-assets.golden.json
+++ b/tests/characterization/refactor-assets.golden.json
@@ -1,0 +1,9 @@
+{
+  "asset_owner": "quality-gate",
+  "refactor_targets": [
+    "src/sample.ts::function:calculate:1-3"
+  ],
+  "unbounded_source_paths": [
+    "src/broken.ts"
+  ]
+}

--- a/tests/test_refactor_policy.py
+++ b/tests/test_refactor_policy.py
@@ -945,18 +945,26 @@ def test_multiline_typescript_declarator_rename_binds_old_and_new_identities(
     assert result["targets"] == targets
 
 
-@pytest.mark.parametrize(
-    ("old_path", "expected_unbounded", "expected_blocks"),
-    [
-        ("sample.bin", [], []),
-        ("src/sample.bin", ["src/sample.bin"], ["UNVERIFIABLE_BOUNDED_TARGET"]),
-    ],
-)
-def test_refactor_targets_unprofiled_to_python_rename_distinguishes_old_production(
-    tmp_path: Path,
-    old_path: str,
-    expected_unbounded: list[str],
-    expected_blocks: list[str],
+def test_refactor_targets_leave_mixed_assets_to_quality_gate(tmp_path: Path) -> None:
+    repository, base_sha, _ = _repository(tmp_path, "typescript")
+    _git(repository, "reset", "--hard", base_sha)
+    _write(
+        repository / "src/sample.ts",
+        "export function calculate(value: number): number {\n  return value + 2;\n}\n",
+    )
+    _write(repository / "src/plugin.json", '{"name":"fixture"}\n')
+    _write(repository / "src/readme.md", "# Fixture\n")
+    head_sha = _commit(repository, "change source and assets")
+
+    assert _derived_targets(repository, base_sha, head_sha) == (
+        ("src/sample.ts::function:calculate:1-3",),
+        (),
+    )
+
+
+@pytest.mark.parametrize("old_path", ["sample.bin", "src/sample.bin"])
+def test_refactor_targets_unprofiled_to_python_rename_ignores_old_asset(
+    tmp_path: Path, old_path: str
 ) -> None:
     repository, base_sha, _ = _repository(tmp_path)
     _git(repository, "reset", "--hard", base_sha)
@@ -982,22 +990,28 @@ def test_refactor_targets_unprofiled_to_python_rename_distinguishes_old_producti
 
     assert _derived_targets(repository, base_sha, head_sha) == (
         (target,),
-        tuple(expected_unbounded),
+        (),
     )
     result = _verify(repository, event, _characterization(base_sha, head_sha, ["src/sample.py"]))
 
-    assert result["overall_result"] == ("BLOCK" if expected_blocks else "PASS")
+    assert result["overall_result"] == "PASS"
     assert result["targets"] == [target]
-    assert result["unbounded_paths"] == expected_unbounded
-    assert result["policy_blocks"] == expected_blocks
+    assert result["unbounded_paths"] == []
+    assert result["policy_blocks"] == []
 
 
 @pytest.mark.parametrize(
-    ("new_path", "head_source"),
-    [("src/sample.txt", "not Python\n"), ("src/renamed.py", "def broken(:\n")],
+    ("new_path", "head_source", "expected_unbounded"),
+    [
+        ("src/sample.txt", "not Python\n", ()),
+        ("src/renamed.py", "def broken(:\n", ("src/renamed.py",)),
+    ],
 )
-def test_renamed_profiled_source_retains_old_target_when_head_is_unbounded(
-    tmp_path: Path, new_path: str, head_source: str
+def test_renamed_profiled_source_distinguishes_asset_from_malformed_head(
+    tmp_path: Path,
+    new_path: str,
+    head_source: str,
+    expected_unbounded: tuple[str, ...],
 ) -> None:
     repository, base_sha, _ = _repository(tmp_path)
     _git(repository, "reset", "--hard", base_sha)
@@ -1020,7 +1034,24 @@ def test_renamed_profiled_source_retains_old_target_when_head_is_unbounded(
         records,
     ) == (
         ("src/sample.py::function:calculate:1-2",),
-        (new_path,),
+        expected_unbounded,
+    )
+
+
+@pytest.mark.parametrize("base_source", ["", "def broken(:\n"])
+def test_source_to_asset_rename_keeps_only_unbounded_source_path(
+    tmp_path: Path, base_source: str
+) -> None:
+    repository, base_sha, _ = _repository(tmp_path)
+    _git(repository, "reset", "--hard", base_sha)
+    _write(repository / "src/sample.py", base_source)
+    base_sha = _commit(repository, "unbounded source")
+    _git(repository, "mv", "src/sample.py", "src/sample.json")
+    head_sha = _commit(repository, "replace source with asset")
+
+    assert _derived_targets(repository, base_sha, head_sha) == (
+        (),
+        ("src/sample.py",),
     )
 
 
@@ -1135,15 +1166,32 @@ def test_python_deletion_authorization_remains_exact(
     assert result["policy_blocks"] == [code]
 
 
-@pytest.mark.parametrize(
-    ("path", "content"),
-    [("src/data.bin", "data\n"), ("src/broken.py", "def broken(:\n")],
-)
-def test_unbounded_deleted_production_files_fail_closed(
-    tmp_path: Path, path: str, content: str
-) -> None:
+def test_deleted_production_asset_is_not_a_refactor(tmp_path: Path) -> None:
     repository, base_sha, _ = _repository(tmp_path)
     _git(repository, "reset", "--hard", base_sha)
+    path = "src/data.bin"
+    _write(repository / path, "data\n")
+    base_sha = _commit(repository, "asset base")
+    (repository / path).unlink()
+    head_sha = _commit(repository, "delete asset")
+
+    result = _verify(
+        repository,
+        _event(base_sha, head_sha, None),
+        _characterization(base_sha, head_sha, []),
+    )
+
+    assert result["overall_result"] == "PASS"
+    assert result["applicable"] is False
+    assert result["targets"] == []
+    assert result["unbounded_paths"] == []
+
+
+def test_unbounded_deleted_production_source_fails_closed(tmp_path: Path) -> None:
+    repository, base_sha, _ = _repository(tmp_path)
+    _git(repository, "reset", "--hard", base_sha)
+    path = "src/broken.py"
+    content = "def broken(:\n"
     _write(repository / path, content)
     base_sha = _commit(repository, "unbounded base")
     (repository / path).unlink()


### PR DESCRIPTION
Follow-up correction for #175 after the protected mixed-asset canary exposed a residual Gate 6 applicability defect.

- Gate 6 derives refactor targets only for contract-language source sides.
- Malformed or empty source remains fail-closed, including source-to-asset renames.
- Assets remain in the exact changed scope and remain owned by Gate 7 receipts.
- No workflow, ruleset, threshold, waiver, exclusion, or immutable-standard change.

Focused evidence:
- exact mixed source/asset and source-to-asset rename regressions pass;
- hosted-style base capture, head capture, and verification pass;
- derived review boundaries are exactly _renamed_spans and derive, with zero unbounded paths;
- independent scoped review approved exact head 0b6acc4e99c4db714a33c08bd17750603e43bf5.

Protected source validation and all eight organization Gate checks remain required before merge.