### PR TITLE
Allow exact deleted high-risk transitions

### DIFF
--- a/.supportability-review.toml
+++ b/.supportability-review.toml
@@ -2,37 +2,43 @@ schema_version = "1.0"
 module_boundaries = []
 
 [behavior]
-intended_behavior = "Record S13 terminal evidence and the no-successor boundary without changing Gate behavior."
-proof = "The ledger cites protected source delivery, final canaries, ruleset activation, TWMN preflight, cleanup, and the remaining closure transaction."
+intended_behavior = "A high-risk contract entry retires only with the exact tracked file deleted in the same immutable diff; every other weakening remains blocked."
+proof = "tests/test_evaluate_complexity.py covers exact deletion, contract-only removal, deletion-only, rename, and combined threshold weakening."
 
 [characterization]
-captured_behavior = "Gate production behavior and immutable requirements remain unchanged by this nonproduction ledger transaction."
-proof = "The exact diff contains only the product completion ledger and its current structured review evidence."
+captured_behavior = "Contract changes were previously allowed only for fixed profile expansion, while quality attestation still required every base high-risk path at the head."
+proof = "The focused red run returned TECHNICAL_FAILURE before the shared transition predicate existed; the directly relevant suite then passed 153 tests with 2 expected skips."
 
 [separation_of_concerns]
-before = "The persistent ledger still names S12 and contains no S13 terminal evidence."
-after = "The ledger alone records S13 status, direct evidence, remaining closure transaction, and no successor Gate work."
-boundaries = []
+before = "The hosted producer and final evaluator selected only profile expansions, so an exact deleted high-risk transition could not share one approved effective contract."
+after = "Gate policy owns one exact transition predicate; the hosted producer and final evaluator consume it, while quality validation remains unchanged."
+boundaries = [
+  { path = "src/supportability_gate/cli.py", kind = "function", symbol = "_contract_blocks", before = "Accepted only profile expansion and otherwise emitted CANDIDATE_CONTRACT_CHANGE.", after = "Uses the shared approved-transition result for candidate blocking and effective policy evaluation." },
+  { path = "src/supportability_gate/cli.py", kind = "function", symbol = "_evaluate", before = "Selected the candidate contract only for profile expansion.", after = "Selects the candidate contract for either profile expansion or an exact deleted high-risk transition." },
+  { path = "src/supportability_gate/gate_policy.py", kind = "function", symbol = "is_allowed_contract_transition", before = "No shared caller-facing predicate represented every approved contract transition.", after = "Combines the existing profile-expansion rule with the exact deleted-high-risk rule." },
+  { path = "src/supportability_gate/gate_policy.py", kind = "function", symbol = "is_deleted_high_risk_transition", before = "No policy function distinguished exact tracked deletion from contract escape.", after = "Requires the ordered remaining high-risk paths and equality of every other contract responsibility." },
+  { path = "src/supportability_gate/gate_policy.py", kind = "module", symbol = "src/supportability_gate/gate_policy.py", before = "The policy module imported only changed-file assessments.", after = "The policy module also consumes immutable changed-path identities for exact deletion classification." },
+]
 
 [architecture]
-dependency_direction = "No production dependency or module boundary changes."
-reviewed_paths = [".supportability-review.toml", "docs/product_completion_contract.md"]
+dependency_direction = "CLI and the hosted producer depend on gate policy; gate policy depends only on lower-layer contract, changed-path, and changed-file types."
+reviewed_paths = ["src/supportability_gate/cli.py", "src/supportability_gate/gate_policy.py", "tests/hosted_quality_profile.py", "tests/test_evaluate_complexity.py"]
 
 [responsibility_boundary]
-path = "docs/product_completion_contract.md"
-owns = "Persistent S13 product status, direct evidence, remaining closure transaction, and successor boundary."
-does_not_own = "Gate runtime, target product code, workflow behavior, thresholds, waivers, or future milestones."
+path = "src/supportability_gate/gate_policy.py"
+owns = "Deterministic approval of the exact candidate contract transition."
+does_not_own = "Quality evidence schema, characterization, workflow orchestration, thresholds, exclusions, waivers, or bypass policy."
 
 [incremental_refactor]
