### PR TITLE
Support additive mixed profile roots

### DIFF
--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -2,43 +2,113 @@ schema_version = "1.0"
 module_boundaries = []
 
 [behavior]
-intended_behavior = "A mixed-profile policy exit is classified by its adapter language without becoming a technical failure."
-proof = "Run 33296347911 measured TypeScript complexity 13 and exposed the mixed-key lookup; the focused classifier check now returns the fixed Gate 1 policy result."
+intended_behavior = "A Python contract can add the fixed TypeScript profile and covered production roots, and an existing mixed contract can add later covered roots without narrowing prior scope."
+proof = "The focused mixed-profile regression uses Python under src and TypeScript under web, retains both through a later gateway-root expansion, and rejects removal of the original root."
 
 [characterization]
-captured_behavior = "The blocking canary preserved runtime behavior while TypeScript complexity exited one."
-proof = "Run 33296347911 quality-gates.json and complexity-result.json."
+captured_behavior = "Fixed Python and TypeScript profiles remain composed while mixed-to-single narrowing stays blocked."
+proof = "tests/characterization/gate-policy-mixed-compatibility.characterization.py"
 
 [separation_of_concerns]
-before = "Quality policy-exit classification indexed the composite mixed identity."
-after = "Quality policy-exit classification derives only the fixed adapter profile before consulting its policy map."
+before = "Mixed transition eligibility, fixed TypeScript execution, and aggregate receipt validation assumed every source lived under src."
+after = "The existing contract, quality-template, runner, and receipt owners bind additive roots and their fixed commands to the exact source manifest."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/contract.py"
+kind = "function"
+symbol = "is_profile_expansion"
+before = "Only unchanged src-style roots qualified during the single-language to mixed transition."
+after = "Existing language, root, risk, threshold, and gate coverage remain while exact fully covered roots may be added."
 
 [[separation_of_concerns.boundaries]]
 path = "src/supportability_gate/quality_profile.py"
 kind = "function"
-symbol = "_command_exit_block"
-before = "The helper treated mixed as a policy-exit map key."
-after = "The helper uses the command adapter's Python or TypeScript prefix."
+symbol = "_asset_result"
+before = "The fixed asset validator map covered JSON, Markdown, and PNG only."
+after = "The same bounded text validator now authenticates CSS as strict UTF-8 without NUL."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/quality_profile.py"
+kind = "function"
+symbol = "_valid_markdown"
+before = "The strict UTF-8 and NUL check was named only for Markdown."
+after = "The unchanged responsibility moved to the accurately named _valid_utf8_text function."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/quality_profile.py"
+kind = "function"
+symbol = "_valid_utf8_text"
+before = "The identical bounded text rule was named only for Markdown."
+after = "The name truthfully owns strict UTF-8 and NUL rejection for both Markdown and CSS."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/quality_profile.py"
+kind = "module"
+symbol = "src/supportability_gate/quality_profile.py"
+before = "Fixed TypeScript templates declared src-only coverage and architecture inputs and no CSS asset identity."
+after = "The same templates declare exact manifest tokens and one bounded CSS asset identity."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/quality_runner.py"
+kind = "function"
+symbol = "_replace_tokens"
+before = "Only absolute source and test manifest tokens expanded into fixed argument vectors."
+after = "Exact relative source and coverage argument lists expand through the same no-shell vector builder."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/quality_runner.py"
+kind = "function"
+symbol = "_write_typescript_configs"
+before = "TypeScript build output required every source below repository src."
+after = "The fixed build root is the repository, preserving every repository-relative source identity."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/quality_runner.py"
+kind = "function"
+symbol = "command_plans"
+before = "Fixed TypeScript coverage and architecture vectors received an implicit src root."
+after = "They receive only the exact language-partitioned source paths already owned by the manifest."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/standard_results.py"
+kind = "function"
+symbol = "_s02_quality_argv"
+before = "Authenticated command receipts expanded only absolute source and test manifest tokens."
+after = "The same receipt parser expands exact relative coverage and architecture source lists."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/standard_results.py"
+kind = "function"
+symbol = "_s02_quality_paths"
+before = "Receipt binding authenticated absolute source and test paths only."
+after = "Receipt binding also requires coverage arguments and relative architecture inputs to equal the source manifest."
+
+[[separation_of_concerns.boundaries]]
+path = "src/supportability_gate/standard_results.py"
+kind = "module"
+symbol = "src/supportability_gate/standard_results.py"
+before = "The fixed authenticated token vocabulary omitted relative source-list identities."
+after = "The same bounded vocabulary recognizes only the two new fixed list tokens."
 
 [architecture]
