### PR TITLE
Allow exact fixed-profile contract expansion

### DIFF
--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -23,7 +23,7 @@ after = "The exact fixed-profile expansion is evaluated without the generic bloc
 [[separation_of_concerns.boundaries]]
 path = "src/supportability_gate/cli.py"
 kind = "function"
-symbol = "main"
+symbol = "_evaluate"
 before = "All analysis remained bound to the base contract."
 after = "Analysis selects the candidate only after the fixed-profile expansion predicate passes."
 

--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -3,16 +3,36 @@ module_boundaries = []
 
 [behavior]
 intended_behavior = "One immutable contract runs fixed Python and TypeScript profiles together while preserving single-language behavior and exact-head coverage."
-proof = "tests/hosted_characterization.py exact-head profile selection; tests/test_quality_profile.py::test_mixed_contract_selects_and_partitions_both_fixed_profiles; tests/test_evaluate_complexity.py; tests/test_standard_results.py"
+proof = "Targeted mixed-transition selector and hosted-profile capture; tests/test_quality_profile.py::test_mixed_contract_selects_and_partitions_both_fixed_profiles"
 
 [characterization]
 captured_behavior = "Existing stack-specific and result-binding scenarios remain bound while the mixed profile composes both fixed profiles without changing their evidence schema."
 proof = "tests/characterization/gate-policy-mixed-compatibility.characterization.py; tests/characterization/gate8-standard-results-boundary-v3.characterization.py; tests/characterization/quality-runner-boundary.characterization.py; tests/characterization/architecture-modularity-baseline.characterization.py"
 
 [separation_of_concerns]
-before = "Base and head captures selected driver profiles from the base contract."
-after = "Both captures select driver profiles from the authenticated exact-head definition while executing behavior against their exact target commits."
-boundaries = []
+before = "Contract evaluation and hosted quality always used the base single-language profile, so the first mixed transition could not run its added profile."
+after = "Only the exact fixed-profile expansion uses the head mixed contract for deterministic analysis and hosted quality; every other contract change remains on the base policy and blocks."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/cli.py"
+kind = "function"
+symbol = "_contract_blocks"
+before = "Every candidate contract change received the generic contract-change block."
+after = "The exact fixed-profile expansion is evaluated without the generic block; all other changes retain it."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/cli.py"
+kind = "function"
+symbol = "main"
+before = "All analysis remained bound to the base contract."
+after = "Analysis selects the candidate only after the fixed-profile expansion predicate passes."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/gate_policy.py"
+kind = "function"
+symbol = "is_profile_expansion"
+before = "No contract transition was distinguished from arbitrary candidate mutation."
+after = "One predicate owns the exact non-weakening single-to-mixed transition boundary."
 [architecture]
 dependency_direction = "Contract selects profiles; CLI orchestrates existing analyzers; quality runner executes fixed commands; result binding consumes authenticated evidence. No new cycle or target-code import."
 reviewed_paths = ["src/supportability_gate/characterization.py", "src/supportability_gate/cli.py", "src/supportability_gate/contract.py", "src/supportability_gate/gate_policy.py", "src/supportability_gate/modularity_policy.py", "src/supportability_gate/quality_profile.py", "src/supportability_gate/quality_runner.py", "src/supportability_gate/refactor_targets.py", "src/supportability_gate/standard_block_ownership.py", "src/supportability_gate/standard_results.py", "tests/hosted_characterization.py"]

--- a/src/supportability_gate/cli.py
+++ b/src/supportability_gate/cli.py
@@ -432,9 +432,10 @@ def _contract_blocks(
     candidate_policy: contract.Contract | None,
     assessments: tuple[function_changes.ChangedFileAssessment, ...],
 ) -> tuple[str, ...]:
