### PR TITLE
Align mixed-asset refactor result binding

### DIFF
--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -2,50 +2,64 @@ schema_version = "1.0"
 module_boundaries = []
 
 [behavior]
-intended_behavior = "Gate 6 derives refactor targets only for contract-language source responsibilities; production assets remain in the exact changed scope and are owned by Gate 7 receipts."
-proof = "tests/test_refactor_policy.py::test_refactor_targets_leave_mixed_assets_to_quality_gate; tests/test_refactor_policy.py::test_deleted_production_asset_is_not_a_refactor"
+intended_behavior = "The standard-results binder requires Gate 6 targets only for complexity-assessed source changes while retaining every changed asset in authorization scope and Gate 7 coverage."
+proof = "tests/test_standard_results.py::test_refactor_binding_leaves_mixed_asset_to_quality_gate; tests/test_standard_results.py::test_refactor_binding_source_to_asset_keeps_source_requirement; tests/test_standard_results.py::test_unbounded_source_path_has_exact_gate_six_blocks"
 
 [characterization]
-captured_behavior = "The refactor-assets scenario normalizes the prior unbounded-asset result to the fixed quality-gate ownership boundary while preserving the exact TypeScript source target."
-proof = "tests/characterization/refactor-assets.characterization.py; tests/characterization/refactor-assets.golden.json"
+captured_behavior = "The existing standard-results boundary scenario preserves authenticated Gate 6 and Gate 8 result composition while the focused binding test covers the mixed-asset requirement."
+proof = "tests/characterization/gate8-standard-results-boundary-v3.characterization.py; tests/characterization/gate8-standard-results-boundary-v3.golden.json"
 
 [separation_of_concerns]