-dependency_direction = "The existing quality-profile owner continues to depend inward on the fixed contract policy map."
-reviewed_paths = ["src/supportability_gate/quality_profile.py"]
+dependency_direction = "Contract transition policy remains inward; templates remain declarative; the runner materializes vectors; aggregate validation authenticates their receipts."
+reviewed_paths = ["src/supportability_gate/contract.py", "src/supportability_gate/quality_profile.py", "src/supportability_gate/quality_runner.py", "src/supportability_gate/standard_results.py"]
 
 [responsibility_boundary]
-path = "src/supportability_gate/quality_profile.py"
-owns = "Classification of authenticated fixed quality-command results."
-does_not_own = "Command execution, complexity measurement, or target repository code."
+path = "src/supportability_gate/contract.py"
+owns = "Eligibility of additive fixed-profile and covered-root contract transitions."
+does_not_own = "Target package layout, runtime-specific commands, product code, waivers, or exclusions."
 
 [incremental_refactor]
-target = "Isolate a mixed-profile complexity policy exit to its owning Gate context."
-completed_step = "Derived one fixed adapter profile before the existing policy lookup."
+target = "Make the fixed mixed profile truthful for production source roots outside src."
+completed_step = "Removed only the fixed src assumptions, bound their receipts, and added bounded CSS attestation required by the live TypeScript consumer."
 
 [review_handoff]
 summary = "DERIVED_FROM_AUTHENTICATED_EVIDENCE"
 remaining_risks = ["DERIVED_FROM_AUTHENTICATED_EVIDENCE"]
 
 [human_review]
-naming = "profile names the fixed Python or TypeScript command family."
-cohesion = "Policy-exit classification remains in the existing quality-profile owner."
-intended_behavior = "Single-language classifications remain unchanged; mixed uses the adapter's fixed profile."
-reviewability = "One branch-local value, no new command, package, waiver, threshold, or abstraction."
+naming = "is_profile_expansion and _valid_utf8_text name the broadened responsibilities directly."
+cohesion = "Contract eligibility, fixed templates, vector materialization, and receipt authentication remain in their existing owners."
+intended_behavior = "Prior roots cannot disappear; every fixed adapter exactly covers added roots; TypeScript commands, receipts, and build proof use the same manifest identities."
+reviewability = "No new package, adapter, executable, threshold, exclusion, waiver, or generic configuration surface was added."

--- a/src/supportability_gate/contract.py
+++ b/src/supportability_gate/contract.py
@@ -88,23 +88,27 @@ class Contract:
 
 
 def is_profile_expansion(base: Contract, head: Contract | None) -> bool:
-    """Return whether one single-language contract safely adds the other fixed profile."""
+    """Return whether a contract safely adds the fixed mixed profile or covered paths."""
     if (
         head is None
-        or base.schema_version != "1.0"
+        or base.schema_version not in {"1.0", "1.1"}
         or head.schema_version != "1.1"
-        or base.production_paths != head.production_paths
-        or base.high_risk_paths != head.high_risk_paths
+        or not set(base.languages).issubset(head.languages)
+        or not set(base.production_paths).issubset(head.production_paths)
+        or not set(base.high_risk_paths).issubset(head.high_risk_paths)
         or base.maximum != head.maximum
     ):
         return False
     base_gates = {gate.adapter: gate for gate in base.gates}
     head_gates = {gate.adapter: gate for gate in head.gates}
-    if any(head_gates.get(adapter) != gate for adapter, gate in base_gates.items()):
+    if any(
+        (head_gate := head_gates.get(adapter)) is None
+        or any(not head_gate.covers(path) for path in gate.paths)
+        for adapter, gate in base_gates.items()
+    ):
         return False
     return set(head_gates) == set(FIXED_ADAPTERS_BY_LANGUAGE["mixed"]) and all(
-        head_gates[adapter].paths == base.production_paths
-        for adapter in set(head_gates) - set(base_gates)
+        gate.paths == head.production_paths for gate in head_gates.values()
     )
 
 