-target = "Close the S13 durable-evidence gap."
-completed_step = "Updated the existing product-status fields, appended one S13 ledger entry, and refreshed current-PR review evidence."
+target = "Permit only the observed exact deleted-high-risk transition through the existing contract-selection path."
+completed_step = "Added one shared predicate, reused it in both existing consumers, and left the quality verifier and schemas unchanged."
 
 [review_handoff]
 summary = "DERIVED_FROM_AUTHENTICATED_EVIDENCE"
 remaining_risks = ["DERIVED_FROM_AUTHENTICATED_EVIDENCE"]
 
 [human_review]
-naming = "The S13 heading and terminal field names match the live issue and Project fields."
-cohesion = "All durable S13 evidence remains in the existing product completion ledger."
-intended_behavior = "The ledger becomes canonical only through normal protected merge and final ruleset, issue, and Project readbacks."
-reviewability = "The two-file nonproduction diff changes no Gate source, workflow, dependency, threshold, exclusion, waiver, Standard, or roadmap."
+naming = "Transition names state the exact allowed event and avoid generic deletion exemptions."
+cohesion = "Contract-transition logic remains in gate policy and both orchestration callers only select its result."
+intended_behavior = "Exact deletion passes; contract-only removal, deletion-only, rename, and combined weakening block."
+reviewability = "The production change is one predicate plus two caller substitutions, with no schema, dependency, threshold, or workflow expansion."

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ for architecture, configuration, evidence, lifecycle, and module details.
 ## Status
 
 Integrated qualification and organization-wide activation completed on 2026-08-27. Project #10 is