-before = "Gate 6 treated every non-source production asset as an unbounded source responsibility, making mixed source-and-asset changes impossible to authorize."
-after = "Gate 6 remains fail-closed for malformed contract-language source but leaves non-source production assets to Gate 7's exact structural receipts."
+before = "The result binder still required every production asset to appear in Gate 6's source targets after target derivation stopped doing so."
+after = "The result binder uses the existing complexity-assessed classification plus the contract language for exact Gate 6 source-side requirements and leaves asset validity to Gate 7."
 
 [[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/refactor_targets.py"
+path = "src/supportability_gate/standard_results.py"
 kind = "function"
-symbol = "_renamed_spans"
-before = "A production rename marked every non-profiled asset side as an unbounded source responsibility."
-after = "Only a profiled source side that cannot be parsed remains unbounded; an asset side stays outside Gate 6 source targeting."
+symbol = "_s02_refactor"
+before = "The refactor result binder received changed-file evidence without the authenticated contract language needed to distinguish rename sides."
+after = "The refactor result binder receives the already-validated contract language from the complexity result."
 
 [[separation_of_concerns.boundaries]]
-path = "src/supportability_gate/refactor_targets.py"
+path = "src/supportability_gate/standard_results.py"
 kind = "function"
-symbol = "derive"
-before = "Non-source production changes entered the refactor target pipeline and became unbounded paths."
-after = "Only production changes with a contract-language source side enter refactor targeting, while source-to-asset renames retain the deleted source target."
+symbol = "_s02_refactor_binding"
+before = "Binding delegated change-path classification without a contract-language identity."
+after = "Binding threads the contract language into exact source-side requirement classification."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/standard_results.py"
+kind = "function"
+symbol = "_s02_refactor_change_paths"
+before = "All production paths were classified as required Gate 6 target paths, including assets that have no source responsibility identity."
+after = "Only contract-language source sides of complexity-assessed changes are required Gate 6 targets; all production paths remain allowed and all changed paths remain in authorization scope."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/standard_results.py"
+kind = "function"
+symbol = "_s02_refactor_shape"
+before = "Binding required every selected production path directly, which could choose an asset side of a rename."
+after = "Each complexity-assessed change must bind at least one exact source side, preserving moved source identities without accepting asset sides."
 
 [architecture]
-dependency_direction = "refactor_targets derives contract-language source responsibilities through function_changes and Git blobs; quality_profile independently owns exact production-asset receipts."
-reviewed_paths = ["src/supportability_gate/refactor_targets.py"]
+dependency_direction = "standard_results consumes the authenticated source classification already emitted by complexity evaluation; quality_profile independently owns production-asset receipts."
+reviewed_paths = ["src/supportability_gate/standard_results.py"]
 
 [responsibility_boundary]
-path = "src/supportability_gate/refactor_targets.py"
-owns = "Exact bounded source responsibility identities and fail-closed malformed-source paths for Gate 6."
-does_not_own = "Production-asset parsing, structural validity, receipts, or Gate 7 block ownership."
+path = "src/supportability_gate/standard_results.py"
+owns = "Cross-binding exact Gate 6 source targets, changed authorization scope, and authenticated result identities."
+does_not_own = "Production-asset parsing, structural validity, receipt generation, or Gate 7 block ownership."
 
 [incremental_refactor]
-target = "Remove the residual Gate 6 mixed-asset false block without changing source responsibility enforcement."
-completed_step = "Restricted refactor applicability to contract-language source sides and retained fail-closed malformed-source behavior."
+target = "Remove the stale result-binding mismatch exposed by the real mixed-asset plugin run."
+completed_step = "Aligned Gate 6 result requirements with the existing complexity-assessed source classification in one binder condition."
 
 [review_handoff]
 summary = "DERIVED_FROM_AUTHENTICATED_EVIDENCE"
 remaining_risks = ["DERIVED_FROM_AUTHENTICATED_EVIDENCE"]
 
 [human_review]
-naming = "Profiled source, asset, target, and unbounded path retain distinct fixed meanings."
-cohesion = "Refactor target applicability remains in refactor_targets; asset validation remains in quality_profile."
-intended_behavior = "Mixed changes keep exact source targets, assets never become unbounded source paths, and malformed source still fails closed."
-reviewability = "The two changed production responsibility identities are enumerated above; protected authorization and merge remain unclaimed."
+naming = "Required source paths, allowed production paths, and full changed scope retain distinct fixed meanings."
+cohesion = "Result cross-binding remains in standard_results; asset validation remains in quality_profile."
+intended_behavior = "Mixed changes bind exact source targets without requiring assets as Gate 6 targets, while malformed source remains fail-closed."
+reviewability = "The four changed production responsibility identities are enumerated above; protected authorization and merge remain unclaimed."

--- a/src/supportability_gate/standard_results.py
+++ b/src/supportability_gate/standard_results.py
@@ -1460,22 +1460,26 @@ def _s02_refactor_predecessor(
 
 
 def _s02_refactor_change_paths(
-    changed: tuple[dict[str, Any], ...],
-) -> tuple[list[str], list[str], list[str]]:
+    changed: tuple[dict[str, Any], ...], language: str
+) -> tuple[list[str], list[tuple[str, ...]], list[str]]:
+    suffixes = (".py", ".pyi") if language == "python" else (".cts", ".mts", ".ts", ".tsx")
     scope = sorted({path for row in changed for path in (row["old_path"], row["new_path"]) if path})
-    required = sorted(
-        {
-            path
-            for row in changed
-            if (
-                path := row["new_path"]
-                if row["head_production"]
-                else row["old_path"]
-                if row["base_production"]
-                else None
+    required = [
+        tuple(
+            sorted(
+                {
+                    path
+                    for path, production in (
+                        (row["old_path"], row["base_production"]),
+                        (row["new_path"], row["head_production"]),
+                    )
+                    if path and production and path.endswith(suffixes)
+                }
             )
-        }
-    )
+        )
+        for row in changed
+        if row["complexity_assessed"]
+    ]
     allowed = sorted(
         {
             path
@@ -1647,8 +1651,9 @@ def _s02_refactor_shape(
     changed: tuple[dict[str, Any], ...],
     responsibility_targets: tuple[str, ...] | None,
     unbounded_production_paths: tuple[str, ...] | None,
+    language: str,
 ) -> tuple[list[str], list[str], list[str]]:
-    scope, required, allowed = _s02_refactor_change_paths(changed)
+    scope, required, allowed = _s02_refactor_change_paths(changed, language)
     target_paths = _s02_refactor_target_paths(row["targets"])
     bounded_paths = set((*target_paths, *row["unbounded_paths"]))
     if (
@@ -1665,7 +1670,7 @@ def _s02_refactor_shape(
             )
         )
         or row["applicable"] is not bool(required)
-        or not set(required).issubset(bounded_paths)
+        or any(not bounded_paths.intersection(paths) for paths in required)
         or not bounded_paths.issubset(allowed)
         or set(target_paths) & set(row["unbounded_paths"])
     ):
@@ -1726,9 +1731,10 @@ def _s02_refactor_binding(
     unbounded_production_paths: tuple[str, ...] | None,
     predecessor: dict[str, Any] | None,
     predecessor_block: str | None,
+    language: str,
 ) -> None:
     scope, allowed, target_paths = _s02_refactor_shape(
-        row, changed, responsibility_targets, unbounded_production_paths
+        row, changed, responsibility_targets, unbounded_production_paths, language
     )
     if authorization is None:
         _s02_refactor_absent_authorization(row, predecessor, predecessor_block)
@@ -1786,6 +1792,7 @@ def _s02_refactor(
             None if targets_unavailable else complexity.unbounded_production_paths,
             predecessor,
             predecessor_block,
+            complexity.source["language"],
         )
     expected = hashlib.sha256(_canonical(characterization)).hexdigest()
     expected_runnability = (

--- a/tests/test_standard_results.py
+++ b/tests/test_standard_results.py
@@ -1040,6 +1040,7 @@ def test_refactor_binding_preserves_deleted_old_path_identity_on_rename() -> Non
     changed = (
         {
             "base_production": True,
+            "complexity_assessed": True,
             "head_production": True,
             "new_path": "src/renamed.py",
             "old_path": "src/sample.py",
@@ -1065,18 +1066,123 @@ def test_refactor_binding_preserves_deleted_old_path_identity_on_rename() -> Non
         "unbounded_paths": [],
     }
 
-    assert standard_results._s02_refactor_change_paths(changed) == (
+    assert standard_results._s02_refactor_change_paths(changed, "python") == (
         ["src/renamed.py", "src/sample.py"],
-        ["src/renamed.py"],
+        [("src/renamed.py", "src/sample.py")],
         ["src/renamed.py", "src/sample.py"],
     )
     standard_results._s02_refactor_binding(
-        row, authorization, IDENTITY, changed, targets, (), None, None
+        row, authorization, IDENTITY, changed, targets, (), None, None, "python"
     )
     row["targets"] = [moved]
     authorization["targets"] = [moved]
     standard_results._s02_refactor_binding(
-        row, authorization, IDENTITY, changed, (moved,), (), None, None
+        row, authorization, IDENTITY, changed, (moved,), (), None, None, "python"
+    )
+
+
+def test_refactor_binding_leaves_mixed_asset_to_quality_gate() -> None:
+    source = "src/sample.py"
+    asset = "src/plugin.json"
+    target = f"{source}::function:calculate:1-2"
+    changed = (
+        {
+            "base_production": True,
+            "complexity_assessed": True,
+            "head_production": True,
+            "new_path": source,
+            "old_path": source,
+        },
+        {
+            "base_production": False,
+            "complexity_assessed": False,
+            "head_production": True,
+            "new_path": asset,
+            "old_path": None,
+        },
+    )
+    scope = [asset, source]
+    authorization = {
+        "base_sha": IDENTITY.base_sha,
+        "broad": True,
+        "head_sha": IDENTITY.head_sha,
+        "repository": IDENTITY.repository,
+        "scope": scope,
+        "sequence": {"predecessor_sha": IDENTITY.base_sha, "step": 1},
+        "targets": [target],
+    }
+    row = {
+        "applicable": True,
+        "changed_paths": scope,
+        "policy_blocks": [],
+        "targets": [target],
+        "unbounded_paths": [],
+    }
+
+    assert standard_results._s02_refactor_change_paths(changed, "python") == (
+        scope,
+        [(source,)],
+        scope,
+    )
+    standard_results._s02_refactor_binding(
+        row, authorization, IDENTITY, changed, (target,), (), None, None, "python"
+    )
+
+
+@pytest.mark.parametrize("malformed", [False, True])
+def test_refactor_binding_source_to_asset_keeps_source_requirement(
+    malformed: bool,
+) -> None:
+    source = "src/sample.py"
+    asset = "src/sample.json"
+    target = f"{source}::function:calculate:1-2"
+    targets = [] if malformed else [target]
+    unbounded = [source] if malformed else []
+    blocks = (
+        ["MISSING_BOUNDED_PRODUCTION_TARGET", "UNVERIFIABLE_BOUNDED_TARGET"] if malformed else []
+    )
+    changed = (
+        {
+            "base_production": True,
+            "complexity_assessed": True,
+            "head_production": True,
+            "new_path": asset,
+            "old_path": source,
+        },
+    )
+    scope = [asset, source]
+    authorization = {
+        "base_sha": IDENTITY.base_sha,
+        "broad": True,
+        "head_sha": IDENTITY.head_sha,
+        "repository": IDENTITY.repository,
+        "scope": scope,
+        "sequence": {"predecessor_sha": IDENTITY.base_sha, "step": 1},
+        "targets": [target],
+    }
+    row = {
+        "applicable": True,
+        "changed_paths": scope,
+        "policy_blocks": blocks,
+        "targets": targets,
+        "unbounded_paths": unbounded,
+    }
+
+    assert standard_results._s02_refactor_change_paths(changed, "python") == (
+        scope,
+        [(source,)],
+        scope,
+    )
+    standard_results._s02_refactor_binding(
+        row,
+        authorization,
+        IDENTITY,
+        changed,
+        tuple(targets),
+        tuple(unbounded),
+        None,
+        None,
+        "python",
     )
 
 
@@ -1343,16 +1449,15 @@ def test_unverifiable_authorized_target_remains_a_gate_six_block() -> None:
     assert payload["shared_failures"] == []
 
 
-def test_unbounded_production_path_has_exact_gate_six_blocks() -> None:
-    path = "src/sample.bin"
+def test_unbounded_source_path_has_exact_gate_six_blocks() -> None:
+    path = "src/sample.py"
     inputs = _inputs(path)
     target = f"{path}::module:{path}:1-1"
     authorization = inputs[2]["authorization"]
     assert isinstance(authorization, dict)
     authorization["broad"] = True
     authorization["targets"] = [target]
-    inputs[0]["changed_files"][0]["complexity_assessed"] = False
-    inputs[0]["modularity"]["changed_paths"] = []
+    inputs[0]["changed_files"][0]["complexity_assessed"] = True
     inputs[0]["responsibility_targets"] = []
     inputs[0]["unbounded_production_paths"] = [path]
     inputs[1]["refactor_runnability"]["targets"] = []


### PR DESCRIPTION
Final focused follow-up for #175, driven by the real protected plugin run at head d858427db429931346fc89170c60069b80f3b40b.

Observed proof:
- Gate 7 passed mixed JSON, Markdown, and PNG asset coverage.
- Gate 6 and Gate 8 returned only REFACTOR_RESULT_BINDING_MISMATCH.
- Root cause: the results binder still selected production paths instead of exact contract-language source sides.

This change:
- binds each complexity-assessed change to at least one exact source side;
- keeps every changed asset in authorization scope and Gate 7 ownership;
- preserves valid and malformed source-to-asset behavior and source-to-source renames;
- changes no workflow, ruleset, threshold, waiver, exclusion, or immutable standard.

Focused regressions and independent exact-head review pass. Protected checks remain required before merge.