--- a/src/supportability_gate/quality_profile.py
+++ b/src/supportability_gate/quality_profile.py
@@ -38,6 +38,7 @@ TEST_SUFFIXES = {
     ),
 }
 ASSET_VALIDATORS = {
+    ".css": ("css", "css.utf8.v1"),
     ".json": ("json", "json.stdlib.v1"),
     ".md": ("markdown", "markdown.utf8.v1"),
     ".png": ("png", "png.crc.v1"),
@@ -237,7 +238,7 @@ _TYPESCRIPT_COMMANDS = (
             "$NODE",
             "--test",
             "--experimental-test-coverage",
-            "--test-coverage-include=src/**",
+            "$COVERAGE_FILES",
             "--test-reporter=spec",
             "--test-reporter=lcov",
             "--test-reporter-destination=stdout",
@@ -258,7 +259,7 @@ _TYPESCRIPT_COMMANDS = (
             "--ts-config",
             "$OUTPUT/tsconfig-check.json",
             "--",
-            "src",
+            "$SOURCE_PATHS",
         ),
     ),
 )
@@ -407,7 +408,7 @@ def _valid_json(content: bytes) -> bool:
     return True
 
 
-def _valid_markdown(content: bytes) -> bool:
+def _valid_utf8_text(content: bytes) -> bool:
     try:
         return "\0" not in content.decode("utf-8")
     except UnicodeDecodeError:
@@ -454,8 +455,9 @@ def _valid_png(content: bytes) -> bool:
 
 def _asset_result(validator: str, content: bytes) -> str:
     validators = {
+        "css.utf8.v1": _valid_utf8_text,
         "json.stdlib.v1": _valid_json,
-        "markdown.utf8.v1": _valid_markdown,
+        "markdown.utf8.v1": _valid_utf8_text,
         "png.crc.v1": _valid_png,
     }
     return "PASS" if validators[validator](content) else "MALFORMED"

--- a/src/supportability_gate/quality_runner.py
+++ b/src/supportability_gate/quality_runner.py
@@ -41,7 +41,7 @@ def fixed_environment(output: Path, repository: Path) -> dict[str, str]:
 def _replace_tokens(arguments: tuple[str, ...], values: dict[str, str]) -> tuple[str, ...]:
     replaced: list[str] = []
     for argument in arguments:
-        if argument in {"$SOURCE_FILES", "$TEST_FILES"}:
+        if argument in {"$COVERAGE_FILES", "$SOURCE_FILES", "$SOURCE_PATHS", "$TEST_FILES"}:
             replaced.extend(values[argument].split("\0") if values[argument] else ())
         else:
             value = argument