-closed, and [terminal issue #154](https://github.com/mbh-solutions/supportability-gate/issues/154)
-records the direct proof. Durable product status and historical evidence remain in the
-[Product Completion Contract](docs/product_completion_contract.md).
+temporarily reopened only for the bounded
+[S14 maintenance issue](https://github.com/mbh-solutions/supportability-gate/issues/192), which
+permits an exact high-risk contract entry to retire with its deleted file. Durable product status
+and historical evidence remain in the [Product Completion Contract](docs/product_completion_contract.md).
 
 Protected `main` requires Source Validation plus eight strict, independently owned deterministic
 contexts:
@@ -36,9 +37,9 @@ conversations.
 Each participating repository commits three fixed inputs:
 
 - `.supportability.toml` — one language or the fixed Python-plus-TypeScript profile, production
-  and high-risk paths, approved adapters, and
-  complexity maximum. The Gate loads this contract from the base commit; weakening or narrowing
-  it in the pull request blocks.
+  and high-risk paths, approved adapters, and complexity maximum. The Gate loads this contract
+  from the base commit; weakening or narrowing it in the pull request blocks. The only removal
+  exception is an exact high-risk path whose tracked file is deleted in the same diff.
 - `.supportability-review.toml` — structured behavior, architecture, responsibility, refactor,
   and handoff evidence bound to exact base/head Git blobs.
 - `.supportability-characterization.json` — fixed hosted scenarios and their covered source

--- a/docs/product_completion_contract.md
+++ b/docs/product_completion_contract.md
@@ -1275,8 +1275,8 @@ Historical deterministic gate deployable to target repositories: YES
 Full Supportability Standard enforcement deployable to target repositories: YES
 Full Supportability Standard runtime: YES
 Required review model: Eight deterministic contexts; Codex review is owner opt-in advisory only
-Current authorized work: NONE in Supportability Gate; return to TWMN bootstrap after S13 closure readback
-Next milestone authorized: NONE; S13 has no successor Gate work
+Current authorized work: Project #10 S14 issue #192, exact deleted high-risk transition
+Next milestone authorized: NONE; after S14 return only to TWMN issue #155 and PR #164
 ```
 
 ## Milestone transition rules
@@ -2333,3 +2333,32 @@ Do not create a new terminal label not authorized by an active milestone directi
   `21664395` at that merge, post terminal issue evidence, set S13
   `Done / Complete / On scope / Yes`, close issue #180 and Project #10, verify all readbacks, and
   stop.
+
+## Project #10 S14 exact deleted high-risk transition
+
+- Prospective terminal result recorded by this protected ledger transaction: Status `COMPLETE`;
+  Evidence `Complete`; Scope `On scope`; Stop confirmed `Yes`. It becomes canonical only after this
+  pull request merges normally without bypass, ruleset `21664395` is pinned to that protected
+  merge, and TWMN PR #164 passes all eight deterministic contexts plus aggregate Gate on its exact
+  head. Project #10 then closes and only the authorized TWMN issue #155 recovery transaction resumes.
+- Authority: private Project #10 `PVT_kwDOEmzFKc4BhXlK`, item
+  `PVTI_lADOEmzFKc4BhXlKzg48uCA`, repository issue #192, blocked consumer TWMN PR #164 at
+  `6de5a8700aa94919e2809f2d97de8df38c9a7aba`, failed required run `33533991213`, and exact source
+  base/workflow rollback pin `b83682464a2853a3b68c36056d82676fc0ac1a08`.
+- Capability boundary: a candidate contract may remove only the ordered subset of base high-risk
+  paths whose exact Git identities are `DELETED` in the same base/head diff. Every schema,
+  language, production path, adapter, threshold, and gate scope must remain byte-semantically
+  unchanged. Contract-only removal, deletion-only, rename/move, and combined weakening remain
+  fail-closed through existing deterministic block ownership.
+- Implementation boundary: one shared predicate selects the same effective candidate contract for
+  the hosted quality producer and final evaluator. Existing quality evidence schema, attestation,
+  characterization, thresholds, eight check names, dependencies, exclusions, waivers, and bypass
+  policy remain unchanged.
+- Local development evidence: the focused red test reproduced the current technical failure; the
+  three exact positive/negative integration canaries then passed. The directly relevant
+  `tests/test_evaluate_complexity.py` plus `tests/test_quality_profile.py` suite passed once with
+  `153 passed, 2 skipped` in 428.93 seconds.
+- Remaining transaction: complete the exact Python 3.12 source proof once, merge one protected
+  source pull request normally, update and read back only ruleset `21664395`'s workflow SHA, obtain
+  fresh exact-head TWMN PR #164 proof, record terminal issue evidence, set S14
+  `Done / Complete / On scope / Yes`, close issue #192 and Project #10, then stop Gate work.

--- a/src/supportability_gate/cli.py
+++ b/src/supportability_gate/cli.py
@@ -432,10 +432,11 @@ def _contract_blocks(
     candidate_policy: contract.Contract | None,
     assessments: tuple[function_changes.ChangedFileAssessment, ...],
 ) -> tuple[str, ...]:
-    expansion = gate_policy.is_profile_expansion(policy, candidate_policy)
+    changes = tuple(item.change for item in assessments)
+    allowed = gate_policy.is_allowed_contract_transition(policy, candidate_policy, changes)
     candidate = (
         (
-            *(() if expansion else ("CANDIDATE_CONTRACT_CHANGE",)),
+            *(() if allowed else ("CANDIDATE_CONTRACT_CHANGE",)),
             *gate_policy.contract_change_blocks(policy, candidate_policy),
         )
         if any(
@@ -443,7 +444,7 @@ def _contract_blocks(
         )
         else ()
     )
-    effective = candidate_policy if expansion and candidate_policy is not None else policy
+    effective = candidate_policy if allowed and candidate_policy is not None else policy
     return (*candidate, *gate_policy.evaluate_contract(effective, assessments))
 
 
@@ -841,8 +842,8 @@ def _evaluate(arguments: argparse.Namespace) -> reporting.EvaluationResult:
                 candidate_policy = contract.parse_contract(candidate_blob.content)
             except (contract.ContractError, git_changes.GitError):
                 candidate_policy = None
-        if candidate_policy is not None and gate_policy.is_profile_expansion(
-            base_policy, candidate_policy
+        if candidate_policy is not None and gate_policy.is_allowed_contract_transition(
+            base_policy, candidate_policy, changes
         ):
             policy = candidate_policy
         assessments = _classify_changes(repository, identity, policy, changes, records)

--- a/src/supportability_gate/gate_policy.py
+++ b/src/supportability_gate/gate_policy.py
@@ -9,6 +9,7 @@ from supportability_gate.contract import (
     GateAdapter,
 )
 from supportability_gate.function_changes import ChangedFileAssessment
+from supportability_gate.git_changes import ChangedPath
 
 APPROVED_ADAPTERS_BY_LANGUAGE = FIXED_ADAPTERS_BY_LANGUAGE
 APPROVED_ADAPTERS = APPROVED_ADAPTERS_BY_LANGUAGE["python"]
@@ -17,6 +18,42 @@ APPROVED_ADAPTERS = APPROVED_ADAPTERS_BY_LANGUAGE["python"]
 def is_profile_expansion(base: Contract, head: Contract | None) -> bool:
     """Expose the inward contract transition predicate to existing callers."""
     return contract.is_profile_expansion(base, head)
+
+
+def is_deleted_high_risk_transition(
+    base: Contract,
+    head: Contract | None,
+    changes: tuple[ChangedPath, ...],
+) -> bool:
+    """Allow only high-risk entries whose exact tracked files were deleted."""
+    if head is None:
+        return False
+    deleted = {
+        item.old_path
+        for item in changes
+        if item.status == "DELETED" and item.old_path is not None and item.new_path is None
+    }
+    remaining = tuple(path for path in base.high_risk_paths if path not in deleted)
+    return (
+        remaining != base.high_risk_paths
+        and head.high_risk_paths == remaining
+        and head.schema_version == base.schema_version
+        and head.language == base.language
+        and head.languages == base.languages
+        and head.production_paths == base.production_paths
+        and head.adapter == base.adapter
+        and head.maximum == base.maximum
+        and head.gates == base.gates
+    )
+
+
+def is_allowed_contract_transition(
+    base: Contract,
+    head: Contract | None,
+    changes: tuple[ChangedPath, ...],
+) -> bool:
+    """Return whether the exact candidate contract transition is approved."""
+    return is_profile_expansion(base, head) or is_deleted_high_risk_transition(base, head, changes)
 
 
 MAXIMUM_COMPLEXITY = 10

--- a/tests/hosted_quality_profile.py
+++ b/tests/hosted_quality_profile.py
@@ -220,12 +220,12 @@ def run_profile(arguments: argparse.Namespace) -> quality_profile.QualityEvidenc
             target, identity.head_sha, ".supportability.toml", records
         ).content
     )
+    changes = git_changes.changed_paths(target, identity.base_sha, identity.head_sha, records)
     policy = (
         candidate_policy
-        if gate_policy.is_profile_expansion(base_policy, candidate_policy)
+        if gate_policy.is_allowed_contract_transition(base_policy, candidate_policy, changes)
         else base_policy
     )
-    changes = git_changes.changed_paths(target, identity.base_sha, identity.head_sha, records)
     changed_paths = tuple(
         sorted(
             {

--- a/tests/test_evaluate_complexity.py
+++ b/tests/test_evaluate_complexity.py
@@ -16,6 +16,7 @@ from supportability_gate import (
     complexity_policy,
     contract,
     function_changes,
+    gate_policy,
     git_changes,
     quality_profile,
     reporting,
@@ -441,12 +442,22 @@ def _evaluate(
     try:
         records: list[git_changes.CommandRecord] = []
         identity = git_changes.inspect_repository(repository, base_sha, head_sha, records)
-        policy = contract.parse_contract(
+        base_policy = contract.parse_contract(
             git_changes.read_regular_blob(
                 repository, identity.base_sha, ".supportability.toml", records
             ).content
         )
         changes = git_changes.changed_paths(repository, base_sha, head_sha, records)
+        candidate_policy = contract.parse_contract(
+            git_changes.read_regular_blob(
+                repository, identity.head_sha, ".supportability.toml", records
+            ).content
+        )
+        policy = (
+            candidate_policy
+            if gate_policy.is_allowed_contract_transition(base_policy, candidate_policy, changes)
+            else base_policy
+        )
         changed_paths = tuple(
             sorted(
                 {
@@ -1328,6 +1339,64 @@ def test_candidate_contract_change_and_complexity_block_are_reported_together(
     ]
     assert result["functions"][0]["head"]["complexity"] == 11
     assert result["functions"][0]["decision"] == "BLOCK"
+
+
+def test_exact_deleted_high_risk_transition_passes(tmp_path: Path) -> None:
+    policy = CONTRACT.replace("high_risk_paths = []", 'high_risk_paths = ["src/risk.py"]')
+    repository = _initialize_repository(tmp_path, policy)
+    _write(repository / "src" / "risk.py", _function_source("risk", 1))
+    base_sha = _commit(repository, "base")
+    (repository / "src" / "risk.py").unlink()
+    _write(repository / ".supportability.toml", CONTRACT)
+    head_sha = _commit(repository, "retire exact high-risk path")
+
+    exit_code, result = _evaluate(repository, base_sha, head_sha, tmp_path / "result")
+
+    assert exit_code == 0
+    assert result["overall_result"] == "PASS"
+    assert result["high_risk_paths"] == []
+    assert result["policy_blocks"] == []
+
+
+def test_high_risk_contract_removal_without_file_deletion_blocks(tmp_path: Path) -> None:
+    policy = CONTRACT.replace("high_risk_paths = []", 'high_risk_paths = ["src/risk.py"]')
+    repository = _initialize_repository(tmp_path, policy)
+    _write(repository / "src" / "risk.py", _function_source("risk", 1))
+    base_sha = _commit(repository, "base")
+    _write(repository / ".supportability.toml", CONTRACT)
+    head_sha = _commit(repository, "remove contract entry only")
+
+    exit_code, result = _evaluate(repository, base_sha, head_sha, tmp_path / "result")
+
+    assert exit_code == 1
+    assert result["policy_blocks"] == ["CANDIDATE_CONTRACT_CHANGE"]
+
+
+def test_high_risk_file_deletion_without_contract_removal_blocks(tmp_path: Path) -> None:
+    policy = CONTRACT.replace("high_risk_paths = []", 'high_risk_paths = ["src/risk.py"]')
+    repository = _initialize_repository(tmp_path, policy)
+    _write(repository / "src" / "risk.py", _function_source("risk", 1))
+    base_sha = _commit(repository, "base")
+    (repository / "src" / "risk.py").unlink()
+    head_sha = _commit(repository, "delete file only")
+
+    exit_code, result = _evaluate(repository, base_sha, head_sha, tmp_path / "result")
+
+    assert exit_code == 1
+    assert result["policy_blocks"] == ["QUALITY_HIGH_RISK_FILE_NOT_ATTESTED:src/risk.py"]
+
+
+def test_deleted_high_risk_transition_rejects_rename_and_combined_weakening() -> None:
+    base = contract.parse_contract(
+        CONTRACT.replace("high_risk_paths = []", 'high_risk_paths = ["src/risk.py"]').encode()
+    )
+    head = contract.parse_contract(CONTRACT.encode())
+    renamed = (git_changes.ChangedPath("RENAMED", "src/risk.py", "src/moved.py"),)
+    deleted = (git_changes.ChangedPath("DELETED", "src/risk.py", None),)
+    weakened = contract.parse_contract(CONTRACT.replace("maximum = 10", "maximum = 11").encode())
+
+    assert not gate_policy.is_deleted_high_risk_transition(base, head, renamed)
+    assert not gate_policy.is_deleted_high_risk_transition(base, weakened, deleted)
 
 
 def test_policy_and_complexity_blocks_are_reported_together(tmp_path: Path) -> None:


### PR DESCRIPTION
## Outcome

Permits an exact high-risk contract entry to retire only when its tracked file is DELETED in the same immutable base/head diff.

## Fail-closed boundary

- Contract-only removal still blocks.
- Deletion-only still blocks quality attestation.
- Renames/moves and combined threshold weakening still block.
- Schema, language, production paths, adapters, gates, thresholds, quality schema, dependencies, eight contexts, and bypass policy are unchanged.

## Local proof

Exact base: b83682464a2853a3b68c36056d82676fc0ac1a08
Exact head: 76bdb617ff323d7256acdeb6d16239979f988086
Immutable Standard SHA-256: 81653c5057c1555f8b6d41c6e5999d0b54caa178a2ca97a07216147ec16133e2

- Focused canaries: 3 passed.
- Directly relevant suite: 153 passed, 2 skipped.
- Full Python 3.12 source proof: Ruff lint/format/C901, strict mypy, Import Linter, 618 passed/2 skipped, compileall, wheel build, fresh exact-lock install, installed CLI help, immutable Standard tamper test, and exact diff check passed.
- Worktree and temporary artifact cleanup read back clean.

Local proof does not establish qualification. Independent exact-head GitHub Gate is required.

Closes #192