+    expansion = gate_policy.is_profile_expansion(policy, candidate_policy)
     candidate = (
         (
-            "CANDIDATE_CONTRACT_CHANGE",
+            *(() if expansion else ("CANDIDATE_CONTRACT_CHANGE",)),
             *gate_policy.contract_change_blocks(policy, candidate_policy),
         )
         if any(
@@ -442,7 +443,8 @@ def _contract_blocks(
         )
         else ()
     )
-    return (*candidate, *gate_policy.evaluate_contract(policy, assessments))
+    effective = candidate_policy if expansion and candidate_policy is not None else policy
+    return (*candidate, *gate_policy.evaluate_contract(effective, assessments))
 
 
 def _result(
@@ -818,13 +820,31 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
             contract_path,
             records,
         )
-        policy = contract.parse_contract(blob.content)
+        base_policy = contract.parse_contract(blob.content)
+        policy = base_policy
         changes = git_changes.changed_paths(
             repository,
             identity.base_sha,
             identity.head_sha,
             records,
         )
+        candidate_policy: contract.Contract | None = None
+        contract_changed = any(contract_path in {item.old_path, item.new_path} for item in changes)
+        if contract_changed and any(item.new_path == contract_path for item in changes):
+            try:
+                candidate_blob = git_changes.read_regular_blob(
+                    repository,
+                    identity.head_sha,
+                    contract_path,
+                    records,
+                )
+                candidate_policy = contract.parse_contract(candidate_blob.content)
+            except (contract.ContractError, git_changes.GitError):
+                candidate_policy = None
+        if candidate_policy is not None and gate_policy.is_profile_expansion(
+            base_policy, candidate_policy
+        ):
+            policy = candidate_policy
         assessments = _classify_changes(repository, identity, policy, changes, records)
         responsibility_targets, unbounded_production_paths = _refactor_target_evidence(
             repository, identity, policy, changes, records, evidence_errors
@@ -837,22 +857,9 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
             records,
             evidence_errors,
         )
-        candidate_policy: contract.Contract | None = None
-        contract_changed = any(
-            contract_path in {item.change.old_path, item.change.new_path} for item in assessments
+        contract_blocks = _contract_blocks(
+            contract_path, base_policy, candidate_policy, assessments
         )
-        if contract_changed and any(item.change.new_path == contract_path for item in assessments):
-            try:
-                candidate_blob = git_changes.read_regular_blob(
-                    repository,
-                    identity.head_sha,
-                    contract_path,
-                    records,
-                )
-                candidate_policy = contract.parse_contract(candidate_blob.content)
-            except (contract.ContractError, git_changes.GitError):
-                candidate_policy = None
-        contract_blocks = _contract_blocks(contract_path, policy, candidate_policy, assessments)
         decisions, ruff_diagnostics = _complexity_evidence(
             repository,
             identity,

--- a/src/supportability_gate/gate_policy.py
+++ b/src/supportability_gate/gate_policy.py
@@ -123,3 +123,24 @@ def contract_change_blocks(base: Contract, head: Contract | None) -> tuple[str, 
             blocks.append("GATE_SCOPE_NARROWING")
             break
     return tuple(blocks)
+
+
+def is_profile_expansion(base: Contract, head: Contract | None) -> bool:
+    """Return whether one single-language contract safely adds the other fixed profile."""
+    if (
+        head is None
+        or base.schema_version != "1.0"
+        or head.schema_version != "1.1"
+        or base.production_paths != head.production_paths
+        or base.high_risk_paths != head.high_risk_paths
+        or base.maximum != head.maximum
+    ):
+        return False
+    base_gates = _gate_map(base)
+    head_gates = _gate_map(head)
+    if any(head_gates.get(adapter) != gate for adapter, gate in base_gates.items()):
+        return False
+    return set(head_gates) == set(APPROVED_ADAPTERS_BY_LANGUAGE["mixed"]) and all(
+        head_gates[adapter].paths == base.production_paths
+        for adapter in set(head_gates) - set(base_gates)
+    )

--- a/tests/hosted_quality_profile.py
+++ b/tests/hosted_quality_profile.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from supportability_gate import (
     architecture_policy,
     contract,
+    gate_policy,
     git_changes,
     quality_profile,
     quality_runner,
@@ -209,10 +210,20 @@ def run_profile(arguments: argparse.Namespace) -> quality_profile.QualityEvidenc
         raise quality_profile.QualityProfileError(
             "INVALID_WORKFLOW_SHA", "workflow SHA must be immutable"
         )
-    policy = contract.parse_contract(
+    base_policy = contract.parse_contract(
         git_changes.read_regular_blob(
             target, identity.base_sha, ".supportability.toml", records
         ).content
+    )
+    candidate_policy = contract.parse_contract(
+        git_changes.read_regular_blob(
+            target, identity.head_sha, ".supportability.toml", records
+        ).content
+    )
+    policy = (
+        candidate_policy
+        if gate_policy.is_profile_expansion(base_policy, candidate_policy)
+        else base_policy
     )
     changes = git_changes.changed_paths(target, identity.base_sha, identity.head_sha, records)
     changed_paths = tuple(


### PR DESCRIPTION
Completes S13 transition enforcement after protected canary #182 proved the remaining Gate 7 block. Only an exact schema 1.0 single-language to schema 1.1 Python+TypeScript expansion with unchanged roots, high-risk paths, threshold, and existing gates may use the head profile. All other candidate contract changes remain blocked. No package, command, threshold, waiver, or exclusion changes.