@@ -113,7 +113,7 @@ def _write_typescript_configs(
             "declaration": True,
             "noEmit": False,
             "outDir": str(output / "build"),
-            "rootDir": str(repository / "src"),
+            "rootDir": str(repository),
         }
     )
     (output / "tsconfig-check.json").write_text(
@@ -219,9 +219,13 @@ def command_plans(
         )
         selected = {
             **values,
+            "$COVERAGE_FILES": "\0".join(
+                f"--test-coverage-include={path}" for path in selected_sources
+            ),
             "$SOURCE_FILES": "\0".join(
                 str((repository / path).resolve()) for path in selected_sources
             ),
+            "$SOURCE_PATHS": "\0".join(selected_sources),
             "$TEST_FILES": "\0".join(str((repository / path).resolve()) for path in selected_tests),
         }
         plans.append(

--- a/src/supportability_gate/standard_results.py
+++ b/src/supportability_gate/standard_results.py
@@ -153,12 +153,16 @@ _S02_QUALITY_TOKENS = frozenset(
         "$OUTPUT",
         "$PYTHON",
         "$REPOSITORY",
+        "$COVERAGE_FILES",
         "$SOURCE_FILES",
+        "$SOURCE_PATHS",
         "$TEST_FILES",
         "$TOOLS",
     }
 )
-_S02_QUALITY_LIST_TOKENS = frozenset({"$SOURCE_FILES", "$TEST_FILES"})
+_S02_QUALITY_LIST_TOKENS = frozenset(
+    {"$COVERAGE_FILES", "$SOURCE_FILES", "$SOURCE_PATHS", "$TEST_FILES"}
+)
 _S02_SHORT_EXCLUSIONS = {
     "docs/fixed_roadmap.md",
     "docs/product_completion_contract.md",
@@ -1937,6 +1941,8 @@ def _s02_quality_paths(
         repository = derived
         if source != tuple(f"{repository}/{path}" for path in source_files):
             raise StandardResultsError(code)
+    coverage = normalized.get("$COVERAGE_FILES")
+    source_paths = normalized.get("$SOURCE_PATHS")
     tests = normalized.get("$TEST_FILES")
     test_files = tuple(profile["test_files"])
     if tests is not None and test_files:
@@ -1951,7 +1957,14 @@ def _s02_quality_paths(
         raise StandardResultsError(code)
     output = normalized.get("$OUTPUT")
     tools = normalized.get("$TOOLS")
-    if tools is not None and (output is None or tools != (f"{output[0]}/quality-tools",)):
+    if (
+        (
+            coverage is not None
+            and coverage != tuple(f"--test-coverage-include={path}" for path in source_files)
+        )
+        or (source_paths is not None and source_paths != source_files)
+        or (tools is not None and (output is None or tools != (f"{output[0]}/quality-tools",)))
+    ):
         raise StandardResultsError(code)
 
 
@@ -1984,7 +1997,9 @@ def _s02_quality_argv(profile: dict[str, Any], provenance: dict[str, Any], code:
             decision["arguments"],
             proof["executed_arguments"],
             {
+                "$COVERAGE_FILES": len(files["source_files"]),
                 "$SOURCE_FILES": len(files["source_files"]),
+                "$SOURCE_PATHS": len(files["source_files"]),
                 "$TEST_FILES": len(files["test_files"]),
             },
             values_by_language.setdefault(language, {}),

--- a/tests/hosted_quality_profile.py
+++ b/tests/hosted_quality_profile.py
@@ -95,9 +95,9 @@ def _typescript_build_proof(
     observed = tuple(
         source
         for source in plan.source_files
-        if str(
-            Path(source.removeprefix("src/")).with_suffix(suffixes.get(Path(source).suffix, ".js"))
-        ).replace("\\", "/")
+        if str(Path(source).with_suffix(suffixes.get(Path(source).suffix, ".js"))).replace(
+            "\\", "/"
+        )
         in built
     )
     raw = (json.dumps(list(built), sort_keys=True) + "\n").encode()

--- a/tests/test_evaluate_complexity.py
+++ b/tests/test_evaluate_complexity.py
@@ -48,7 +48,9 @@ def _executed_quality_arguments(
         "$TOOLS": "C:/quality/quality-tools",
     }
     list_values = {
+        "$COVERAGE_FILES": tuple(f"--test-coverage-include={path}" for path in production_files),
         "$SOURCE_FILES": tuple(f"C:/repo/target/{path}" for path in production_files),
+        "$SOURCE_PATHS": tuple(production_files),
         "$TEST_FILES": tuple(f"C:/repo/target/{path}" for path in test_files),
     }
     executed: list[str] = []

--- a/tests/test_quality_profile.py
+++ b/tests/test_quality_profile.py
@@ -93,13 +93,22 @@ IDENTITY = git_changes.RepositoryIdentity(
 
 
 def test_mixed_contract_selects_and_partitions_both_fixed_profiles(tmp_path: Path) -> None:
-    policy = contract.parse_contract(MIXED_POLICY_TEXT.encode())
+    expanded_text = MIXED_POLICY_TEXT.replace(
+        'production_paths = ["src"]', 'production_paths = ["src", "web"]'
+    ).replace('paths = ["src"]', 'paths = ["src", "web"]')
+    policy = contract.parse_contract(expanded_text.encode())
+    later = contract.parse_contract(
+        expanded_text.replace(
+            '["src", "web"]', '["src", "web", "supabase/functions/ask-twmn-gateway"]'
+        ).encode()
+    )
+    narrowed = contract.parse_contract(expanded_text.replace('["src", "web"]', '["web"]').encode())
     assessments = tuple(
         ChangedFileAssessment(git_changes.ChangedPath("ADDED", None, path), False, True, True, (1,))
-        for path in ("src/backend.py", "src/frontend.ts")
+        for path in ("src/backend.py", "web/frontend.ts")
     )
     sources = quality_profile.source_files(
-        ("src/backend.py", "src/config.json", "src/frontend.ts"), policy.language
+        ("src/backend.py", "src/config.json", "web/frontend.ts"), policy.language
     )
     plans = quality_runner.command_plans(
         policy.language,
@@ -110,8 +119,11 @@ def test_mixed_contract_selects_and_partitions_both_fixed_profiles(tmp_path: Pat
     )
 
     assert policy.languages == ("python", "typescript")
+    assert contract.is_profile_expansion(POLICY, policy)
+    assert contract.is_profile_expansion(policy, later)
+    assert not contract.is_profile_expansion(POLICY, narrowed)
     assert gate_policy.evaluate_contract(policy, assessments) == ()
-    assert sources == ("src/backend.py", "src/frontend.ts")
+    assert sources == ("src/backend.py", "web/frontend.ts")
     assert {item.adapter for item in plans} == set(
         quality_profile.required_adapters("python")
     ) | set(quality_profile.required_adapters("typescript"))
@@ -121,6 +133,14 @@ def test_mixed_contract_selects_and_partitions_both_fixed_profiles(tmp_path: Pat
         else all(path.endswith((".ts", ".tsx", ".mts", ".cts")) for path in item.source_files)
         for item in plans
     )
+    test_plan = next(item for item in plans if item.adapter == "typescript.test.v1")
+    architecture_plan = next(
+        item for item in plans if item.adapter == "typescript.import-boundaries.v1"
+    )
+    build_config = json.loads((tmp_path / "evidence" / "tsconfig-build.json").read_text())
+    assert "--test-coverage-include=web/frontend.ts" in test_plan.actual
+    assert architecture_plan.actual[-1] == "web/frontend.ts"
+    assert build_config["compilerOptions"]["rootDir"] == str(tmp_path)
 
 
 def _commands() -> tuple[quality_profile.GateResult, ...]:
@@ -583,6 +603,7 @@ def test_mixed_production_assets_are_attested_without_entering_source_manifest(
     source = repository / "src"
     source.mkdir()
     (source / "index.ts").write_text("export const ready = true;\n", encoding="utf-8")
+    (source / "index.css").write_text("body { color: black; }\n", encoding="utf-8")
     (source / "manifest.json").write_text('{"name":"plugin"}\n', encoding="utf-8")
     (source / "README.md").write_text("# Plugin\n", encoding="utf-8")
 
@@ -604,6 +625,7 @@ def test_mixed_production_assets_are_attested_without_entering_source_manifest(
     assert production == (
         "src/README.md",
         "src/icon.png",
+        "src/index.css",
         "src/index.ts",
         "src/manifest.json",
     )
@@ -612,6 +634,7 @@ def test_mixed_production_assets_are_attested_without_entering_source_manifest(
     assert tuple(receipt.path for receipt in receipts) == (
         "src/README.md",
         "src/icon.png",
+        "src/index.css",
         "src/manifest.json",
     )
     assert all(receipt.result == "PASS" for receipt in receipts)
@@ -690,6 +713,7 @@ def test_valid_asset_can_pass_without_code_command_observation() -> None:
             "MALFORMED_PRODUCTION_ASSET:src/duplicate.json",
             id="duplicate-json-keys",
         ),
+        ("bad.css", b"body {\x00}", "MALFORMED", "MALFORMED_PRODUCTION_ASSET:src/bad.css"),
         ("bad.md", b"\xff", "MALFORMED", "MALFORMED_PRODUCTION_ASSET:src/bad.md"),
         (
             "bad.png",
@@ -1030,16 +1054,16 @@ def test_typescript_profile_executes_every_fixed_gate_on_hosted_runner(tmp_path:
     (repository / ".supportability.toml").write_text(
         """schema_version = "1.0"
 language = "typescript"
-production_paths = ["src"]
-high_risk_paths = ["src/presentation/Card.tsx"]
+production_paths = ["web"]
+high_risk_paths = ["web/presentation/Card.tsx"]
 
 [[gates]]
 adapter = "typescript.c901-equivalent-touched.v1"
-paths = ["src"]
+paths = ["web"]
 
 [[gates]]
 adapter = "typescript.import-boundaries.v1"
-paths = ["src"]
+paths = ["web"]
 
 [complexity]
 adapter = "typescript.c901-equivalent-touched.v1"
@@ -1048,7 +1072,7 @@ maximum = 10
         encoding="utf-8",
         newline="\n",
     )
-    source = repository / "src" / "domain" / "model.ts"
+    source = repository / "web" / "domain" / "model.ts"
     source.parent.mkdir(parents=True)
     source.write_text(
         'import { increment } from "fixture-dependency";\n\n'
@@ -1056,7 +1080,7 @@ maximum = 10
         encoding="utf-8",
         newline="\n",
     )
-    component = repository / "src" / "presentation" / "Card.tsx"
+    component = repository / "web" / "presentation" / "Card.tsx"
     component.parent.mkdir(parents=True)
     component.write_text(
         "declare global {\n"
@@ -1111,8 +1135,8 @@ maximum = 10
         "});\n\n"
         'test("covered component", async () => {\n'
         "  const [{ score }, { default: Card }] = await Promise.all([\n"
-        '    import("../src/domain/model.ts"),\n'
-        '    import("../src/presentation/Card.tsx"),\n'
+        '    import("../web/domain/model.ts"),\n'
+        '    import("../web/presentation/Card.tsx"),\n'
         "  ]);\n"
         "  assert.equal(score(1), 2);\n"
         '  assert.equal(Card({ label: " ready " }).child, "ready");\n'
@@ -1132,7 +1156,7 @@ maximum = 10
     component.write_text(
         component.read_text().replace("{label}", "{label.trim()}"), encoding="utf-8", newline="\n"
     )
-    poison = "src/domain/unexecuted.ts"
+    poison = "web/domain/unexecuted.ts"
     (repository / poison).write_text(
         'throw new Error("poison file executed");\n', encoding="utf-8", newline="\n"
     )
@@ -1237,7 +1261,7 @@ maximum = 10
     policy = contract.parse_contract((repository / ".supportability.toml").read_bytes())
     assessments = (
         ChangedFileAssessment(
-            git_changes.ChangedPath("MODIFIED", "src/domain/model.ts", "src/domain/model.ts"),
+            git_changes.ChangedPath("MODIFIED", "web/domain/model.ts", "web/domain/model.ts"),
             True,
             True,
             True,
@@ -1248,7 +1272,7 @@ maximum = 10
         ),
         ChangedFileAssessment(
             git_changes.ChangedPath(
-                "MODIFIED", "src/presentation/Card.tsx", "src/presentation/Card.tsx"
+                "MODIFIED", "web/presentation/Card.tsx", "web/presentation/Card.tsx"
             ),
             True,
             True,
@@ -1269,9 +1293,9 @@ maximum = 10
     )
 
     assert poison not in test_result.observed_paths
-    assert "src/presentation/Card.tsx" in test_result.observed_paths
+    assert "web/presentation/Card.tsx" in test_result.observed_paths
     assert not any(
-        block.endswith(":src/presentation/Card.tsx")
+        block.endswith(":web/presentation/Card.tsx")
         and block.startswith("QUALITY_HIGH_RISK_FILE_COVERAGE:")
         for block in blocks
     )

--- a/tests/test_standard_results.py
+++ b/tests/test_standard_results.py
@@ -122,7 +122,9 @@ def _quality_arguments(
         "$TOOLS": "C:/quality/quality-tools",
     }
     list_values = {
+        "$COVERAGE_FILES": tuple(f"--test-coverage-include={path}" for path in production_files),
         "$SOURCE_FILES": tuple(f"C:/repo/target/{path}" for path in production_files),
+        "$SOURCE_PATHS": production_files,
         "$TEST_FILES": tuple(f"C:/repo/target/{path}" for path in test_files),
     }
     executed: list[str] = []


### PR DESCRIPTION
S13 root-neutral mixed-profile completion. Keeps fixed Python and TypeScript adapters while making contract expansion, TypeScript coverage, dependency checks, build proof, authenticated command receipts, and strict CSS asset attestation follow exact declared production roots. No package, command, waiver, threshold, exclusion, or target-code execution change. References #180.